### PR TITLE
SIP redirect callbackfunction

### DIFF
--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -347,6 +347,7 @@ int  sip_dialog_fork(struct sip_dialog **dlgp, struct sip_dialog *odlg,
 int  sip_dialog_update(struct sip_dialog *dlg, const struct sip_msg *msg);
 bool sip_dialog_rseq_valid(struct sip_dialog *dlg, const struct sip_msg *msg);
 const char *sip_dialog_callid(const struct sip_dialog *dlg);
+const char *sip_dialog_uri(const struct sip_dialog *dlg);
 uint32_t sip_dialog_lseq(const struct sip_dialog *dlg);
 bool sip_dialog_established(const struct sip_dialog *dlg);
 bool sip_dialog_cmp(const struct sip_dialog *dlg, const struct sip_msg *msg);

--- a/include/re_sipsess.h
+++ b/include/re_sipsess.h
@@ -20,6 +20,8 @@ typedef void (sipsess_refer_h)(struct sip *sip, const struct sip_msg *msg,
 			       void *arg);
 typedef void (sipsess_close_h)(int err, const struct sip_msg *msg, void *arg);
 
+typedef void (sipsess_redirect_h)(const struct sip_msg *msg,
+				  const char *uri, void *arg);
 
 int  sipsess_listen(struct sipsess_sock **sockp, struct sip *sip,
 		    int htsize, sipsess_conn_h *connh, void *arg);
@@ -44,6 +46,9 @@ int  sipsess_accept(struct sipsess **sessp, struct sipsess_sock *sock,
 		    sipsess_estab_h *estabh, sipsess_info_h *infoh,
 		    sipsess_refer_h *referh, sipsess_close_h *closeh,
 		    void *arg, const char *fmt, ...);
+
+int  sipsess_set_redirect_handler(struct sipsess *sess,
+				  sipsess_redirect_h *redirecth);
 
 int  sipsess_progress(struct sipsess *sess, uint16_t scode,
 		      const char *reason, struct mbuf *desc,

--- a/src/sip/sip.h
+++ b/src/sip/sip.h
@@ -87,7 +87,6 @@ int  sip_auth_encode(struct mbuf *mb, struct sip_auth *auth, const char *met,
 /* dialog */
 int  sip_dialog_encode(struct mbuf *mb, struct sip_dialog *dlg, uint32_t cseq,
 		       const char *met);
-const char *sip_dialog_uri(const struct sip_dialog *dlg);
 const struct uri *sip_dialog_route(const struct sip_dialog *dlg);
 uint32_t sip_dialog_hash(const struct sip_dialog *dlg);
 

--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -90,6 +90,10 @@ static void invite_resp_handler(int err, const struct sip_msg *msg, void *arg)
 		if (err)
 			goto out;
 
+		if (sess->redirecth)
+			sess->redirecth(msg, sip_dialog_uri(sess->dlg),
+				        sess->arg);
+
 		err = invite(sess);
 		if (err)
 			goto out;

--- a/src/sipsess/sess.c
+++ b/src/sipsess/sess.c
@@ -203,6 +203,18 @@ int sipsess_alloc(struct sipsess **sessp, struct sipsess_sock *sock,
 }
 
 
+int  sipsess_set_redirect_handler(struct sipsess *sess,
+				  sipsess_redirect_h *redirecth)
+{
+	if (!sess || !redirecth)
+		return EINVAL;
+
+	sess->redirecth = redirecth;
+
+	return 0;
+}
+
+
 void sipsess_terminate(struct sipsess *sess, int err,
 		       const struct sip_msg *msg)
 {

--- a/src/sipsess/sipsess.h
+++ b/src/sipsess/sipsess.h
@@ -30,6 +30,7 @@ struct sipsess {
 	sipsess_info_h *infoh;
 	sipsess_refer_h *referh;
 	sipsess_close_h *closeh;
+	sipsess_redirect_h *redirecth;
 	void *arg;
 	bool owner;
 	bool sent_offer;


### PR DESCRIPTION
Adding a redirect handler allows libre to push information into baresip
about an ongoing redirection resulting from a 3xx code.