### PR TITLE
Fix win32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ tags
 # clangd
 .cache
 compile_commands.json
+
+# Visual studio config
+mk/win32/*.vcxproj.user

--- a/mk/win32/re.vcxproj
+++ b/mk/win32/re.vcxproj
@@ -303,6 +303,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <DisableSpecificWarnings>4142;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <ObjectFileName>$(IntDir)%(RelativeDir)%(Filename).obj</ObjectFileName>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Lib>
       <AdditionalOptions>Iphlpapi.lib %(AdditionalOptions)</AdditionalOptions>

--- a/mk/win32/re.vcxproj
+++ b/mk/win32/re.vcxproj
@@ -160,6 +160,7 @@
     <ClCompile Include="..\..\src\net\sockopt.c" />
     <ClCompile Include="..\..\src\net\win32\wif.c" />
     <ClCompile Include="..\..\src\odict\entry.c" />
+    <ClCompile Include="..\..\src\odict\get.c" />
     <ClCompile Include="..\..\src\odict\odict.c" />
     <ClCompile Include="..\..\src\odict\type.c" />
     <ClCompile Include="..\..\src\rtp\fb.c" />

--- a/mk/win32/re.vcxproj.filters
+++ b/mk/win32/re.vcxproj.filters
@@ -858,6 +858,9 @@
     <ClCompile Include="..\..\src\http\chunk.c">
       <Filter>src\http</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\odict\get.c">
+      <Filter>src\odict</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\srtp\README">


### PR DESCRIPTION
fix compiling whole Baresip solution (win32) in Visual Studio (2019)