### PR TITLE
Cisco register keep alive

### DIFF
--- a/include/re_sipreg.h
+++ b/include/re_sipreg.h
@@ -20,3 +20,7 @@ int sipreg_set_rwait(struct sipreg *reg, uint32_t rwait);
 const struct sa *sipreg_laddr(const struct sipreg *reg);
 
 uint32_t sipreg_proxy_expires(const struct sipreg *reg);
+bool sipreg_registered(const struct sipreg *reg);
+bool sipreg_failed(const struct sipreg *reg);
+
+int sipreg_set_fbregint(struct sipreg *reg, uint32_t fbregint);

--- a/include/re_sipreg.h
+++ b/include/re_sipreg.h
@@ -22,5 +22,6 @@ const struct sa *sipreg_laddr(const struct sipreg *reg);
 uint32_t sipreg_proxy_expires(const struct sipreg *reg);
 bool sipreg_registered(const struct sipreg *reg);
 bool sipreg_failed(const struct sipreg *reg);
+void sipreg_incfailc(struct sipreg *reg);
 
 int sipreg_set_fbregint(struct sipreg *reg, uint32_t fbregint);

--- a/src/sipreg/reg.c
+++ b/src/sipreg/reg.c
@@ -205,6 +205,7 @@ static void response_handler(int err, const struct sip_msg *msg, void *arg)
 
 		case 401:
 		case 407:
+			sip_auth_reset(reg->auth);
 			err = sip_auth_authenticate(reg->auth, msg);
 			if (err) {
 				err = (err == EAUTH) ? 0 : err;
@@ -291,8 +292,10 @@ static int request(struct sipreg *reg, bool reset_ls)
 	if (reg->terminated)
 		reg->expires = 0;
 
-	if (reset_ls)
+	if (reset_ls) {
 		sip_loopstate_reset(&reg->ls);
+		sip_auth_reset(reg->auth);
+	}
 
 	return sip_drequestf(&reg->req, reg->sip, true, "REGISTER", reg->dlg,
 			     0, reg->auth, send_handler, response_handler, reg,

--- a/src/sipreg/reg.c
+++ b/src/sipreg/reg.c
@@ -461,6 +461,15 @@ bool sipreg_failed(const struct sipreg *reg)
 }
 
 
+void sipreg_incfailc(struct sipreg *reg)
+{
+	if (!reg)
+		return;
+
+	reg->failc++;
+}
+
+
 int sipreg_set_fbregint(struct sipreg *reg, uint32_t fbregint)
 {
 	if (!reg)

--- a/src/sipreg/reg.c
+++ b/src/sipreg/reg.c
@@ -244,11 +244,14 @@ static void response_handler(int err, const struct sip_msg *msg, void *arg)
 		if (msg && msg->scode >= 400 && msg->scode < 500)
 			reg->fbregint = 0;
 
-		if (!reg->terminated && reg->fbregint)
+		if (!reg->terminated && reg->fbregint) {
 			tmr_start(&reg->tmr, reg->fbregint * 1000, tmr_handler,
 					reg);
-		else if (reg->terminated)
+			reg->resph(err, msg, reg->arg);
+		}
+		else if (reg->terminated) {
 			mem_deref(reg);
+		}
 	}
 	else if (reg->terminated) {
 		if (!reg->registered || request(reg, true))


### PR DESCRIPTION
Cisco REGISTER keep-alive is only a name for a periodic un-REGISTER, this is nothing more than a REGISTER with expires=0. A SIP proxy that is available answers to these un-REGISTER requests and thus the UA is able to track the availability of a proxy without having to register to it.

This is useful for a setup with a main SIP proxy and fallback proxies. Initially the registration is only done for the main proxy. The availability of the fallback proxy can be tracked by the Cisco REGISTER keep-alives.

The https://github.com/baresip/baresip/pull/1083 is based on this PR.