### PR TITLE
sdp: in media_decode() reset rdir if port is zero

### DIFF
--- a/src/sdp/msg.c
+++ b/src/sdp/msg.c
@@ -222,6 +222,9 @@ static int media_decode(struct sdp_media **mp, struct sdp_session *sess,
 
 	m->rdir = sess->rdir;
 
+	if (!pl_u32(&port))
+		m->rdir = SDP_INACTIVE;
+
 	*mp = m;
 
 	return 0;


### PR DESCRIPTION
Consider the case e.g. in Session Progress SDP when the port number is zero!
This, means that the media should be deactivated and no attribute lines will
follow in the SDP. In this case the rdir should be set to SDP_INACTIVE.

- Tested with baresip on both sides branch https://github.com/cspiel1/baresip/tree/selective_early_media.
- Had an outgoing call and the peer sends a 183 Session Progress with deactivated audio (early video only).
- In `sdp_decode()` from SDP on the 183 Session Progress the audio rdir should be set to SDP_INACTIVE, which is not done in master.

This fix relates to baresip PR: https://github.com/baresip/baresip/pull/1398