### PR TITLE
tls: set selfsigned Elliptic Curve (EC) function

### DIFF
--- a/include/re_tls.h
+++ b/include/re_tls.h
@@ -36,6 +36,8 @@ int tls_add_ca(struct tls *tls, const char *cafile);
 int tls_add_capem(struct tls *tls, const char *capem);
 int tls_set_selfsigned(struct tls *tls, const char *cn);
 int tls_set_selfsigned_rsa(struct tls *tls, const char *cn, size_t bits);
+int tls_set_selfsigned_ec(struct tls *tls, const char *cn,
+	const char *curve_n);
 int tls_set_certificate_pem(struct tls *tls, const char *cert, size_t len_cert,
 			    const char *key, size_t len_key);
 int tls_set_certificate_der(struct tls *tls, enum tls_keytype keytype,


### PR DESCRIPTION
A new function to generate a self signed cert using elliptic curve cryptographic primitives.
The used elliptic curve is hardcoded with NID_secp521r1. 
One can use this function in the barsip dtls_srtp module.