### PR TITLE
sip: allow sip authentification only for registered proxies

### DIFF
--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -263,6 +263,10 @@ int  sip_send(struct sip *sip, void *sock, enum sip_transp tp,
 	      const struct sa *dst, struct mbuf *mb);
 void sip_set_trace_handler(struct sip *sip, sip_trace_h *traceh);
 
+int sip_add_regip(struct sip *sip, const struct sa *addr);
+void sip_rm_regip(struct sip *sip, const struct sa *addr);
+bool sip_is_regip(struct sip *sip, const struct sa *addr);
+
 
 /* transport */
 int  sip_transp_add(struct sip *sip, enum sip_transp tp,
@@ -323,8 +327,8 @@ void sip_reply_addr(struct sa *addr, const struct sip_msg *msg, bool rport);
 
 /* auth */
 int  sip_auth_authenticate(struct sip_auth *auth, const struct sip_msg *msg);
-int  sip_auth_alloc(struct sip_auth **authp, sip_auth_h *authh,
-		    void *arg, bool ref);
+int  sip_auth_alloc(struct sip_auth **authp, struct sip *sip,
+		    sip_auth_h *authh, void *arg, bool ref);
 void sip_auth_reset(struct sip_auth *auth);
 
 

--- a/src/sip/sip.h
+++ b/src/sip/sip.h
@@ -9,6 +9,7 @@ struct sip {
 	struct list transpl;
 	struct list lsnrl;
 	struct list reql;
+	struct list regipl;
 	struct hash *ht_ctrans;
 	struct hash *ht_strans;
 	struct hash *ht_strans_mrg;
@@ -40,6 +41,12 @@ struct sip_keepalive {
 	struct sip_keepalive **kap;
 	sip_keepalive_h *kah;
 	void *arg;
+};
+
+
+struct sip_regip {
+	struct le le;
+	struct sa addr;
 };
 
 

--- a/src/sipevent/notify.c
+++ b/src/sipevent/notify.c
@@ -363,7 +363,7 @@ int sipevent_accept(struct sipnot **notp, struct sipevent_sock *sock,
 		    hash_joaat_str(sip_dialog_callid(not->dlg)),
 		    &not->he, not);
 
-	err = sip_auth_alloc(&not->auth, authh, aarg, aref);
+	err = sip_auth_alloc(&not->auth, sock->sip, authh, aarg, aref);
 	if (err)
 		goto out;
 

--- a/src/sipevent/subscribe.c
+++ b/src/sipevent/subscribe.c
@@ -391,7 +391,7 @@ static int sipsub_alloc(struct sipsub **subp, struct sipevent_sock *sock,
 		    hash_joaat_str(sip_dialog_callid(sub->dlg)),
 		    &sub->he, sub);
 
-	err = sip_auth_alloc(&sub->auth, authh, aarg, aref);
+	err = sip_auth_alloc(&sub->auth, sock->sip, authh, aarg, aref);
 	if (err)
 		goto out;
 
@@ -636,7 +636,7 @@ int sipevent_fork(struct sipsub **subp, struct sipsub *osub,
 		    hash_joaat_str(sip_dialog_callid(sub->dlg)),
 		    &sub->he, sub);
 
-	err = sip_auth_alloc(&sub->auth, authh, aarg, aref);
+	err = sip_auth_alloc(&sub->auth, osub->sip, authh, aarg, aref);
 	if (err)
 		goto out;
 

--- a/src/sipsess/sess.c
+++ b/src/sipsess/sess.c
@@ -169,7 +169,7 @@ int sipsess_alloc(struct sipsess **sessp, struct sipsess_sock *sock,
 	if (!sess)
 		return ENOMEM;
 
-	err = sip_auth_alloc(&sess->auth, authh, aarg, aref);
+	err = sip_auth_alloc(&sess->auth, sock->sip, authh, aarg, aref);
 	if (err)
 		goto out;
 


### PR DESCRIPTION
* peer to peer connections should never challenge a sip auth

* maintain a list of registrar IP addresses to check against if a
  digest challenge is received

The attack is fully described [here](https://resources.enablesecurity.com/resources/sipdigestleak-tut.pdf)
Short:
- The attacker is able to call a client
- The client accept the call
- Only music is played and the callee hangup
- The attacker challenge the BYE request with 407
- The callee response with a digest challenge response and leak the digest including the password

If the digest response is leaked the security depends only on the complexity of the used password. There are tools out there which utilizes GPUs to recover the password from the digest response. 