### PR TITLE
Add function that resets the timeout timer.

### DIFF
--- a/include/re_http.h
+++ b/include/re_http.h
@@ -178,6 +178,7 @@ struct tcp_sock *http_sock_tcp(struct http_sock *sock);
 const struct sa *http_conn_peer(const struct http_conn *conn);
 struct tcp_conn *http_conn_tcp(struct http_conn *conn);
 struct tls_conn *http_conn_tls(struct http_conn *conn);
+void http_conn_reset_timeout(struct http_conn *conn);
 void http_conn_close(struct http_conn *conn);
 int  http_reply(struct http_conn *conn, uint16_t scode, const char *reason,
 		const char *fmt, ...);

--- a/src/http/server.c
+++ b/src/http/server.c
@@ -375,6 +375,12 @@ struct tls_conn *http_conn_tls(struct http_conn *conn)
 }
 
 
+void http_conn_reset_timeout(struct http_conn *conn)
+{
+	tmr_start(&conn->tmr, TIMEOUT_IDLE, timeout_handler, conn);
+}
+
+
 /**
  * Close the HTTP connection
  *


### PR DESCRIPTION
Add function that resets the timeout timer for a connection of the HTTP server. 

This is required for long lasting requests such as streaming media (MJPEG stream) or file uploads.