### PR TITLE
http: fix ptr of conn and request at req_close

### DIFF
--- a/src/http/client.c
+++ b/src/http/client.c
@@ -158,11 +158,11 @@ static void conn_idle(struct conn *conn)
 		return;
 
 	req =  conn->req;
-	if (req)
+	if (!req)
 		return;
 
 	cli = req->cli;
-	if (cli)
+	if (!cli)
 		return;
 
 	tmr_start(&conn->tmr, cli->conf.idle_timeout, timeout_handler, conn);
@@ -181,10 +181,13 @@ static void req_close(struct http_req *req, int err,
 		if (req->connh)
 			req->connh(req->conn->tc, req->conn->sc, req->arg);
 
-		if (err || req->close || req->connh)
+		if (err || req->close || req->connh) {
 			mem_deref(req->conn);
-		else
+		}
+		else {
 			conn_idle(req->conn);
+			req->conn->req = NULL;
+		}
 
 		req->conn = NULL;
 	}

--- a/src/http/client.c
+++ b/src/http/client.c
@@ -159,13 +159,15 @@ static void conn_idle(struct conn *conn)
 
 	req =  conn->req;
 	if (!req)
-		return;
+		goto out;
 
 	cli = req->cli;
 	if (!cli)
-		return;
+		goto out;
 
 	tmr_start(&conn->tmr, cli->conf.idle_timeout, timeout_handler, conn);
+
+ out:
 	conn->req = NULL;
 }
 
@@ -181,13 +183,10 @@ static void req_close(struct http_req *req, int err,
 		if (req->connh)
 			req->connh(req->conn->tc, req->conn->sc, req->arg);
 
-		if (err || req->close || req->connh) {
+		if (err || req->close || req->connh)
 			mem_deref(req->conn);
-		}
-		else {
+		else
 			conn_idle(req->conn);
-			req->conn->req = NULL;
-		}
 
 		req->conn = NULL;
 	}


### PR DESCRIPTION
The request of the connection must be set to NULL at req_close.

Wrong checks in conn_idle would lead to not start the idle_timeout
and the request of the connection would not be set to NULL.
At TCP connection close, close_handler & try_next is called with
ECONNRESET. This would lead to a ptr deref in try_next of conn->req
which is valid data, but the req itself is not valid anymore.
conn_req is not a NULL ptr so the check if (!req) is not effective.
Following the next line, one sets a nonvalid data segment (req->conn) -> SEGV.