### PR TITLE
Http request mem leak

### DIFF
--- a/src/http/request.c
+++ b/src/http/request.c
@@ -228,14 +228,13 @@ static void resp_handler(int err, const struct http_msg *msg, void *arg)
 	if (err)
 		goto disconnect;
 
-	mem_deref(abuf);
-	mem_deref(basic);
-	return;
+	goto out;
 
  disconnect:
 	if (conn && conn->resph)
 		conn->resph(err, msg, conn->arg);
 
+ out:
 	mem_deref(abuf);
 	mem_deref(basic);
 	mem_deref(conn);


### PR DESCRIPTION
The http request code should not handle any TCP&TLS connections. Beside mem_ref and mem_deref nothing special happens with the connections. Connection handling by the http client is sufficient and prevents memory problems.

For each request sent, the reference counter of a http_reqconn is incremented. Therefore, we have to ensure a decrementation of the counter for each handled response.