### PR TITLE
tcp: close socket on windows if connection is aborted or reset

### DIFF
--- a/src/tcp/tcp.c
+++ b/src/tcp/tcp.c
@@ -377,7 +377,17 @@ static void tcp_recv_handler(int flags, void *arg)
 		return;
 	}
 	else if (n < 0) {
+#ifdef WIN32
+		err = WSAGetLastError();
+		DEBUG_WARNING("recv handler: recv(): %d\n", err);
+		if (err == WSAECONNRESET || err == WSAECONNABORTED) {
+			mem_deref(mb);
+			conn_close(tc, err);
+			return;
+		}
+#else
 		DEBUG_WARNING("recv handler: recv(): %m\n", errno);
+#endif
 		goto out;
 	}
 


### PR DESCRIPTION
As mentioned here:
https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recv

For WSAECONNRESET and WSAECONNABORTED:

`The application should close the socket as it is no longer usable.`

Fixes never-ending recv handler warnings.