### PR TITLE
Fix for the fact that windows file descriptors do not follow posix numbering standard

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libre (0.6.1-3) unstable; urgency=medium
+
+  * version 0.6.1-3
+
+ -- Richard Aas <richaraas@gmail.com>  Thu, 23 Apr 2020 13:00:00 +0200
+
 libre (0.6.1-2) unstable; urgency=medium
 
   * version 0.6.1-2

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -83,15 +83,17 @@ enum {
 #endif
 };
 
+/** File descriptor handler struct */
+struct fhs {
+	int fd;              /**< File Descriptor                   */
+	int flags;           /**< Polling flags (Read, Write, etc.) */
+	fd_h* fh;            /**< Event handler                     */
+	void* arg;           /**< Handler argument                  */
+};
 
 /** Polling loop data */
 struct re {
-	/** File descriptor handler set */
-	struct {
-		int flags;           /**< Polling flags (Read, Write, etc.) */
-		fd_h *fh;            /**< Event handler                     */
-		void *arg;           /**< Handler argument                  */
-	} *fhs;
+	struct fhs *fhs;             /** File descriptor handler set        */
 	int maxfds;                  /**< Maximum number of polling fds     */
 	int nfds;                    /**< Number of active file descriptors */
 	enum poll_method method;     /**< The current polling method        */
@@ -221,6 +223,19 @@ static struct re *re_get(void)
 
 #endif
 
+#ifdef WIN32
+static int lookup_fd_index(struct re* re, int fd) {
+	int i = 0;
+	int lim = fd == 0 ? re->maxfds : re->nfds;
+
+	for (i = 0; i < lim; i++) {
+		if (re->fhs[i].fd == fd)
+			return i;
+	}
+
+	return -1;
+}
+#endif
 
 #if MAIN_DEBUG
 /**
@@ -230,21 +245,21 @@ static struct re *re_get(void)
  * @param fd     File descriptor
  * @param flags  Event flags
  */
-static void fd_handler(struct re *re, int fd, int flags)
+static void fd_handler(struct re *re, int i, int flags)
 {
 	const uint64_t tick = tmr_jiffies();
 	uint32_t diff;
 
-	DEBUG_INFO("event on fd=%d (flags=0x%02x)...\n", fd, flags);
+	DEBUG_INFO("event on fd=%d (flags=0x%02x)...\n", re->fhs[i].fd, flags);
 
-	re->fhs[fd].fh(flags, re->fhs[fd].arg);
+	re->fhs[i].fh(flags, re->fhs[i].arg);
 
 	diff = (uint32_t)(tmr_jiffies() - tick);
 
 	if (diff > MAX_BLOCKING) {
 		DEBUG_WARNING("long async blocking: %u>%u ms (h=%p arg=%p)\n",
 			      diff, MAX_BLOCKING,
-			      re->fhs[fd].fh, re->fhs[fd].arg);
+			      re->fhs[i].fh, re->fhs[i].arg);
 	}
 }
 #endif
@@ -565,6 +580,7 @@ int fd_listen(int fd, int flags, fd_h *fh, void *arg)
 {
 	struct re *re = re_get();
 	int err = 0;
+	int i = fd;
 
 	DEBUG_INFO("fd_listen: fd=%d flags=0x%02x\n", fd, flags);
 
@@ -579,7 +595,18 @@ int fd_listen(int fd, int flags, fd_h *fh, void *arg)
 			return err;
 	}
 
