### PR TITLE
sipreg: unset registered state in error case

### DIFF
--- a/src/sipreg/reg.c
+++ b/src/sipreg/reg.c
@@ -195,6 +195,9 @@ static void response_handler(int err, const struct sip_msg *msg, void *arg)
 			start_outbound(reg, msg);
 	}
 	else {
+		if (msg->scode != 401 && msg->scode != 407)
+			reg->registered = false;
+
 		if (reg->terminated && !reg->registered)
 			goto out;
 


### PR DESCRIPTION
The status codes 401/407 means that an authorization header should be added.
Every other status code >= 400 means we are not registered any longer.