### PR TITLE
mk/re: add C11 and Atomic detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Please send private feedback to libre [at] creytiv.com
 
 ## Design goals
 
-* Portable POSIX source code (ANSI C89 and ISO C99 standard)
+* Portable POSIX source code (ISO C99 and C11 standard)
 * Robust, fast, low memory footprint
 * RFC compliance
 * IPv4 and IPv6 support

--- a/mk/re.mk
+++ b/mk/re.mk
@@ -83,7 +83,7 @@ LD := $(CC)
 CC_LONGVER  := $(shell $(CC) - --version|head -n 1)
 CC_SHORTVER := $(shell $(CC) -dumpversion)
 CC_MAJORVER := $(shell echo $(CC_SHORTVER) |\
-			sed -e 's/\([1-9]\+[0-9]*\)\.[0-9]\+\.[0-9]\+/\1/g')
+			sed -e 's/\([0-9]*\)\.[0-9]\+\.[0-9]\+/\1/g')
 
 # find-out the compiler's name
 
@@ -308,9 +308,14 @@ ifeq ($(CC_C11),)
 CFLAGS  += -std=c99
 else
 CFLAGS  += -std=c11
+HAVE_ATOMIC := 1
 endif
 
 CFLAGS  += -pedantic
+
+ifneq ($(HAVE_ATOMIC),)
+CFLAGS  += -DHAVE_ATOMIC
+endif
 
 
 ifeq ($(OS),)

--- a/mk/re.mk
+++ b/mk/re.mk
@@ -79,8 +79,11 @@ ifeq ($(CC),cc)
 	CC := gcc
 endif
 LD := $(CC)
-CC_LONGVER := $(shell $(CC) - --version|head -n 1)
+
+CC_LONGVER  := $(shell $(CC) - --version|head -n 1)
 CC_SHORTVER := $(shell $(CC) -dumpversion)
+CC_MAJORVER := $(shell echo $(CC_SHORTVER) |\
+			sed -e 's/\([1-9]\+[0-9]*\)\.[0-9]\+\.[0-9]\+/\1/g')
 
 # find-out the compiler's name
 
@@ -88,6 +91,9 @@ ifneq (,$(findstring gcc, $(CC_LONGVER)))
 	CC_NAME := gcc
 	CC_VER := $(CC) $(CC_SHORTVER)
 	MKDEP := $(CC) -MM
+ifneq ($(CC_MAJORVER), 4)
+	CC_C11 := 1
+endif
 endif
 
 ifeq ($(CC_NAME),)
@@ -95,6 +101,9 @@ ifneq (,$(findstring clang, $(CC_LONGVER)))
 	CC_NAME := clang
 	CC_VER := $(CC) $(CC_SHORTVER)
 	MKDEP := $(CC) -MM
+ifneq ($(CC_MAJORVER), 4)
+	CC_C11 := 1
+endif
 endif
 endif
 
@@ -295,7 +304,12 @@ endif
 
 CFLAGS	+= -DOS=\"$(OS)\"
 
+ifeq ($(CC_C11),)
 CFLAGS  += -std=c99
+else
+CFLAGS  += -std=c11
+endif
+
 CFLAGS  += -pedantic
 
 

--- a/mk/re.mk
+++ b/mk/re.mk
@@ -89,7 +89,7 @@ CC_MAJORVER := $(shell echo $(CC_SHORTVER) |\
 
 ifneq (,$(findstring gcc, $(CC_LONGVER)))
 	CC_NAME := gcc
-	CC_VER := $(CC) $(CC_SHORTVER)
+	CC_VER := $(CC) $(CC_SHORTVER) ($(CC_MAJORVER).x)
 	MKDEP := $(CC) -MM
 ifneq ($(CC_MAJORVER), 4)
 	CC_C11 := 1
@@ -99,7 +99,7 @@ endif
 ifeq ($(CC_NAME),)
 ifneq (,$(findstring clang, $(CC_LONGVER)))
 	CC_NAME := clang
-	CC_VER := $(CC) $(CC_SHORTVER)
+	CC_VER := $(CC) $(CC_SHORTVER) ($(CC_MAJORVER).x)
 	MKDEP := $(CC) -MM
 ifneq ($(CC_MAJORVER), 4)
 	CC_C11 := 1
@@ -632,7 +632,7 @@ info:
 	@echo "  OS:            $(OS)"
 	@echo "  BUILD:         $(BUILD)"
 	@echo "  CCACHE:        $(CCACHE)"
-	@echo "  CC:            $(CC_NAME) $(CC_SHORTVER)"
+	@echo "  CC:            $(CC_VER)"
 	@echo "  CFLAGS:        $(CFLAGS)"
 	@echo "  DFLAGS:        $(DFLAGS)"
 	@echo "  LFLAGS:        $(LFLAGS)"


### PR DESCRIPTION
Adding C11 detection (gcc/clang 5.x and newer). It can be disabled with `make CC_C11=`.  When C11 is detected, it defines `HAVE_ATOMIC`. This can also be disabled with `make HAVE_ATOMIC=`.

Fallback tested on centos 7 with gcc 4.x and clang 3.x (`clang -dumpversion` shows 4.x gcc compatibility version and not the real version).