### PR TITLE
sip: SIP/TLS Server Name Indication

### DIFF
--- a/src/sip/request.c
+++ b/src/sip/request.c
@@ -194,7 +194,8 @@ static int request(struct sip_request *req, enum sip_transp tp,
 		err = sip_send(req->sip, NULL, tp, dst, mb);
 	else
 		err = sip_ctrans_request(&req->ct, req->sip, tp, dst, req->met,
-					 branch, mb, response_handler, req);
+					 branch, req->host, mb,
+					 response_handler, req);
 	if (err)
 		goto out;
 

--- a/src/sip/sip.c
+++ b/src/sip/sip.c
@@ -207,7 +207,7 @@ void sip_close(struct sip *sip, bool force)
 int sip_send(struct sip *sip, void *sock, enum sip_transp tp,
 	     const struct sa *dst, struct mbuf *mb)
 {
-	return sip_transp_send(NULL, sip, sock, tp, dst, mb, NULL, NULL);
+	return sip_transp_send(NULL, sip, sock, tp, dst, NULL, mb, NULL, NULL);
 }
 
 

--- a/src/sip/sip.h
+++ b/src/sip/sip.h
@@ -51,8 +51,8 @@ struct sip_ctrans;
 
 int  sip_ctrans_request(struct sip_ctrans **ctp, struct sip *sip,
 			enum sip_transp tp, const struct sa *dst, char *met,
-			char *branch, struct mbuf *mb, sip_resp_h *resph,
-			void *arg);
+			char *branch, char *host, struct mbuf *mb,
+			sip_resp_h *resph, void *arg);
 int  sip_ctrans_cancel(struct sip_ctrans *ct);
 int  sip_ctrans_init(struct sip *sip, uint32_t sz);
 int  sip_ctrans_debug(struct re_printf *pf, const struct sip *sip);
@@ -70,8 +70,8 @@ typedef void(sip_transp_h)(int err, void *arg);
 
 int  sip_transp_init(struct sip *sip, uint32_t sz);
 int  sip_transp_send(struct sip_connqent **qentp, struct sip *sip, void *sock,
-		     enum sip_transp tp, const struct sa *dst, struct mbuf *mb,
-		     sip_transp_h *transph, void *arg);
+		     enum sip_transp tp, const struct sa *dst, char *host,
+		     struct mbuf *mb, sip_transp_h *transph, void *arg);
 bool sip_transp_supported(struct sip *sip, enum sip_transp tp, int af);
 const char *sip_transp_srvid(enum sip_transp tp);
 bool sip_transp_reliable(enum sip_transp tp);

--- a/src/sip/transp.c
+++ b/src/sip/transp.c
@@ -639,6 +639,10 @@ static int conn_send(struct sip_connqent **qentp, struct sip *sip, bool secure,
 	struct sip_connqent *qent;
 	int err = 0;
 
+#ifndef USE_TLS
+	(void) host;
+#endif
+
 	conn = conn_find(sip, dst, secure);
 	if (conn) {
 		if (!conn->established)

--- a/src/sip/transp.c
+++ b/src/sip/transp.c
@@ -632,7 +632,7 @@ static void tcp_connect_handler(const struct sa *paddr, void *arg)
 
 
 static int conn_send(struct sip_connqent **qentp, struct sip *sip, bool secure,
-		     const struct sa *dst, struct mbuf *mb,
+		     const struct sa *dst, char *host, struct mbuf *mb,
 		     sip_transp_h *transph, void *arg)
 {
 	struct sip_conn *conn, *new_conn = NULL;
@@ -681,6 +681,10 @@ static int conn_send(struct sip_connqent **qentp, struct sip *sip, bool secure,
 		}
 
 		err = tls_start_tcp(&conn->sc, transp->tls, conn->tc, 0);
+		if (err)
+			goto out;
+
+		err = tls_set_verify_server(conn->sc, host);
 		if (err)
 			goto out;
 	}
@@ -1155,8 +1159,8 @@ void sip_transp_flush(struct sip *sip)
 
 
 int sip_transp_send(struct sip_connqent **qentp, struct sip *sip, void *sock,
-		    enum sip_transp tp, const struct sa *dst, struct mbuf *mb,
-		    sip_transp_h *transph, void *arg)
+		    enum sip_transp tp, const struct sa *dst, char *host,
+		    struct mbuf *mb, sip_transp_h *transph, void *arg)
 {
 	const struct sip_transport *transp;
 	struct sip_conn *conn;
@@ -1196,7 +1200,7 @@ int sip_transp_send(struct sip_connqent **qentp, struct sip *sip, void *sock,
 			err = tcp_send(conn->tc, mb);
 		}
 		else
-			err = conn_send(qentp, sip, secure, dst, mb,
+			err = conn_send(qentp, sip, secure, dst, host, mb,
 					transph, arg);
 		break;
 


### PR DESCRIPTION
A change in the API of ctrans and transp is necessary. At the
calls between request and ctrans, the hostname information of the
next hop is lost. This information is crucial for SNI, which is set
in transp.