### PR TITLE
sipsess: do not call desc handler on shutdown

### DIFF
--- a/src/sipsess/sess.c
+++ b/src/sipsess/sess.c
@@ -66,6 +66,7 @@ static bool termwait(struct sipsess *sess)
 	bool wait = false;
 
 	sess->terminated = 1;
+	sess->desch   = NULL;
 	sess->offerh  = internal_offer_handler;
 	sess->answerh = internal_answer_handler;
 	sess->progrh  = internal_progress_handler;


### PR DESCRIPTION
This fixes a segfault that occurs when the session is terminated abnormally.

@juha-h Please could you test with your setup where baresip is restarted while an INVITE is about to be sent?