### PR TITLE
sipreg: make re-register interval configurable

### DIFF
--- a/include/re_sipreg.h
+++ b/include/re_sipreg.h
@@ -15,4 +15,6 @@ int sipreg_register(struct sipreg **regp, struct sip *sip, const char *reg_uri,
 		    sip_resp_h *resph, void *arg,
 		    const char *params, const char *fmt, ...);
 
+int sipreg_set_rwait(struct sipreg *reg, uint32_t rwait);
+
 const struct sa *sipreg_laddr(const struct sipreg *reg);


### PR DESCRIPTION
Adds a function sipreg_set_rwait() that sets the re-register interval relative
to the proxy expiry time reported from the SIP proxy. Currently this value was
hard-coded to 90%.

The baresip PR https://github.com/baresip/baresip/pull/1069 makes use of the new function.