### PR TITLE
net: get default source addr

### DIFF
--- a/include/re_net.h
+++ b/include/re_net.h
@@ -40,6 +40,7 @@ struct sa;
 
 /* Net generic */
 int  net_hostaddr(int af, struct sa *ip);
+int  net_dst_source_addr_get(struct sa *dst, struct sa *ip);
 int  net_default_source_addr_get(int af, struct sa *ip);
 int  net_default_gateway_get(int af, struct sa *gw);
 


### PR DESCRIPTION
Especially under windows the selection of the default ip/route is not very reliable. If the new approach fails, it fallbacks to the old mechanisms.

Todo:

- [x] Windows testing (with single adapter)
- [x] Windows testing (with multiple adapters)
- [x] macOS testing (single)
- [x] macOS testing (multiple)
- [x] Linux testing (single)
- [x] Linux testing (multiple)