### PR TITLE
Cleanup mk/re.mk

### DIFF
--- a/mk/re.mk
+++ b/mk/re.mk
@@ -179,17 +179,11 @@ endif
 
 ifneq ($(OPTIMIZE),)
 CFLAGS	+= -Wuninitialized
-ifneq ($(CC_SHORTVER), 2.9x)
 CFLAGS	+= -Wno-strict-aliasing
-endif
 endif
 
 # Compiler dependency flags
-ifeq ($(CC_SHORTVER), 2.9x)
-	DFLAGS		= -MD
-else
-	DFLAGS		= -MD -MF $(@:.o=.d) -MT $@
-endif
+DFLAGS		= -MD -MF $(@:.o=.d) -MT $@
 
 
 ##############################################################################
@@ -343,16 +337,8 @@ endif
 
 CFLAGS	+= -DOS=\"$(OS)\"
 
-ifeq ($(CC_SHORTVER),2.9x)
-CFLAGS  += -Wno-long-long
-else
 CFLAGS  += -std=c99
-PEDANTIC := 1
-endif # CC_SHORTVER
-
-ifneq ($(PEDANTIC),)
 CFLAGS  += -pedantic
-endif
 
 
 ifeq ($(OS),)

--- a/mk/re.mk
+++ b/mk/re.mk
@@ -150,6 +150,7 @@ endif
 
 # Compiler warning flags
 CFLAGS	+= -Wall
+CFLAGS	+= -Wextra
 CFLAGS	+= -Wmissing-declarations
 CFLAGS	+= -Wmissing-prototypes
 CFLAGS	+= -Wstrict-prototypes
@@ -159,13 +160,8 @@ CFLAGS	+= -Wnested-externs
 CFLAGS	+= -Wshadow
 CFLAGS	+= -Waggregate-return
 CFLAGS	+= -Wcast-align
-
-
-ifeq ($(CC_SHORTVER),4.x)
-CFLAGS	+= -Wextra
 CFLAGS	+= -Wold-style-definition
 CFLAGS	+= -Wdeclaration-after-statement
-endif
 
 CFLAGS  += -g
 ifneq ($(OPT_SPEED),)

--- a/src/hash/func.c
+++ b/src/hash/func.c
@@ -315,17 +315,17 @@ static uint32_t hashlittle( const void *key, size_t length, uint32_t initval)
 		/* all the case statements fall through */
 		switch (length) {
 
-		case 12: c+=((uint32_t)k[11])<<24;
-		case 11: c+=((uint32_t)k[10])<<16;
-		case 10: c+=((uint32_t)k[9])<<8;
-		case 9 : c+=k[8];
-		case 8 : b+=((uint32_t)k[7])<<24;
-		case 7 : b+=((uint32_t)k[6])<<16;
-		case 6 : b+=((uint32_t)k[5])<<8;
-		case 5 : b+=k[4];
-		case 4 : a+=((uint32_t)k[3])<<24;
-		case 3 : a+=((uint32_t)k[2])<<16;
-		case 2 : a+=((uint32_t)k[1])<<8;
+		case 12: c+=((uint32_t)k[11])<<24;	/* fall through */
+		case 11: c+=((uint32_t)k[10])<<16;	/* fall through */
+		case 10: c+=((uint32_t)k[9])<<8;	/* fall through */
+		case 9 : c+=k[8];			/* fall through */
+		case 8 : b+=((uint32_t)k[7])<<24;	/* fall through */
+		case 7 : b+=((uint32_t)k[6])<<16;	/* fall through */
+		case 6 : b+=((uint32_t)k[5])<<8;	/* fall through */
+		case 5 : b+=k[4];			/* fall through */
+		case 4 : a+=((uint32_t)k[3])<<24;	/* fall through */
+		case 3 : a+=((uint32_t)k[2])<<16;	/* fall through */
+		case 2 : a+=((uint32_t)k[1])<<8;	/* fall through */
 		case 1 : a+=k[0];
 			break;
 		case 0 : return c;

--- a/src/http/request.c
+++ b/src/http/request.c
@@ -289,8 +289,9 @@ static int send_req(struct http_reqconn *conn, const struct pl *auth)
 			conn->body ? strlen(conn->body) : 0,
 			auth ? "with" : "without");
 
-	if (auth)
+	if (auth) {
 		DEBUG_INFO("auth=|%r|\n", auth);
+	}
 
 #if (DEBUG_LEVEL >= 7)
 	if (conn->body) {

--- a/src/main/openssl.c
+++ b/src/main/openssl.c
@@ -114,8 +114,9 @@ static void sigpipe_handler(int x)
 
 int openssl_init(void)
 {
+	int err;
 #if defined (HAVE_PTHREAD) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
-	int err, i;
+	int i;
 
 	lockv = mem_zalloc(sizeof(pthread_mutex_t) * CRYPTO_num_locks(), NULL);
 	if (!lockv)
@@ -150,7 +151,6 @@ int openssl_init(void)
 #endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-	int err;
 	err = OPENSSL_init_ssl(OPENSSL_INIT_SSL_DEFAULT, NULL);
 	if (!err)
 		return !err;

--- a/src/rtmp/conn.c
+++ b/src/rtmp/conn.c
@@ -938,13 +938,13 @@ int rtmp_accept(struct rtmp_conn **connp, struct tcp_sock *ts,
 	if (err)
 		goto out;
 
-#ifdef USE_TLS
 	if (tls) {
+#ifdef USE_TLS
 		err = tls_start_tcp(&conn->sc, tls, conn->tc, 0);
 		if (err)
 			goto out;
-	}
 #endif
+	}
 
  out:
 	if (err)

--- a/src/sip/transp.c
+++ b/src/sip/transp.c
@@ -182,6 +182,7 @@ static struct sip_conn *ws_conn_find(struct sip *sip, const struct sa *paddr,
 				     enum sip_transp tp)
 {
 	struct le *le;
+	(void) tp;
 
 	le = list_head(hash_list(sip->ht_conn, sa_hash(paddr, SA_ALL)));
 
@@ -768,6 +769,7 @@ static void websock_recv_handler(const struct websock_hdr *hdr,
 	struct sip_msg *msg;
 	size_t start;
 	int err;
+	(void) hdr;
 
 #if 0
 	re_printf(


### PR DESCRIPTION
- [x] Drop Solaris compiler support (sun cc)
- [x] Drop intel icc support
- [x] Drop gcc 2.x/3.x support
- [x] Fix gcc/clang version detection (with -Wextra Bug)
- [x] test baresip and create pull request (fix compiler warnings)