### PR TITLE
http: fixes memleak, segv and hostname check for http_cli and http_reqconn

### DIFF
--- a/src/http/client.c
+++ b/src/http/client.c
@@ -475,6 +475,8 @@ static int conn_connect(struct http_req *req)
 		if (req->cli->tlshn)
 			err = tls_peer_set_verify_host(conn->sc,
 				req->cli->tlshn);
+		else
+			err = tls_peer_set_verify_host(conn->sc, req->host);
 
 		if (err)
 			goto out;

--- a/src/http/request.c
+++ b/src/http/request.c
@@ -79,7 +79,6 @@ static void destructor(void *arg)
 	mem_deref(conn->req);
 	mem_deref(conn->tc);
 	mem_deref(conn->sc);
-	mem_deref(conn->client);
 
 	mem_deref(conn->uri);
 	mem_deref(conn->met);
@@ -404,7 +403,7 @@ int http_reqconn_alloc(struct http_reqconn **pconn,
 	if (!conn)
 		return ENOMEM;
 
-	conn->client = mem_ref(client);
+	conn->client = client;
 	conn->resph = resph;
 	conn->datah = datah;
 	conn->arg = arg;

--- a/src/http/request.c
+++ b/src/http/request.c
@@ -547,7 +547,7 @@ int http_reqconn_send(struct http_reqconn *conn, const struct pl *uri)
 	struct sa sa;
 #endif
 
-	if (!pl_isset(uri))
+	if (!conn || !pl_isset(uri))
 		return EINVAL;
 
 	err = http_uri_decode(&hu, uri);

--- a/src/http/request.c
+++ b/src/http/request.c
@@ -544,7 +544,6 @@ int http_reqconn_send(struct http_reqconn *conn, const struct pl *uri)
 	char *host = NULL;
 #ifdef USE_TLS
 	struct pl tlshn;
-	struct sa sa;
 #endif
 
 	if (!conn || !pl_isset(uri))
@@ -569,10 +568,6 @@ int http_reqconn_send(struct http_reqconn *conn, const struct pl *uri)
 		pl_set_str(&tlshn, conn->tlshn);
 		err = http_client_set_tls_hostname(conn->client, &tlshn);
 	}
-	else if (sa_set_str(&sa, host, 0) && (
-			!pl_strcasecmp(&hu.scheme, "https") ||
-			!pl_strcasecmp(&hu.scheme, "wss")))
-		err = http_client_set_tls_hostname(conn->client, &hu.host);
 
 	if (err) {
 		DEBUG_WARNING("Could not set TLS hostname.\n");


### PR DESCRIPTION
- Fixes segfault if http_reqconn_send() is called with NULL parameter.
- Activates hostname check for http_cli in general.
- Enables parallel HTTPS requests.