### PR TITLE
mk/re: info double colon rule

### DIFF
--- a/mk/re.mk
+++ b/mk/re.mk
@@ -626,7 +626,7 @@ distclean:
 	@rm -f `find . -name "*.dylib"`
 
 .PHONY: info
-info:
+info::
 	@echo "info - $(PROJECT) version $(VERSION)"
 	@echo "  MODULES:       $(MODULES)"
 #	@echo "  SRCS:          $(SRCS)"


### PR DESCRIPTION
With Double-Colon Rules you can now extend `make info` in other makefiles.