### PR TITLE
fmt: support different separators for parameter parsing

### DIFF
--- a/include/re_fmt.h
+++ b/include/re_fmt.h
@@ -141,6 +141,8 @@ typedef void (fmt_param_h)(const struct pl *name, const struct pl *val,
 			   void *arg);
 
 bool fmt_param_exists(const struct pl *pl, const char *pname);
+bool fmt_param_sep_get(const struct pl *pl, const char *pname, char sep,
+		struct pl *val);
 bool fmt_param_get(const struct pl *pl, const char *pname, struct pl *val);
 void fmt_param_apply(const struct pl *pl, fmt_param_h *ph, void *arg);
 

--- a/src/fmt/prm.c
+++ b/src/fmt/prm.c
@@ -38,6 +38,36 @@ bool fmt_param_exists(const struct pl *pl, const char *pname)
 
 
 /**
+ * Fetch parameter from a PL string. The separator can be specified
+ *
+ * @param pl    PL string to search
+ * @param pname Parameter name
+ * @param sep   Separator
+ * @param val   Parameter value, set on return
+ *
+ * @return true if found, false if not found
+ */
+bool fmt_param_sep_get(const struct pl *pl, const char *pname, char sep,
+		struct pl *val)
+{
+	struct pl semi;
+	char expr[128];
+
+	if (!pl || !pname)
+		return false;
+
+	(void)re_snprintf(expr, sizeof(expr),
+		  "[%c]*[ \t\r\n]*%s[ \t\r\n]*=[ \t\r\n]*[~ \t\r\n%c]+",
+		  sep, pname, sep);
+
+	if (re_regex(pl->p, pl->l, expr, &semi, NULL, NULL, NULL, val))
+		return false;
+
+	return semi.l > 0 || pl->p == semi.p;
+}
+
+
+/**
  * Fetch a semicolon separated parameter from a PL string
  *
  * @param pl    PL string to search
@@ -48,20 +78,7 @@ bool fmt_param_exists(const struct pl *pl, const char *pname)
  */
 bool fmt_param_get(const struct pl *pl, const char *pname, struct pl *val)
 {
-	struct pl semi;
-	char expr[128];
-
-	if (!pl || !pname)
-		return false;
-
-	(void)re_snprintf(expr, sizeof(expr),
-			  "[;]*[ \t\r\n]*%s[ \t\r\n]*=[ \t\r\n]*[~ \t\r\n;]+",
-			  pname);
-
-	if (re_regex(pl->p, pl->l, expr, &semi, NULL, NULL, NULL, val))
-		return false;
-
-	return semi.l > 0 || pl->p == semi.p;
+	return fmt_param_sep_get(pl, pname, ';', val);
 }
 
 


### PR DESCRIPTION
This e.g. would allow to specify in baresip account specific parameters in the `extra` address parameter.

e.g.:
```
<sip:user@domain.com;transport=tcp>;auth_pass=secret;extra=ex1=1,ex2=2,ex3=3;medianat=ice
```
Can be used for baresip-apps PR: https://github.com/baresip/baresip-apps/pull/5 