### PR TITLE
tls: add keylogger callback function

### DIFF
--- a/mk/re.mk
+++ b/mk/re.mk
@@ -20,6 +20,7 @@
 #   PROJECT        Project name
 #   RELEASE        Release build
 #   TRACE_ERR      Trace error codes
+#   TRACE_SSL      Log SSL key material = [/path/to/log/file.log]
 #   SYSROOT        System root of library and include files
 #   SYSROOT_ALT    Alternative system root of library and include files
 #   USE_OPENSSL    If non-empty, link to libssl library
@@ -55,6 +56,11 @@ endif
 ifneq ($(TRACE_ERR),)
 CFLAGS  += -DTRACE_ERR
 endif
+
+ifneq ($(TRACE_SSL),)
+CFLAGS  += -DTRACE_SSL="\"${TRACE_SSL}\""
+endif
+
 
 # Default system root
 ifeq ($(SYSROOT),)


### PR DESCRIPTION
* THIS IS ONLY FOR DEBUGGING PURPOSE.

* The key logger is only available with OpenSSL >= v1.1.1
* It is only compiled if TRACE_SSL is defined
* TRACE_SSL must define a writeable location and filename
* In case the conditions above are fulfiled, it
  allows the developer to log key material of a tls connection.
  Including the key material into eg. Wireshark allows the developer
  to decrypt the SSL stream.