### PR TITLE
sip: add TCP idle timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Christoph Huber
 - Franz Auernigg
 - Juha Heinanen
+- johnjuuljensen
 - Sebastian Reimers
 
 ## [v1.0.0] - 2020-09-08

--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -262,6 +262,7 @@ int  sip_debug(struct re_printf *pf, const struct sip *sip);
 int  sip_send(struct sip *sip, void *sock, enum sip_transp tp,
 	      const struct sa *dst, struct mbuf *mb);
 void sip_set_trace_handler(struct sip *sip, sip_trace_h *traceh);
+void sip_set_timeout(struct sip *sip, uint64_t timeout);
 
 
 /* transport */

--- a/src/sip/sip.c
+++ b/src/sip/sip.c
@@ -22,6 +22,12 @@
 #include "sip.h"
 
 
+enum {
+	TCP_IDLE_TIMEOUT_DEF  = 900,
+	TCP_IDLE_TIMEOUT_MIN  = 180,
+};
+
+
 static void websock_shutdown_handler(void *arg)
 {
 	struct sip *sip = arg;
@@ -126,6 +132,7 @@ int sip_alloc(struct sip **sipp, struct dnsc *dnsc, uint32_t ctsz,
 	if (!sip)
 		return ENOMEM;
 
+	sip->timeout = TCP_IDLE_TIMEOUT_DEF;
 	err = sip_transp_init(sip, tcsz);
 	if (err)
 		goto out;
@@ -278,4 +285,13 @@ void sip_set_trace_handler(struct sip *sip, sip_trace_h *traceh)
 		return;
 
 	sip->traceh = traceh;
+}
+
+
+void sip_set_timeout(struct sip *sip, uint64_t timeout)
+{
+	if (!sip)
+		return;
+
+	sip->timeout = max(timeout, TCP_IDLE_TIMEOUT_MIN);
 }

--- a/src/sip/sip.h
+++ b/src/sip/sip.h
@@ -22,6 +22,7 @@ struct sip {
 	sip_trace_h *traceh;
 	void *arg;
 	bool closing;
+	uint32_t timeout;
 };
 
 

--- a/src/sip/transp.c
+++ b/src/sip/transp.c
@@ -28,7 +28,6 @@
 
 enum {
 	TCP_ACCEPT_TIMEOUT    = 32,
-	TCP_IDLE_TIMEOUT      = 900,
 	TCP_KEEPALIVE_TIMEOUT = 10,
 	TCP_KEEPALIVE_INTVAL  = 120,
 	TCP_BUFSIZE_MAX       = 65536,
@@ -403,7 +402,7 @@ static void tcp_recv_handler(struct mbuf *mb, void *arg)
 
 		if (!memcmp(mbuf_buf(conn->mb), "\r\n", 2)) {
 
-			tmr_start(&conn->tmr, TCP_IDLE_TIMEOUT * 1000,
+			tmr_start(&conn->tmr, conn->sip->timeout * 1000,
 				  conn_tmr_handler, conn);
 
 			conn->mb->pos += 2;
@@ -455,7 +454,7 @@ static void tcp_recv_handler(struct mbuf *mb, void *arg)
 			break;
 		}
 
-		tmr_start(&conn->tmr, TCP_IDLE_TIMEOUT * 1000,
+		tmr_start(&conn->tmr, conn->sip->timeout * 1000,
 			  conn_tmr_handler, conn);
 
 		end = conn->mb->end;
@@ -685,7 +684,8 @@ static int conn_send(struct sip_connqent **qentp, struct sip *sip, bool secure,
 	}
 #endif
 
-	tmr_start(&conn->tmr, TCP_IDLE_TIMEOUT * 1000, conn_tmr_handler, conn);
+	tmr_start(&conn->tmr, conn->sip->timeout * 1000, conn_tmr_handler,
+			conn);
 
  enqueue:
 	qent = mem_zalloc(sizeof(*qent), qent_destructor);


### PR DESCRIPTION
The default value of 900 seconds for detecting connection loss can be
overwritten by a new function sip_set_timeout(). The lower boundary is 180
seconds to comply with RFC3261.

This PR is a rework of https://github.com/baresip/re/pull/23.

This PR is related to 