### PR TITLE
SIP default protocol

### DIFF
--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -283,6 +283,7 @@ enum sip_transp sip_transp_decode(const struct pl *pl);
 uint16_t sip_transp_port(enum sip_transp tp, uint16_t port);
 int  sip_transp_laddr(struct sip *sip, struct sa *laddr, enum sip_transp tp,
 		      const struct sa *dst);
+int  sip_transp_set_default(struct sip *sip, enum sip_transp tp);
 int  sip_settos(struct sip *sip, uint8_t tos);
 
 

--- a/src/sip/request.c
+++ b/src/sip/request.c
@@ -306,6 +306,22 @@ static bool transp_next_srv(struct sip *sip, enum sip_transp *tp)
 }
 
 
+static bool transp_first(struct sip *sip, enum sip_transp *tp)
+{
+	if (!sip || !tp)
+		return false;
+
+	if (sip->tp_def != SIP_TRANSP_NONE &&
+			sip_transp_supported(sip, sip->tp_def, AF_UNSPEC)) {
+		*tp = sip->tp_def;
+		return true;
+	}
+
+	*tp = SIP_TRANSP_NONE;
+	return transp_next(sip, tp);
+}
+
+
 static bool rr_append_handler(struct dnsrr *rr, void *arg)
 {
 	struct list *lst = arg;
@@ -468,8 +484,7 @@ static void srv_handler(int err, const struct dnshdr *hdr, struct list *ansl,
 				return;
 			}
 
-			req->tp = SIP_TRANSP_NONE;
-			if (!transp_next(req->sip, &req->tp)) {
+			if (!transp_first(req->sip, &req->tp)) {
 				err = EPROTONOSUPPORT;
 				goto fail;
 			}
@@ -659,8 +674,7 @@ int sip_request(struct sip_request **reqp, struct sip *sip, bool stateful,
 		req->tp_selected = true;
 	}
 	else {
-		req->tp = SIP_TRANSP_NONE;
-		if (!transp_next(sip, &req->tp)) {
+		if (!transp_first(sip, &req->tp)) {
 			err = EPROTONOSUPPORT;
 			goto out;
 		}

--- a/src/sip/sip.c
+++ b/src/sip/sip.c
@@ -126,6 +126,7 @@ int sip_alloc(struct sip **sipp, struct dnsc *dnsc, uint32_t ctsz,
 	if (!sip)
 		return ENOMEM;
 
+	sip->tp_def = SIP_TRANSP_NONE;
 	err = sip_transp_init(sip, tcsz);
 	if (err)
 		goto out;

--- a/src/sip/sip.h
+++ b/src/sip/sip.h
@@ -23,6 +23,7 @@ struct sip {
 	void *arg;
 	bool closing;
 	uint8_t tos;
+	enum sip_transp tp_def;
 };
 
 

--- a/src/sip/transp.c
+++ b/src/sip/transp.c
@@ -1497,6 +1497,16 @@ bool sip_transp_supported(struct sip *sip, enum sip_transp tp, int af)
 }
 
 
+int  sip_transp_set_default(struct sip *sip, enum sip_transp tp)
+{
+	if (!sip)
+		return EINVAL;
+
+	sip->tp_def = tp;
+	return 0;
+}
+
+
 /**
  * Check if network address is part of SIP transports
  *


### PR DESCRIPTION
Currently always UDP is used if no "transport=" parameter is present.

This PR allows to set a different default transport protocol.