-	if (fd >= re->maxfds) {
+#ifdef WIN32
+	// Windows file descriptors do not follow possix standard ranges.
+	// This code emulates possix numbering. There is no locking, so zero thread-safety.
+	// FRirst a linear search through the list of file handles to find existing descriptor.
+	i = lookup_fd_index(re, fd);
+	if (i == -1) {
+		// And if nothing is found a linear search for the first zeroed handler
+		i = lookup_fd_index(re, 0);
+	}
+#endif // #ifdef WIN32
+
+	if (i >= re->maxfds) {
 		if (flags) {
 			DEBUG_WARNING("fd_listen: fd=%d flags=0x%02x"
 				      " - Max %d fds\n",
@@ -590,12 +617,13 @@ int fd_listen(int fd, int flags, fd_h *fh, void *arg)
 
 	/* Update fh set */
 	if (re->fhs) {
-		re->fhs[fd].flags = flags;
-		re->fhs[fd].fh    = fh;
-		re->fhs[fd].arg   = arg;
+		re->fhs[i].fd    = fd;
+		re->fhs[i].flags = flags;
+		re->fhs[i].fh    = fh;
+		re->fhs[i].arg   = arg;
 	}
 
-	re->nfds = max(re->nfds, fd+1);
+	re->nfds = max(re->nfds, i+1);
 
 	switch (re->method) {
 
@@ -683,15 +711,16 @@ static int fd_poll(struct re *re)
 		FD_ZERO(&efds);
 
 		for (i=0; i<re->nfds; i++) {
+			int fd = re->fhs[i].fd;
 			if (!re->fhs[i].fh)
 				continue;
 
 			if (re->fhs[i].flags & FD_READ)
-				FD_SET(i, &rfds);
+				FD_SET(fd, &rfds);
 			if (re->fhs[i].flags & FD_WRITE)
-				FD_SET(i, &wfds);
+				FD_SET(fd, &wfds);
 			if (re->fhs[i].flags & FD_EXCEPT)
-				FD_SET(i, &efds);
+				FD_SET(fd, &efds);
 		}
 
 #ifdef WIN32
@@ -767,13 +796,15 @@ static int fd_poll(struct re *re)
 #endif
 #ifdef HAVE_SELECT
 		case METHOD_SELECT:
-			fd = i;
-			if (FD_ISSET(fd, &rfds))
-				flags |= FD_READ;
-			if (FD_ISSET(fd, &wfds))
-				flags |= FD_WRITE;
-			if (FD_ISSET(fd, &efds))
-				flags |= FD_EXCEPT;
+			fd = re->fhs[i].fd;
+			if (fd) {
+				if (FD_ISSET(fd, &rfds))
+					flags |= FD_READ;
+				if (FD_ISSET(fd, &wfds))
+					flags |= FD_WRITE;
+				if (FD_ISSET(fd, &efds))
+					flags |= FD_EXCEPT;
+			}
 			break;
 #endif
 #ifdef HAVE_EPOLL
@@ -838,11 +869,11 @@ static int fd_poll(struct re *re)
 		if (!flags)
 			continue;
 
-		if (re->fhs[fd].fh) {
+		if (re->fhs[i].fh) {
 #if MAIN_DEBUG
-			fd_handler(re, fd, flags);
+			fd_handler(re, i, flags);
 #else
-			re->fhs[fd].fh(flags, re->fhs[fd].arg);
+			re->fhs[i].fh(flags, re->fhs[i].arg);
 #endif
 		}
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -231,7 +231,7 @@ static struct re *re_get(void)
 static int lookup_fd_index(struct re* re, int fd) {
 	int i = 0;
 
-        /* First a linear search through the list of file handles
+	/* First a linear search through the list of file handles
 	 * to find existing descriptor. */
 	for (i = 0; i < re->nfds; i++) {
 		if (re->fhs[i].fd == fd)

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -225,18 +225,21 @@ static struct re *re_get(void)
 
 #ifdef WIN32
 /**
- * This code emulates POSIX numbering. There is no locking, so zero thread-safety.
+ * This code emulates POSIX numbering. There is no locking,
+ * so zero thread-safety.
  */
 static int lookup_fd_index(struct re* re, int fd) {
 	int i = 0;
 
-        /* First a linear search through the list of file handles to find existing descriptor. */
+        /* First a linear search through the list of file handles
+	 * to find existing descriptor. */
 	for (i = 0; i < re->nfds; i++) {
 		if (re->fhs[i].fd == fd)
 			return i;
 	}
 
-	/* And if nothing is found a linear search for the first zeroed handler */
+	/* And if nothing is found a linear search for the first
+	 * zeroed handler */
 	for (i = 0; i < re->maxfds; i++) {
 		if (re->fhs[i].fd == 0)
 			return i;

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -224,17 +224,19 @@ static struct re *re_get(void)
 #endif
 
 #ifdef WIN32
-// This code emulates possix numbering. There is no locking, so zero thread-safety.
-// First a linear search through the list of file handles to find existing descriptor.
+/**
+ * This code emulates POSIX numbering. There is no locking, so zero thread-safety.
+ */
 static int lookup_fd_index(struct re* re, int fd) {
 	int i = 0;
 
+        /* First a linear search through the list of file handles to find existing descriptor. */
 	for (i = 0; i < re->nfds; i++) {
 		if (re->fhs[i].fd == fd)
 			return i;
 	}
 
-	// And if nothing is found a linear search for the first zeroed handler
+	/* And if nothing is found a linear search for the first zeroed handler */
 	for (i = 0; i < re->maxfds; i++) {
 		if (re->fhs[i].fd == 0)
 			return i;
@@ -593,9 +595,9 @@ int fd_listen(int fd, int flags, fd_h *fh, void *arg)
 
 
 #ifdef WIN32
-	// Windows file descriptors do not follow possix standard ranges.
+	/* Windows file descriptors do not follow POSIX standard ranges. */
 	i = lookup_fd_index(re, fd);
-#endif // #ifdef WIN32
+#endif
 
 	if (fd < 0) {
 		DEBUG_WARNING("fd_listen: corrupt fd %d\n", fd);


### PR DESCRIPTION
Resubmitting as requested.

Hey

So I tried to build and run under windows, but calling kept failing in fd_listen due to out of bounds check on the file descriptor.
I was pointed to this change: 49834b7
But thought it was somewhat invasive.

I ended up making this change instead. It's pretty simple and consists mostly of renaming of variables to clearly distinguish between what is an index into fhs and what is an actual descriptor handle.

The only new thing is the windows-only lookup_fd_index which maps file descriptors to indices.

Baresip compiles and runs and makes calls, when build with this version on windows SDK 10.

I have not tested anything under linux, not even compilation.

If you're interested, I can make any recommended changes and test it under linux.

Cheers,
John