### PR TITLE
sdp: include all media formats in SDP offer

### DIFF
--- a/src/sdp/msg.c
+++ b/src/sdp/msg.c
@@ -398,7 +398,7 @@ static int media_encode(const struct sdp_media *m, struct mbuf *mb, bool offer)
 
 		const struct sdp_format *fmt = le->data;
 
-		if (!fmt->sup)
+		if (!fmt->sup && !offer)
 			continue;
 
 		err |= mbuf_printf(mb, " %s", fmt->id);
@@ -424,7 +424,10 @@ static int media_encode(const struct sdp_media *m, struct mbuf *mb, bool offer)
 
 		const struct sdp_format *fmt = le->data;
 
-		if (!fmt->sup || !str_isset(fmt->name))
+		if (!str_isset(fmt->name))
+			continue;
+
+		if (!fmt->sup && !offer)
 			continue;
 
 		err |= mbuf_printf(mb, "a=rtpmap:%s %s/%u",


### PR DESCRIPTION
This patch adds support for the SDP offer to include all available
local media formats regardless of the already selected format.
It allows the practical usecase of a re-Invite as late offer. The
receiver of the re-Invite can include a list of all available
media formats as SDP offer.