### PR TITLE
sys_usleep: replace win32 Sleep() with more reliable/precise waitable timer object

### DIFF
--- a/src/sys/sleep.c
+++ b/src/sys/sleep.c
@@ -29,7 +29,15 @@ void sys_usleep(unsigned int us)
 		return;
 
 #ifdef WIN32
-	Sleep(us / 1000);
+	HANDLE timer;
+	LARGE_INTEGER ft;
+
+	ft.QuadPart = -(10 * (int64_t)us);
+
+	timer = CreateWaitableTimer(NULL, TRUE, NULL);
+	SetWaitableTimer(timer, &ft, 0, NULL, NULL, 0);
+	WaitForSingleObject(timer, INFINITE);
+	CloseHandle(timer);
 #elif defined(HAVE_SELECT)
 	do {
 		struct timeval tv;


### PR DESCRIPTION
In my tests win32 Sleep does not work very well for microseconds sleeps (especially multi threaded), only reliable for milliseconds. 

https://social.msdn.microsoft.com/Forums/en-US/f8b49b74-0dd3-4f9a-8cbf-be4715e2859f/waitable-timers-as-alternative-to-sleep?forum=windowssdk


```
Whats wrong with using Sleep/SleepEx ?

Sleep/SleepEx should not be used for timing.  They're not consistent from platform to platform (they 
depend on the system quantum which varies between 15-30+ ms depending on the version of Windows) 
and the delay could be less (by almost a quantum) than the time requested and will likely be much 
more than the time requested as the system must decide when your thread can be given the CPU 
again as another thread may not have relinquished it yet.
```

