### PR TITLE
mk: use posix regex for sed gcc major version detection

### DIFF
--- a/mk/re.mk
+++ b/mk/re.mk
@@ -102,7 +102,7 @@ LD := $(CC)
 CC_LONGVER  := $(shell $(CC) - --version|head -n 1)
 CC_SHORTVER := $(shell $(CC) -dumpversion)
 CC_MAJORVER := $(shell echo $(CC_SHORTVER) |\
-			sed -E 's/([0-9]*).[0-9]+.[0-9]+/\1/g')
+			sed -E 's/([0-9]+).[0-9]+.[0-9]+/\1/g')
 
 # find-out the compiler's name
 

--- a/mk/re.mk
+++ b/mk/re.mk
@@ -102,7 +102,7 @@ LD := $(CC)
 CC_LONGVER  := $(shell $(CC) - --version|head -n 1)
 CC_SHORTVER := $(shell $(CC) -dumpversion)
 CC_MAJORVER := $(shell echo $(CC_SHORTVER) |\
-			sed -e 's/\([0-9]*\)\.[0-9]\+\.[0-9]\+/\1/g')
+			sed -E 's/([0-9]*).[0-9]+.[0-9]+/\1/g')
 
 # find-out the compiler's name
 


### PR DESCRIPTION
Fixes OpenBSD