### PR TITLE
tls: accept SSL_ERROR_ZERO_RETURN of SSL_read if we already got data

### DIFF
--- a/src/tls/openssl/tls_tcp.c
+++ b/src/tls/openssl/tls_tcp.c
@@ -306,8 +306,14 @@ static bool recv_handler(int *err, struct mbuf *mb, bool *estab, void *arg)
 
 			switch (ssl_err) {
 
-			case SSL_ERROR_ZERO_RETURN:
 			case SSL_ERROR_WANT_READ:
+				break;
+
+			case SSL_ERROR_ZERO_RETURN:
+				if (!mb->pos) {
+					*err = ECONNRESET;
+					return true;
+				}
 				break;
 
 			default:

--- a/src/tls/openssl/tls_udp.c
+++ b/src/tls/openssl/tls_udp.c
@@ -434,8 +434,11 @@ static void conn_recv(struct tls_conn *tc, struct mbuf *mb)
 				break;
 
 			case SSL_ERROR_ZERO_RETURN:
-				conn_close(tc, ECONNRESET);
-				return;
+				if (!mb->pos) {
+					conn_close(tc, ECONNRESET);
+					return;
+				}
+				break;
 
 			default:
 				DEBUG_WARNING("read error: %i\n", ssl_err);


### PR DESCRIPTION
- The function SSL_read returns multiple times with positive return value. Then
it returns with zero and SSL_get_error returns SSL_ERROR_ZERO_RETURN. 
The OpenSSL docu states that the TLS connection is closed if SSL_ERROR_ZERO_RETURN occurs.
Therefore, we think this is no error situation and we may proceed with processing collected data.