### PR TITLE
transp: support TCP idle timeout option

### DIFF
--- a/include/re_tcp.h
+++ b/include/re_tcp.h
@@ -7,6 +7,14 @@ struct sa;
 struct tcp_sock;
 struct tcp_conn;
 
+enum {
+	TCP_ACCEPT_TIMEOUT    = 32,
+	TCP_IDLE_TIMEOUT      = 900,
+	TCP_IDLE_TIMEOUT_MIN  = 180,
+	TCP_KEEPALIVE_TIMEOUT = 10,
+	TCP_KEEPALIVE_INTVAL  = 120,
+	TCP_BUFSIZE_MAX       = 65536,
+};
 
 /**
  * Defines the incoming TCP connection handler

--- a/include/re_tls.h
+++ b/include/re_tls.h
@@ -30,8 +30,8 @@ enum tls_keytype {
 };
 
 
-int tls_alloc(struct tls **tlsp, enum tls_method method, const char *keyfile,
-	      const char *pwd);
+int tls_alloc(struct tls **tlsp, enum tls_method method, uint16_t timeout,
+	      const char *keyfile, const char *pwd);
 int tls_add_ca(struct tls *tls, const char *cafile);
 int tls_set_selfsigned(struct tls *tls, const char *cn);
 int tls_set_selfsigned_rsa(struct tls *tls, const char *cn, size_t bits);
@@ -105,4 +105,5 @@ void dtls_recv_packet(struct dtls_sock *sock, const struct sa *src,
 struct ssl_ctx_st;
 
 struct ssl_ctx_st *tls_openssl_context(const struct tls *tls);
+uint16_t tls_timeout(const struct tls *tls);
 #endif

--- a/src/http/client.c
+++ b/src/http/client.c
@@ -695,7 +695,8 @@ int http_client_alloc(struct http_cli **clip, struct dnsc *dnsc)
 		goto out;
 
 #ifdef USE_TLS
-	err = tls_alloc(&cli->tls, TLS_METHOD_SSLV23, NULL, NULL);
+	err = tls_alloc(&cli->tls, TLS_METHOD_SSLV23, TCP_IDLE_TIMEOUT,
+		NULL, NULL);
 	if (err)
 		goto out;
 

--- a/src/http/server.c
+++ b/src/http/server.c
@@ -306,7 +306,8 @@ int https_listen(struct http_sock **sockp, const struct sa *laddr,
 		return err;
 
 #ifdef USE_TLS
-	err = tls_alloc(&sock->tls, TLS_METHOD_SSLV23, cert, NULL);
+	err = tls_alloc(&sock->tls, TLS_METHOD_SSLV23, TCP_IDLE_TIMEOUT,
+		cert, NULL);
 #else
 	err = EPROTONOSUPPORT;
 #endif

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -90,15 +90,16 @@ static int keytype2int(enum tls_keytype type)
 /**
  * Allocate a new TLS context
  *
- * @param tlsp    Pointer to allocated TLS context
- * @param method  TLS method
- * @param keyfile Optional private key file
- * @param pwd     Optional password
+ * @param tlsp         Pointer to allocated TLS context
+ * @param method       TLS method
+ * @param timeout      Idle timeout of underlying TCP layer
+ * @param keyfile      Optional private key file
+ * @param pwd          Optional password
  *
  * @return 0 if success, otherwise errorcode
  */
-int tls_alloc(struct tls **tlsp, enum tls_method method, const char *keyfile,
-	      const char *pwd)
+int tls_alloc(struct tls **tlsp, enum tls_method method, uint16_t timeout,
+	      const char *keyfile, const char *pwd)
 {
 	struct tls *tls;
 	int r, err;
@@ -109,6 +110,8 @@ int tls_alloc(struct tls **tlsp, enum tls_method method, const char *keyfile,
 	tls = mem_zalloc(sizeof(*tls), destructor);
 	if (!tls)
 		return ENOMEM;
+
+	tls->timeout = timeout;
 
 	switch (method) {
 
@@ -1158,4 +1161,17 @@ int tls_get_subject(struct tls *tls, struct mbuf *mb)
 
 	return tls_get_ca_chain_field(tls, mb, &X509_get_subject_name,
 		XN_FLAG_RFC2253);
+}
+
+
+/**
+ * Get the idle timeout of the underlying tcp layer
+ *
+ * @param tls  Generic TLS Context
+ *
+ * @return idle timeout
+ */
+uint16_t tls_timeout(const struct tls *tls)
+{
+	return tls ? tls->timeout : 0;
 }

--- a/src/tls/openssl/tls.h
+++ b/src/tls/openssl/tls.h
@@ -36,6 +36,7 @@ struct tls {
 	SSL_CTX *ctx;
 	X509 *cert;
 	char *pass;  /* password for private key */
+	uint16_t timeout;
 };
 
 


### PR DESCRIPTION
The idle timeout of the TCP connection can be changed
by the user if needed.