### PR TITLE
mk: move darwin dns LFLAGS to re.mk (fixes static builds)

### DIFF
--- a/mk/re.mk
+++ b/mk/re.mk
@@ -240,6 +240,9 @@ endif
 	DFLAGS		:= -MD
 	LIBS		+= -lresolv
 	LFLAGS		+= -fPIC
+	# add libraries for darwin dns servers
+	LFLAGS		+= -framework SystemConfiguration \
+			   -framework CoreFoundation
 	SH_LFLAGS	+= -dynamiclib
 ifeq ($(CC_NAME),gcc)
 	SH_LFLAGS	+= -dylib

--- a/src/dns/mod.mk
+++ b/src/dns/mod.mk
@@ -22,6 +22,4 @@ endif
 
 ifeq ($(OS),darwin)
 SRCS	+= dns/darwin/srv.c
-# add libraries for darwin dns servers
-LFLAGS	+= -framework SystemConfiguration -framework CoreFoundation
 endif


### PR DESCRIPTION
If apps are build static, not all necessary LFLAGS are included for macOS:

```shell
make -C re libre.a
make -C rem librem.a
make -C baresip STATIC=1 MODULES=
./baresip

dyld[838]: symbol not found in flat namespace '___CFConstantStringClassReference'
[1]    838 abort      ./baresip
```

(Baresip builds/runs fine with some modules, because some are including the necessary frameworks).