### PR TITLE
Re mk cross compile fixes

### DIFF
--- a/mk/re.mk
+++ b/mk/re.mk
@@ -8,6 +8,8 @@
 #   ARCH           Target architecture
 #   CC             Compiler
 #   CROSS_COMPILE  Cross-compiler prefix (optional)
+#   LIBRE_INC      Libre include path (optional)
+#   LIBRE_SO       Libre library search path (optional)
 #   EXTRA_CFLAGS   Extra compiler flags appended to CFLAGS
 #   EXTRA_LFLAGS   Extra linker flags appended to LFLAGS
 #   GCOV           If non-empty, enable GNU Coverage testing
@@ -725,8 +727,10 @@ rpm:    tar
 LIBRE_PATH := ../re
 
 # Include path
+ifeq ($(LIBRE_INC),)
 LIBRE_INC := $(shell [ -f $(LIBRE_PATH)/include/re.h ] && \
 	echo "$(LIBRE_PATH)/include")
+endif
 ifeq ($(LIBRE_INC),)
 LIBRE_INC := $(shell [ -f /usr/local/include/re/re.h ] && \
 	echo "/usr/local/include/re")
@@ -736,8 +740,10 @@ LIBRE_INC := $(shell [ -f /usr/include/re/re.h ] && echo "/usr/include/re")
 endif
 
 # Library path
+ifeq ($(LIBRE_SO),)
 LIBRE_SO  := $(shell [ -f $(LIBRE_PATH)/libre.a ] \
 	&& echo "$(LIBRE_PATH)")
+endif
 ifeq ($(LIBRE_SO),)
 LIBRE_SO  := $(shell [ -f $(LIBRE_PATH)/libre$(LIB_SUFFIX) ] \
 	&& echo "$(LIBRE_PATH)")

--- a/mk/re.mk
+++ b/mk/re.mk
@@ -8,6 +8,7 @@
 #   ARCH           Target architecture
 #   CC             Compiler
 #   CROSS_COMPILE  Cross-compiler prefix (optional)
+#   LIBRE_PATH     Libre path (optional)
 #   LIBRE_INC      Libre include path (optional)
 #   LIBRE_SO       Libre library search path (optional)
 #   EXTRA_CFLAGS   Extra compiler flags appended to CFLAGS
@@ -724,12 +725,18 @@ rpm:    tar
 # - system installation
 #
 
+ifeq ($(LIBRE_PATH),)
 LIBRE_PATH := ../re
+endif
 
 # Include path
 ifeq ($(LIBRE_INC),)
 LIBRE_INC := $(shell [ -f $(LIBRE_PATH)/include/re.h ] && \
 	echo "$(LIBRE_PATH)/include")
+endif
+ifeq ($(LIBRE_INC),)
+LIBRE_INC := $(shell [ -f $(LIBRE_PATH)/include/re/re.h ] && \
+	echo "$(LIBRE_PATH)/include/re")
 endif
 ifeq ($(LIBRE_INC),)
 LIBRE_INC := $(shell [ -f /usr/local/include/re/re.h ] && \


### PR DESCRIPTION
These days again we are playing around with optimizing/simplifying our yocto recipes. Same for a very old buildroot system. We always run in problems that libre is detected on the build/devel host and paths are set in-correctly.

This two commits repair two possibilities to set the paths to libre, which we think solve cross compilation problems.

1. LIBRE_PATH could be set externally. If it is not set, nothing changes the old behavior. So it should not break anything.
2. LIBRE_INC, LIBRE_SO could be used if headers and libre.so is lying on different places. Same here: If it is not set externally, nothing changes.

If the user previously set one of these variables, it had no result.

With this patches it may often be enough to set CC and SYSROOT correctly for cross compilation. Maybe in addition SYSROOT_ALT. Also DESTDIR for the install target dir.