### PR TITLE
dns: fix dnsc_alloc with IPv6 disabled

### DIFF
--- a/src/dns/client.c
+++ b/src/dns/client.c
@@ -880,7 +880,7 @@ int dnsc_alloc(struct dnsc **dcpp, const struct dnsc_conf *conf,
 
 #ifdef HAVE_INET6
 	sa_set_str(&laddr6, "::", 0);
-	err |= udp_listen(&dnsc->us6, &laddr6, udp_recv_handler, dnsc);
+	err &= udp_listen(&dnsc->us6, &laddr6, udp_recv_handler, dnsc);
 #endif
 	if (err)
 		goto out;


### PR DESCRIPTION
Return error only if IPv4 and IPv6 udp_listen fail.
If IPv6 is completely disabled with kernel line "ipv6.disable=1", dnsc_alloc fails with HAVE_INET6=1 enabled.