### PR TITLE
Http request bind laddr

### DIFF
--- a/include/re_http.h
+++ b/include/re_http.h
@@ -132,7 +132,8 @@ int http_request(struct http_req **reqp, struct http_cli *cli, const char *met,
 		 const char *uri, http_resp_h *resph, http_data_h *datah,
 		 void *arg, const char *fmt, ...);
 void http_req_set_conn_handler(struct http_req *req, http_conn_h *connh);
-
+void http_client_set_laddr(struct http_cli *cli, struct sa *addr);
+void http_client_set_laddr6(struct http_cli *cli, struct sa *addr);
 
 /* Server */
 struct http_sock;

--- a/include/re_tcp.h
+++ b/include/re_tcp.h
@@ -82,6 +82,9 @@ int  tcp_listen(struct tcp_sock **tsp, const struct sa *local,
 		tcp_conn_h *ch, void *arg);
 int  tcp_connect(struct tcp_conn **tcp, const struct sa *peer,
 		 tcp_estab_h *eh, tcp_recv_h *rh, tcp_close_h *ch, void *arg);
+int  tcp_connect_bind(struct tcp_conn **tcp, const struct sa *peer,
+		tcp_estab_h *eh, tcp_recv_h *rh, tcp_close_h *ch,
+		const struct sa *local, void *arg);
 int  tcp_local_get(const struct tcp_sock *ts, struct sa *local);
 
 

--- a/src/tcp/tcp_high.c
+++ b/src/tcp/tcp_high.c
@@ -90,6 +90,51 @@ int tcp_connect(struct tcp_conn **tcp, const struct sa *peer,
 
 
 /**
+ * Make a TCP Connection to a remote peer
+ *
+ * @param tcp   Returned TCP Connection object
+ * @param peer  Network address of peer
+ * @param eh    TCP Connection Established handler
+ * @param rh    TCP Connection Receive data handler
+ * @param ch    TCP Connection close handler
+ * @param local Bind to local address
+ * @param arg   Handler argument
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int tcp_connect_bind(struct tcp_conn **tcp, const struct sa *peer,
+		tcp_estab_h *eh, tcp_recv_h *rh, tcp_close_h *ch,
+		const struct sa *local, void *arg)
+{
+	struct tcp_conn *tc = NULL;
+	int err;
+
+	if (!tcp || !peer)
+		return EINVAL;
+
+	err = tcp_conn_alloc(&tc, peer, eh,rh, ch, arg);
+	if (err)
+		goto out;
+
+	err = tcp_conn_bind(tc, local);
+	if (err)
+		goto out;
+
+	err = tcp_conn_connect(tc, peer);
+	if (err)
+		goto out;
+
+ out:
+	if (err)
+		tc = mem_deref(tc);
+	else
+		*tcp = tc;
+
+	return err;
+}
+
+
+/**
  * Get local network address of TCP Socket
  *
  * @param ts    TCP Socket


### PR DESCRIPTION
Bind socket to local address allows us to use specific network interfaces for http requests (e.g. for a VPN).
This is used by a baresip http request module. We could make a PR for this module for baresip if required.