### PR TITLE
tls: replace deprecated SSL_state call with SSL_get_state.

### DIFF
--- a/src/tls/openssl/tls_tcp.c
+++ b/src/tls/openssl/tls_tcp.c
@@ -261,7 +261,7 @@ static bool recv_handler(int *err, struct mbuf *mb, bool *estab, void *arg)
 		return true;
 	}
 
-	if (SSL_state(tc->ssl) != SSL_ST_OK) {
+	if (SSL_get_state(tc->ssl) != SSL_ST_OK) {
 
 		if (tc->up) {
 			*err = EPROTO;
@@ -275,10 +275,10 @@ static bool recv_handler(int *err, struct mbuf *mb, bool *estab, void *arg)
 			*err = tls_accept(tc);
 		}
 
-		DEBUG_INFO("state=0x%04x\n", SSL_state(tc->ssl));
+		DEBUG_INFO("state=0x%04x\n", SSL_get_state(tc->ssl));
 
 		/* TLS connection is established */
-		if (SSL_state(tc->ssl) != SSL_ST_OK)
+		if (SSL_get_state(tc->ssl) != SSL_ST_OK)
 			return true;
 
 		*estab = true;

--- a/src/tls/openssl/tls_udp.c
+++ b/src/tls/openssl/tls_udp.c
@@ -362,7 +362,7 @@ static void conn_recv(struct tls_conn *tc, struct mbuf *mb)
 		return;
 	}
 
-	if (SSL_state(tc->ssl) != SSL_ST_OK) {
+	if (SSL_get_state(tc->ssl) != SSL_ST_OK) {
 
 		if (tc->up) {
 			conn_close(tc, EPROTO);
@@ -383,10 +383,10 @@ static void conn_recv(struct tls_conn *tc, struct mbuf *mb)
 
 		DEBUG_INFO("%s: state=0x%04x\n",
 			   tc->active ? "client" : "server",
-			   SSL_state(tc->ssl));
+			   SSL_get_state(tc->ssl));
 
 		/* TLS connection is established */
-		if (SSL_state(tc->ssl) != SSL_ST_OK)
+		if (SSL_get_state(tc->ssl) != SSL_ST_OK)
 			return;
 
 		tc->up = true;


### PR DESCRIPTION
compatible down to openSSL 1.0.2 (replaced in 1.1.0)
version problem solved via preprocessor define in 1.0.2