### PR TITLE
sipreg: skip digest challenge for de-register

### DIFF
--- a/src/sipreg/reg.c
+++ b/src/sipreg/reg.c
@@ -297,7 +297,6 @@ static int request(struct sipreg *reg, bool reset_ls)
 
 	if (reset_ls) {
 		sip_loopstate_reset(&reg->ls);
-		sip_auth_reset(reg->auth);
 	}
 
 	return sip_drequestf(&reg->req, reg->sip, true, "REGISTER", reg->dlg,


### PR DESCRIPTION
The dialog will stop after sending the REGISTER with expires=0
(de-register). So the 401 unauthorized response does not trigger another
REGISTER as it would usually be the case.

So in order to allow proper de-register, include auth in this case.