### PR TITLE
sa: fix build for old systems

### DIFF
--- a/src/sa/sa.c
+++ b/src/sa/sa.c
@@ -10,11 +10,14 @@
 #include <winsock2.h>
 #else
 #include <arpa/inet.h>
+#define __USE_POSIX 1  /**< Use POSIX flag */
+#define __USE_XOPEN2K 1/**< Use POSIX.1:2001 code */
+#define __USE_MISC 1
+#include <netdb.h>
 #endif
 #include <string.h>
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <netdb.h>
 #include <re_types.h>
 #include <re_fmt.h>
 #include <re_list.h>


### PR DESCRIPTION
On some old systems getaddrinfo() is not available.
