### PR TITLE
add error trace helpers

### DIFF
--- a/include/re_types.h
+++ b/include/re_types.h
@@ -143,6 +143,40 @@ typedef bool _Bool;
 #define BREAKPOINT
 #endif
 
+/* Error return/goto debug helpers */
+#ifdef TRACE_ERR
+#define PRINT_TRACE_ERR							\
+		(void)re_fprintf(stderr, "TRACE_ERR: %s:%u: %s():"	\
+			      " %m (%d)\n",				\
+			      __FILE__, __LINE__, __func__,		\
+			      (err), (err));
+#else
+#define PRINT_TRACE_ERR
+#endif
+
+#define IF_ERR_GOTO_OUT(err)	\
+	if ((err)) {		\
+		PRINT_TRACE_ERR	\
+		goto out;	\
+	}
+
+#define IF_ERR_GOTO_OUT1(err)	\
+	if ((err)) {		\
+		PRINT_TRACE_ERR	\
+		goto out1;	\
+	}
+
+#define IF_ERR_GOTO_OUT2(err)	\
+	if ((err)) {		\
+		PRINT_TRACE_ERR	\
+		goto out2;	\
+	}
+
+#define IF_ERR_RETURN(exp)	\
+	if ((exp)) {		\
+		PRINT_TRACE_ERR	\
+		return err;	\
+	}
 
 /* Error codes */
 #include <errno.h>

--- a/mk/re.mk
+++ b/mk/re.mk
@@ -19,6 +19,7 @@
 #   OPT_SPEED      If non-empty, optimize for speed
 #   PROJECT        Project name
 #   RELEASE        Release build
+#   TRACE_ERR      Trace error codes
 #   SYSROOT        System root of library and include files
 #   SYSROOT_ALT    Alternative system root of library and include files
 #   USE_OPENSSL    If non-empty, link to libssl library
@@ -49,6 +50,9 @@ CFLAGS  += -DRELEASE
 OPT_SPEED=1
 endif
 
+ifneq ($(TRACE_ERR),)
+CFLAGS  += -DTRACE_ERR
+endif
 
 # Default system root
 ifeq ($(SYSROOT),)


### PR DESCRIPTION
Usage example:
```c
#include <re.h>

int fn1(void);
int fn2(void);
int fn3(void);

int fn1(void) {
	int err;

	err = fn2();
	IF_ERR_RETURN(err);

	return 0;
}

int fn2(void) {
	int err;

	err = fn3();
	IF_ERR_RETURN(err);

	return 0;
}

int fn3(void) {
	int err;

	err = EINVAL;
	IF_ERR_RETURN(err);

	return 0;
}

int main(void)
{
	int err;

	err = fn1();
	IF_ERR_GOTO_OUT(err);

	return 0;
out:
	re_printf("error %d\n", err);
        return err;
}
```

`make TRACE_ERR=1`

Output after execution:
```
TRACE_ERR: src/main.c:29: fn3(): Invalid argument (22)
TRACE_ERR: src/main.c:20: fn2(): Invalid argument (22)
TRACE_ERR: src/main.c:11: fn1(): Invalid argument (22)
TRACE_ERR: src/main.c:39: main(): Invalid argument (22)
error 22
```           
