### PR TITLE
call answer media dir

### DIFF
--- a/src/sdp/media.c
+++ b/src/sdp/media.c
@@ -54,7 +54,7 @@ static int media_alloc(struct sdp_media **mp, struct list *list)
 	list_append(list, &m->le, m);
 
 	m->ldir  = SDP_SENDRECV;
-	m->rdir  = SDP_SENDRECV;
+	m->rdir  = SDP_INACTIVE;
 	m->dynpt = RTP_DYNPT_START;
 
 	sa_init(&m->laddr, AF_INET);
@@ -169,7 +169,7 @@ void sdp_media_rreset(struct sdp_media *m)
 	list_flush(&m->rfmtl);
 	list_flush(&m->rattrl);
 
-	m->rdir = SDP_SENDRECV;
+	m->rdir = SDP_INACTIVE;
 
 	for (i=0; i<SDP_BANDWIDTH_MAX; i++)
 		m->rbwv[i] = -1;


### PR DESCRIPTION
    sdp: initialize SDP media dir to inactive
    
    In baresip audio+video with SDP session and media is allocated by default for
    each call. Thus it would expect video RTP packets, regardless if the remote
    offers video or not. This fix achieves that the video remote direction stays at
    inactive until an m-line for video is found in an SDP offer. Then the media
    remote dir is initialized to the sessions media dir, which is send-receive. The
    direction attribute may override to e.g. one-directional video.