### PR TITLE
clang shorten-64-to-32 warnings

### DIFF
--- a/mk/re.mk
+++ b/mk/re.mk
@@ -136,6 +136,9 @@ CFLAGS	+= -Waggregate-return
 CFLAGS	+= -Wcast-align
 CFLAGS	+= -Wold-style-definition
 CFLAGS	+= -Wdeclaration-after-statement
+ifeq ($(CC_NAME), clang)
+CFLAGS	+= -Wshorten-64-to-32
+endif
 
 CFLAGS  += -g
 ifneq ($(OPT_SPEED),)

--- a/src/net/linux/rt.c
+++ b/src/net/linux/rt.c
@@ -57,7 +57,7 @@ static int read_sock(int fd, uint8_t *buf, size_t size, int seq, int pid)
 
 	do {
 		/* Receive response from the kernel */
-		if ((n = recv(fd, buf, size - len, 0)) < 0) {
+		if ((n = (int)recv(fd, buf, size - len, 0)) < 0) {
 			DEBUG_WARNING("SOCK READ: %m\n", errno);
 			return -1;
 		}

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -284,7 +284,7 @@ int tls_add_capem(struct tls *tls, const char *capem)
 	if (!store)
 		return EINVAL;
 
-	bio  = BIO_new_mem_buf((char *)capem, strlen(capem));
+	bio  = BIO_new_mem_buf((char *)capem, (int)strlen(capem));
 	if (!bio)
 		return EINVAL;
 


### PR DESCRIPTION
This helps to detect such warnings earlier on all platforms, like mentioned here:
https://github.com/baresip/baresip/pull/1159

depends on: https://github.com/baresip/baresip/pull/1170