### PR TITLE
fix warnings from PVS-Studio C++ static analyzer

### DIFF
--- a/src/jbuf/jbuf.c
+++ b/src/jbuf/jbuf.c
@@ -190,10 +190,11 @@ static uint32_t calc_ptime(struct jbuf *jb)
 	if (lt && lt->prev) {
 		ft  = lt->data;
 		ftt = lt->prev->data;
-		seqd = ft->hdr.seq - ftt->hdr.seq;
-		if (ftt && ft && seqd > 0)
-			ptime = (ft->hdr.ts - ftt->hdr.ts) / (8 * seqd);
-
+		if(ftt && ft) {
+			seqd = ft->hdr.seq - ftt->hdr.seq;
+			if(seqd > 0)
+				ptime = (ft->hdr.ts - ftt->hdr.ts) / (8 * seqd);
+		}
 	}
 
 #if DEBUG_LEVEL >= 6

--- a/src/jbuf/jbuf.c
+++ b/src/jbuf/jbuf.c
@@ -191,7 +191,7 @@ static uint32_t calc_ptime(struct jbuf *jb)
 		ft  = lt->data;
 		ftt = lt->prev->data;
 		if (!ftt || !ft)
-			return ptime; 
+			return ptime;
 
 		seqd = ft->hdr.seq - ftt->hdr.seq;
 		if (seqd > 0)

--- a/src/jbuf/jbuf.c
+++ b/src/jbuf/jbuf.c
@@ -190,10 +190,11 @@ static uint32_t calc_ptime(struct jbuf *jb)
 	if (lt && lt->prev) {
 		ft  = lt->data;
 		ftt = lt->prev->data;
-		if(ftt && ft) {
+		if (ftt && ft) {
 			seqd = ft->hdr.seq - ftt->hdr.seq;
-			if(seqd > 0)
-				ptime = (ft->hdr.ts - ftt->hdr.ts) / (8 * seqd);
+			if (seqd > 0)
+				ptime = (ft->hdr.ts - ftt->hdr.ts) 
+					/ (8 * seqd);
 		}
 	}
 

--- a/src/jbuf/jbuf.c
+++ b/src/jbuf/jbuf.c
@@ -190,12 +190,13 @@ static uint32_t calc_ptime(struct jbuf *jb)
 	if (lt && lt->prev) {
 		ft  = lt->data;
 		ftt = lt->prev->data;
-		if (ftt && ft) {
-			seqd = ft->hdr.seq - ftt->hdr.seq;
-			if (seqd > 0)
-				ptime = (ft->hdr.ts - ftt->hdr.ts)
-					/ (8 * seqd);
-		}
+		if (!ftt || !ft)
+			return ptime; 
+
+		seqd = ft->hdr.seq - ftt->hdr.seq;
+		if (seqd > 0)
+			ptime = (ft->hdr.ts - ftt->hdr.ts) / (8 * seqd);
+
 	}
 
 #if DEBUG_LEVEL >= 6

--- a/src/jbuf/jbuf.c
+++ b/src/jbuf/jbuf.c
@@ -193,7 +193,7 @@ static uint32_t calc_ptime(struct jbuf *jb)
 		if (ftt && ft) {
 			seqd = ft->hdr.seq - ftt->hdr.seq;
 			if (seqd > 0)
-				ptime = (ft->hdr.ts - ftt->hdr.ts) 
+				ptime = (ft->hdr.ts - ftt->hdr.ts)
 					/ (8 * seqd);
 		}
 	}

--- a/src/sdp/msg.c
+++ b/src/sdp/msg.c
@@ -470,7 +470,7 @@ static int media_encode(const struct sdp_media *m, struct mbuf *mb, bool offer)
  */
 int sdp_encode(struct mbuf **mbp, struct sdp_session *sess, bool offer)
 {
-	const int ipver = sa_af(&sess->laddr) == AF_INET ? 4 : 6;
+	int ipver;
 	enum sdp_bandwidth i;
 	struct mbuf *mb;
 	struct le *le;
@@ -483,6 +483,7 @@ int sdp_encode(struct mbuf **mbp, struct sdp_session *sess, bool offer)
 	if (!mb)
 		return ENOMEM;
 
+	ipver = sa_af(&sess->laddr) == AF_INET ? 4 : 6;
 	err  = mbuf_printf(mb, "v=%u\r\n", SDP_VERSION);
 	err |= mbuf_printf(mb, "o=- %u %u IN IP%d %j\r\n",
 			   sess->id, sess->ver++, ipver, &sess->laddr);


### PR DESCRIPTION
jbuf.c:193  High  V595  The 'ft' pointer was utilized before it was verified against nullptr. Check lines: 193, 194.
msg.c:473  High  V595  The 'sess' pointer was utilized before it was verified against nullptr. Check lines: 473, 479.