### PR TITLE
HTTP SNI check

### DIFF
--- a/include/re_tls.h
+++ b/include/re_tls.h
@@ -52,7 +52,6 @@ int tls_fingerprint(const struct tls *tls, enum tls_fingerprint type,
 int tls_peer_fingerprint(const struct tls_conn *tc, enum tls_fingerprint type,
 			 uint8_t *md, size_t size);
 int tls_peer_common_name(const struct tls_conn *tc, char *cn, size_t size);
-int tls_peer_set_verify_host(struct tls_conn *tc, const char *hostname);
 int tls_set_verify_purpose(struct tls *tls, const char *purpose);
 int tls_peer_verify(const struct tls_conn *tc);
 int tls_srtp_keyinfo(const struct tls_conn *tc, enum srtp_suite *suite,
@@ -60,7 +59,6 @@ int tls_srtp_keyinfo(const struct tls_conn *tc, enum srtp_suite *suite,
 		     uint8_t *srv_key, size_t srv_key_size);
 const char *tls_cipher_name(const struct tls_conn *tc);
 int tls_set_ciphers(struct tls *tls, const char *cipherv[], size_t count);
-int tls_set_servername(struct tls_conn *tc, const char *servername);
 int tls_set_verify_server(struct tls_conn *tc, const char *host);
 
 int tls_get_issuer(struct tls *tls, struct mbuf *mb);

--- a/src/http/client.c
+++ b/src/http/client.c
@@ -507,15 +507,11 @@ static int conn_connect(struct http_req *req)
 			goto out;
 
 		if (req->cli->tlshn)
-			err = tls_peer_set_verify_host(conn->sc,
-				req->cli->tlshn);
+			err  = tls_set_verify_server(conn->sc,
+					req->cli->tlshn);
 		else
-			err = tls_peer_set_verify_host(conn->sc, req->host);
+			err  = tls_set_verify_server(conn->sc, req->host);
 
-		if (err)
-			goto out;
-
-		err = tls_set_servername(conn->sc, req->host);
 		if (err)
 			goto out;
 	}

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -81,6 +81,44 @@ static int keytype2int(enum tls_keytype type)
 }
 
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
+	!defined(LIBRESSL_VERSION_NUMBER)
+static int verify_handler(int ok, X509_STORE_CTX *ctx)
+{
+	int err, depth;
+
+	err = X509_STORE_CTX_get_error(ctx);
+
+#if (DEBUG_LEVEL >= 6)
+	char    buf[128];
+	X509   *err_cert;
+
+	err_cert = X509_STORE_CTX_get_current_cert(ctx);
+
+	X509_NAME_oneline(X509_get_subject_name(err_cert), buf, 128);
+	DEBUG_INFO("%s: subject_name = %s\n", __func__, buf);
+
+	X509_NAME_oneline(X509_get_issuer_name(err_cert), buf, 128);
+	DEBUG_INFO("%s: issuer_name  = %s\n", __func__, buf);
+#endif
+
+	if (err) {
+		depth = X509_STORE_CTX_get_error_depth(ctx);
+		DEBUG_WARNING("%s: err          = %d\n", __func__, err);
+		DEBUG_WARNING("%s: error_string = %s\n", __func__,
+				X509_verify_cert_error_string(err));
+		DEBUG_WARNING("%s: depth        = %d\n", __func__, depth);
+	}
+
+#if (DEBUG_LEVEL >= 6)
+	DEBUG_INFO("tls verify ok = %d\n", ok);
+#endif
+
+	return ok;
+}
+#endif
+
+
 /**
  * Allocate a new TLS context
  *
@@ -722,7 +760,7 @@ int tls_set_certificate(struct tls *tls, const char *pem, size_t len)
 }
 
 
-static int verify_handler(int ok, X509_STORE_CTX *ctx)
+static int verify_trust_all(int ok, X509_STORE_CTX *ctx)
 {
 	(void)ok;
 	(void)ctx;
@@ -743,7 +781,7 @@ void tls_set_verify_client(struct tls *tls)
 
 	SSL_CTX_set_verify_depth(tls->ctx, 0);
 	SSL_CTX_set_verify(tls->ctx, SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE,
-			   verify_handler);
+			   verify_trust_all);
 }
 
 
@@ -1101,7 +1139,7 @@ int tls_set_servername(struct tls_conn *tc, const char *servername)
 
 
 /**
- * Enable verification of server certificate and hostname
+ * Enable verification of server certificate and hostname (SNI)
  *
  * @param tc   TLS Connection
  * @param host Server hostname
@@ -1112,17 +1150,29 @@ int tls_set_verify_server(struct tls_conn *tc, const char *host)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
 	!defined(LIBRESSL_VERSION_NUMBER)
+	struct sa sa;
 
 	if (!tc || !host)
 		return EINVAL;
 
-	SSL_set_hostflags(tc->ssl, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
-	if (!SSL_set1_host(tc->ssl, host)) {
-		ERR_clear_error();
-		return EPROTO;
+	if (sa_set_str(&sa, host, 0)) {
+		SSL_set_hostflags(tc->ssl,
+				X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+
+		if (!SSL_set1_host(tc->ssl, host)) {
+			DEBUG_WARNING("SSL_set1_host error\n");
+			ERR_clear_error();
+			return EPROTO;
+		}
+
+		if (!SSL_set_tlsext_host_name(tc->ssl, host)) {
+			DEBUG_WARNING("SSL_set_tlsext_host_name error\n");
+			ERR_clear_error();
+			return EPROTO;
+		}
 	}
 
-	SSL_set_verify(tc->ssl, SSL_VERIFY_PEER, NULL);
+	SSL_set_verify(tc->ssl, SSL_VERIFY_PEER, verify_handler);
 
 	return 0;
 #else

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -346,32 +346,6 @@ int tls_set_verify_purpose(struct tls *tls, const char *purpose)
 
 
 /**
- * Set SSL verification of hostname
- *
- * @param tc       TLS Connection
- * @param hostname Certificate hostname
- *
- * @return int     0 if success, errorcode otherwise
- */
-int tls_peer_set_verify_host(struct tls_conn *tc, const char *hostname)
-{
-	int err = 0;
-
-	if (!tc)
-		return EINVAL;
-
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
-	err = SSL_set1_host(tc->ssl, hostname);
-#else
-	DEBUG_WARNING("verify hostname needs openssl version 1.1.0\n");
-	return ENOSYS;
-#endif
-
-	return err == 1 ? 0 : EINVAL;
-}
-
-
-/**
  * Generate and set selfsigned certificate on TLS context
  *
  * @param tls TLS Context
@@ -1112,29 +1086,6 @@ int tls_set_ciphers(struct tls *tls, const char *cipherv[], size_t count)
 	mem_deref(mb);
 
 	return err;
-}
-
-
-/**
- * Set the server name on a TLS Connection, using TLS SNI extension.
- *
- * @param tc         TLS Connection
- * @param servername Server name
- *
- * @return 0 if success, otherwise errorcode
- */
-int tls_set_servername(struct tls_conn *tc, const char *servername)
-{
-	if (!tc || !servername)
-		return EINVAL;
-
-	if (1 != SSL_set_tlsext_host_name(tc->ssl, servername)) {
-		DEBUG_WARNING("tls: SSL_set_tlsext_host_name error\n");
-		ERR_clear_error();
-		return EPROTO;
-	}
-
-	return 0;
 }
 
 


### PR DESCRIPTION
- The function tls_set_verify_server() should be extended by SNI (hostname verification).
- Currently only used for rtmp. But this doesn't hurt because IP-addresses are excepted from this change. And for domains it makes sense to check the hostname.
- The function tls_set_verify_server() now also is used for HTTP clients.
- The function tls_set_verify_client() only activates certificate verification that accepts all certificates. It is used only in baresip module dtls_srtp. We do not touch this here, but want to rename the verify-handler to "verify_trust_all()".

TODO (but in another PR):
- For SIP/TLS this function should be called for each TLS connection once. Maybe then it should be renamed to tls_set_verify_peer().