### PR TITLE
basic support for SIP SHA-256 digest

### DIFF
--- a/include/re_sha.h
+++ b/include/re_sha.h
@@ -32,3 +32,12 @@ void SHA1_Update(SHA1_CTX* context, const void *p, size_t len);
 void SHA1_Final(uint8_t digest[SHA1_DIGEST_SIZE], SHA1_CTX* context);
 
 #endif
+
+/** SHA256 values */
+enum {
+	SHA256_SIZE     = 32,                /**< Number of bytes in SHA256 hash   */
+	SHA256_STR_SIZE = 2*SHA256_SIZE + 1  /**< Number of bytes in SHA256 string */
+};
+
+void sha256(const uint8_t *d, size_t n, uint8_t *md);
+int  sha256_printf(uint8_t *md, const char *fmt, ...);

--- a/include/re_sha.h
+++ b/include/re_sha.h
@@ -35,8 +35,8 @@ void SHA1_Final(uint8_t digest[SHA1_DIGEST_SIZE], SHA1_CTX* context);
 
 /** SHA256 values */
 enum {
-	SHA256_SIZE     = 32,                /**< Number of bytes in SHA256 hash   */
-	SHA256_STR_SIZE = 2*SHA256_SIZE + 1  /**< Number of bytes in SHA256 string */
+	SHA256_SIZE     = 32,                /**< Bytes in SHA256 hash   */
+	SHA256_STR_SIZE = 2*SHA256_SIZE + 1  /**< Bytes in SHA256 string */
 };
 
 void sha256(const uint8_t *d, size_t n, uint8_t *md);

--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -247,6 +247,7 @@ typedef int(sip_auth_h)(char **username, char **password, const char *realm,
 typedef bool(sip_hdr_h)(const struct sip_hdr *hdr, const struct sip_msg *msg,
 			void *arg);
 typedef void(sip_keepalive_h)(int err, void *arg);
+typedef int(digest_printf_h)(uint8_t *md, const char *fmt, ...);
 
 #define LIBRE_HAVE_SIPTRACE 1
 typedef void(sip_trace_h)(bool tx, enum sip_transp tp,

--- a/src/sha/mod.mk
+++ b/src/sha/mod.mk
@@ -6,4 +6,7 @@
 
 ifeq ($(USE_OPENSSL),)
 SRCS	+= sha/sha1.c
+else
+SRCS    += sha/wrap.c
 endif
+

--- a/src/sha/wrap.c
+++ b/src/sha/wrap.c
@@ -1,0 +1,55 @@
+/**
+ * @file wrap.c  SHA256 wrappers
+ *
+ */
+#ifdef USE_OPENSSL
+#include <stddef.h>
+#include <openssl/sha.h>
+#include <re_types.h>
+#include <re_fmt.h>
+#include <re_mem.h>
+#include <re_mbuf.h>
+#include <re_sha.h>
+
+/**
+ * Calculate the SHA256 hash from a buffer
+ *
+ * @param d  Data buffer (input)
+ * @param n  Number of input bytes
+ * @param md Calculated SHA256 hash (output)
+ */
+void sha256(const uint8_t *d, size_t n, uint8_t *md)
+{
+	(void)SHA256(d, n, md);
+}
+
+
+/**
+ * Calculate the SHA256 hash from a formatted string
+ *
+ * @param md  Calculated SHA256 hash
+ * @param fmt Formatted string
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int sha256_printf(uint8_t *md, const char *fmt, ...)
+{
+	struct mbuf mb;
+	va_list ap;
+	int err;
+
+	mbuf_init(&mb);
+
+	va_start(ap, fmt);
+	err = mbuf_vprintf(&mb, fmt, ap);
+	va_end(ap);
+
+	if (!err)
+		sha256(mb.buf, mb.end, md);
+
+	mbuf_reset(&mb);
+
+	return err;
+}
+
+#endif

--- a/src/sip/auth.c
+++ b/src/sip/auth.c
@@ -95,7 +95,8 @@ static int mkdigest(uint8_t *digest, const struct realm *realm,
 
 #ifndef USE_OPENSSL
 	if (use_sha256) {
-		DEBUG_WARNING("SHA2 digest only supported when compiled with OpenSSL\n");
+		DEBUG_WARNING("SHA2 digest only supported "
+				"when compiled with OpenSSL\n");
 		return 1;
 	}
 #endif
@@ -103,11 +104,10 @@ static int mkdigest(uint8_t *digest, const struct realm *realm,
 	ha1 = mem_zalloc(h_size, NULL);
 	ha2 = mem_zalloc(h_size, NULL);
 
-	if (use_sha256) {
+	if (use_sha256)
 		digest_printf = &sha256_printf;
-	} else {
+	else
 		digest_printf = &md5_printf;
-	}
 	err = digest_printf(ha1, "%s:%s:%s",
 			 realm->user, realm->realm, realm->pass);
 
@@ -119,19 +119,18 @@ static int mkdigest(uint8_t *digest, const struct realm *realm,
 		return err;
 
 	DEBUG_INFO("mkdigest algorithm: %s\n", realm->algorithm);
-	if (realm->qop) {
+	if (realm->qop)
 		return digest_printf(digest, "%w:%s:%08x:%016llx:auth:%w",
 				  ha1, h_size,
 				  realm->nonce,
 				  realm->nc,
 				  cnonce,
 				  ha2, h_size);
-	} else {
+	else
 		return digest_printf(digest, "%w:%s:%w",
 				  ha1, h_size,
 				  realm->nonce,
 				  ha2, h_size);
-	}
 }
 
 
@@ -162,13 +161,15 @@ static bool auth_handler(const struct sip_hdr *hdr, const struct sip_msg *msg,
 		goto out;
 	}
 
-	if (pl_isset(&ch.algorithm) && pl_strcasecmp(&ch.algorithm, "md5") && pl_strcasecmp(&ch.algorithm, "sha-256")) {
+	if (pl_isset(&ch.algorithm) && pl_strcasecmp(&ch.algorithm, "md5") &&
+			pl_strcasecmp(&ch.algorithm, "sha-256")) {
 		err = ENOSYS;
 		goto out;
 	}
 #ifndef USE_OPENSSL
 	if (pl_strcasecmp(&ch.algorithm, "sha-256") == 0) {
-		DEBUG_WARNING("SHA2 digest only supported when compiled with OpenSSL\n");
+		DEBUG_WARNING("SHA2 digest only supported "
+				"when compiled with OpenSSL\n");
 		err = ENOSYS;
 		goto out;
 	}
@@ -275,7 +276,8 @@ int sip_auth_encode(struct mbuf *mb, struct sip_auth *auth, const char *met,
 		use_sha256 = str_casecmp(realm->algorithm, "sha-256") == 0;
 #ifndef USE_OPENSSL
 		if (use_sha256) {
-			DEBUG_WARNING("SHA2 digest only supported when compiled with OpenSSL\n");
+			DEBUG_WARNING("SHA2 digest only supported "
+					"when compiled with OpenSSL\n");
 			break;
 		}
 #endif


### PR DESCRIPTION
This PR introduces support for SHA-256 in SIP authentication.

What's missing:
* support for other algorithms specified in https://datatracker.ietf.org/doc/html/rfc8760
* support in src/httpauth/digest.c and (maybe?) src/turn/turnc.c

Also notice that right now it only works if OpenSSL is available; sha1.c doesn't support sha2 algorithms
and I'm not sure which of the various implementations is better to be included in Baresip.

An example of SIP server that supports SHA-256 digests is FlexiSIP.

Any help to improve this PR is welcome.
