### PR TITLE
fix clang analyze warnings

### DIFF
--- a/.github/workflows/clang-analyze.yml
+++ b/.github/workflows/clang-analyze.yml
@@ -1,0 +1,15 @@
+name: clang analyze
+
+on: [push, pull_request]
+
+jobs:
+  clang-analyze:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: make
+      run: | 
+        make info EXTRA_CFLAGS="-Werror" CCACHE=
+        make clang EXTRA_CFLAGS="-Werror" CCACHE=

--- a/src/http/client.c
+++ b/src/http/client.c
@@ -632,7 +632,7 @@ static int read_file(char **pbuf, const char *path)
 	fclose(f);
 	buf[s] = 0;
 	if (n < s) {
-		buf = mem_deref(buf);
+		mem_deref(buf);
 		return EIO;
 	}
 
@@ -769,6 +769,8 @@ int http_request(struct http_req **reqp, struct http_cli *cli, const char *met,
 		err = tls_set_certificate(cli->tls,
 				cli->cert, strlen(cli->cert));
 	}
+	if (err)
+		goto out;
 #endif
 
 	if (!sa_set_str(&req->srvv[0], req->host, req->port)) {

--- a/src/http/request.c
+++ b/src/http/request.c
@@ -327,7 +327,7 @@ static int send_req(struct http_reqconn *conn, const struct pl *auth)
 	}
 
 	/* keep internal reference for resp_handler */
-	conn = mem_ref(conn);
+	mem_ref(conn);
 	return 0;
 }
 

--- a/src/httpauth/digest.c
+++ b/src/httpauth/digest.c
@@ -242,8 +242,7 @@ int httpauth_digest_make_response(struct httpauth_digest_resp **presp,
 
 	resp = mem_zalloc(sizeof(*resp), response_destructor);
 	if (!resp) {
-		err = ENOMEM;
-		goto out;
+		return ENOMEM;
 	}
 
 	mb = mbuf_alloc(256);

--- a/src/jbuf/jbuf.c
+++ b/src/jbuf/jbuf.c
@@ -345,7 +345,7 @@ int jbuf_set_wish(struct jbuf *jb, uint32_t wish)
 static uint32_t calc_bufftime(struct jbuf *jb)
 {
 	struct frame *fh, *ft;
-	uint32_t buftime = jb->ptime;
+	uint32_t buftime;
 	uint32_t diff;
 
 	jb->ptime = calc_ptime(jb);


### PR DESCRIPTION
- http/request.c:send_req - Dead assignment
- http/client.c:read_file - Dead assignment
- http/client.c:http_request - Dead assignment
- jbuf/jbuf.c:calc_bufftime - Dead initialization
- httpauth/digest.c:httpauth_digest_make_response - Dereference of null pointer