### PR TITLE
md5: use EVP_Digest for newer openssl versions

### DIFF
--- a/src/md5/wrap.c
+++ b/src/md5/wrap.c
@@ -25,13 +25,17 @@
  */
 void md5(const uint8_t *d, size_t n, uint8_t *md)
 {
-#ifdef USE_OPENSSL
+#if defined USE_OPENSSL
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 	EVP_MD_CTX *ctx = EVP_MD_CTX_new();
 
 	EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
 	EVP_DigestUpdate(ctx, d, n);
 	EVP_DigestFinal_ex(ctx, md, NULL);
 	EVP_MD_CTX_free(ctx);
+#else
+	(void)MD5(d, n, md);
+#endif
 #else
 	md5_state_t state;
 

--- a/src/md5/wrap.c
+++ b/src/md5/wrap.c
@@ -6,6 +6,7 @@
 #ifdef USE_OPENSSL
 #include <stddef.h>
 #include <openssl/evp.h>
+#include <openssl/md5.h>
 #else
 #include "md5.h"
 #endif
@@ -25,7 +26,7 @@
  */
 void md5(const uint8_t *d, size_t n, uint8_t *md)
 {
-#if defined USE_OPENSSL
+#ifdef USE_OPENSSL
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 	EVP_MD_CTX *ctx = EVP_MD_CTX_new();
 

--- a/src/md5/wrap.c
+++ b/src/md5/wrap.c
@@ -5,7 +5,7 @@
  */
 #ifdef USE_OPENSSL
 #include <stddef.h>
-#include <openssl/md5.h>
+#include <openssl/evp.h>
 #else
 #include "md5.h"
 #endif
@@ -26,7 +26,12 @@
 void md5(const uint8_t *d, size_t n, uint8_t *md)
 {
 #ifdef USE_OPENSSL
-	(void)MD5(d, n, md);
+	EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+
+	EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
+	EVP_DigestUpdate(ctx, d, n);
+	EVP_DigestFinal_ex(ctx, md, NULL);
+	EVP_MD_CTX_free(ctx);
 #else
 	md5_state_t state;
 


### PR DESCRIPTION
refs #197 

Fixes:

```
src/md5/wrap.c:29:8: warning: 'MD5' is deprecated [-Wdeprecated-declarations]
        (void)MD5(d, n, md);
              ^
.././include/openssl/md5.h:52:1: note: 'MD5' has been explicitly marked deprecated here
OSSL_DEPRECATEDIN_3_0 unsigned char *MD5(const unsigned char *d, size_t n,
^
.././include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)
                                                ^
.././include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))
                                                   ^
1 warning generated.
```