### PR TITLE
fix weak self-signed certificates

### DIFF
--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -355,7 +355,7 @@ int tls_set_verify_purpose(struct tls *tls, const char *purpose)
  */
 int tls_set_selfsigned(struct tls *tls, const char *cn)
 {
-	return tls_set_selfsigned_rsa(tls, cn, 1024);
+	return tls_set_selfsigned_rsa(tls, cn, 2048);
 }
 
 


### PR DESCRIPTION
increases the size of the self-signed key/certificate to 2048 bytes.
Recent versions of OpenSSL refuse to use certificates with 1024 byte
RSA signatures.

I ran into this after upgrading ubuntu and SSL_CTX_use_certificate returning an error 1.
https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_get_security_level.html returns 2 on those systems, forbidding 1024 byte keys. The overall security of self-signed certificates is not great but this helper method is convenient :-)