### PR TITLE
json: fix parsing json containing only single value

### DIFF
--- a/src/json/decode.c
+++ b/src/json/decode.c
@@ -443,10 +443,16 @@ static int _json_decode(const char **str, size_t *len,
 
 			if (**str == '\"')
 				inquot = true;
-
 			val.p = *str;
 			val.l = 0;
 			ws = 0;
+
+			if (!inobj && !inarray) {
+				val.l = *len;
+				if (array_entry(idx, &val, aeh, arg))
+					val.l = 0;
+			}
+
 			break;
 		}
 	}


### PR DESCRIPTION
Fix parsing simple json containing only 1 value without a name
.e.g. '"HelloWorld"' or '42'