### PR TITLE
sipreg: call response handler also for un-register

### DIFF
--- a/include/re_sipreg.h
+++ b/include/re_sipreg.h
@@ -15,4 +15,6 @@ int sipreg_register(struct sipreg **regp, struct sip *sip, const char *reg_uri,
 		    sip_resp_h *resph, void *arg,
 		    const char *params, const char *fmt, ...);
 
+uint32_t sipreg_expires(struct sipreg *regp);
+
 const struct sa *sipreg_laddr(const struct sipreg *reg);

--- a/src/sipreg/reg.c
+++ b/src/sipreg/reg.c
@@ -237,6 +237,7 @@ static void response_handler(int err, const struct sip_msg *msg, void *arg)
 
  out:
 	if (!reg->expires) {
+		reg->resph(err, msg, reg->arg);
 		mem_deref(reg);
 	}
 	else if (reg->terminated) {
@@ -406,4 +407,17 @@ int sipreg_register(struct sipreg **regp, struct sip *sip, const char *reg_uri,
 const struct sa *sipreg_laddr(const struct sipreg *reg)
 {
 	return reg ? &reg->laddr : NULL;
+}
+
+
+/**
+ * Get the expire value of a SIP Registration client.
+ *
+ * @param regp SIP Registration client
+ *
+ * @return The expire value in [seconds].
+ */
+uint32_t sipreg_expires(struct sipreg *reg)
+{
+	return reg ? reg->expires : 0;
 }


### PR DESCRIPTION
In baresip we want to add new events for the un-register result. Adds also a
new getter function for sipreg->expires to decide if it was the response for
a REGISTER or for an un-REGISTER.

See also baresip PR https://github.com/baresip/baresip/pull/1070!