### PR TITLE
ua selection checks for UDP transport

### DIFF
--- a/include/re_sipreg.h
+++ b/include/re_sipreg.h
@@ -18,6 +18,7 @@ int sipreg_register(struct sipreg **regp, struct sip *sip, const char *reg_uri,
 int sipreg_set_rwait(struct sipreg *reg, uint32_t rwait);
 
 const struct sa *sipreg_laddr(const struct sipreg *reg);
+const struct sa *sipreg_paddr(const struct sipreg *reg);
 
 uint32_t sipreg_proxy_expires(const struct sipreg *reg);
 bool sipreg_registered(const struct sipreg *reg);

--- a/src/sipreg/reg.c
+++ b/src/sipreg/reg.c
@@ -27,6 +27,7 @@ enum {
 struct sipreg {
 	struct sip_loopstate ls;
 	struct sa laddr;
+	struct sa paddr;
 	struct tmr tmr;
 	struct sip *sip;
 	struct sip_keepalive *ka;
@@ -196,6 +197,8 @@ static void response_handler(int err, const struct sip_msg *msg, void *arg)
 
 		if (reg->regid > 0 && !reg->terminated && !reg->ka)
 			start_outbound(reg, msg);
+
+		sa_cpy(&reg->paddr, &msg->src);
 	}
 	else {
 		if (reg->terminated && !reg->registered)
@@ -438,6 +441,19 @@ int sipreg_set_rwait(struct sipreg *reg, uint32_t rwait)
 const struct sa *sipreg_laddr(const struct sipreg *reg)
 {
 	return reg ? &reg->laddr : NULL;
+}
+
+
+/**
+ * Get the IP address of the SIP Registration server
+ *
+ * @param reg sipreg object
+ *
+ * @return IP address
+ */
+const struct sa *sipreg_paddr(const struct sipreg *reg)
+{
+	return reg ? &reg->paddr : NULL;
 }
 
 


### PR DESCRIPTION
* paddr holds the address information of the peer where
  a successful registration happend