### PR TITLE
tls: use correct pointer notation in parameter of tls_set_hostname()

### DIFF
--- a/include/re_tls.h
+++ b/include/re_tls.h
@@ -51,7 +51,7 @@ int tls_peer_fingerprint(const struct tls_conn *tc, enum tls_fingerprint type,
 int tls_peer_common_name(const struct tls_conn *tc, char *cn, size_t size);
 int tls_peer_set_verify_host(struct tls_conn *tc, const char *hostname);
 int tls_set_verify_purpose(struct tls *tls, const char *purpose);
-int tls_set_hostname(char *tls_hostname, const struct pl *hostname);
+int tls_set_hostname(char **tls_hostname, const struct pl *hostname);
 int tls_peer_verify(const struct tls_conn *tc);
 int tls_srtp_keyinfo(const struct tls_conn *tc, enum srtp_suite *suite,
 		     uint8_t *cli_key, size_t cli_key_size,

--- a/src/http/client.c
+++ b/src/http/client.c
@@ -766,7 +766,8 @@ int http_client_set_tls_hostname(struct http_cli *cli,
 	if (!cli || !hostname)
 		return EINVAL;
 
-	return tls_set_hostname(cli->tls_hostname, hostname);
+	cli->tls_hostname = mem_deref(cli->tls_hostname);
+	return tls_set_hostname(&cli->tls_hostname, hostname);
 }
 #endif
 

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -286,24 +286,24 @@ int tls_peer_set_verify_host(struct tls_conn *tc, const char *hostname)
 
 
 /**
- * Convert string hostname to pl hostname
+ * Convert a hostname given as pl into a newly allocated 0-terminated C-string.
+ * The main intention of this function is that the OPENSSL_VERSION_NUMBER
+ * pre-processor check should be done in openssl/tls.c.
  *
  * @param tls_hostname Certificate hostname as string
  * @param hostname     Certificate hostname as pl
  *
  * @return int         0 if success, errorcode otherwise
  */
-int tls_set_hostname(char *tls_hostname, const struct pl *hostname)
+int tls_set_hostname(char **tls_hostname, const struct pl *hostname)
 {
-	if (!tls_hostname || !hostname)
-		return EINVAL;
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 	DEBUG_WARNING("verify hostname needs openssl version 1.1.0\n");
 	return ENOSYS;
 #endif
 
-	return pl_strdup(&tls_hostname, hostname);
+	return pl_strdup(tls_hostname, hostname);
 }
 
 


### PR DESCRIPTION
tls: use correct pointer notation in parameter of tls_set_hostname()

- We need a **char to return newly allocated string.
- Added doxygen to function tls_set_hostname() to describe its purpose (OPENSSL_VERSION_NUMBER should be checked in openssl sub-dir, instead of http/client.c).