### PR TITLE
sha: add new sha1() api

### DIFF
--- a/include/re_sha.h
+++ b/include/re_sha.h
@@ -4,31 +4,12 @@
  * Copyright (C) 2010 Creytiv.com
  */
 
-
-#ifdef USE_OPENSSL
-#include <openssl/sha.h>
-#else
-
-/* public api for steve reid's public domain SHA-1 implementation */
-/* this file is in the public domain */
-
-/** SHA-1 Context */
-typedef struct {
-	uint32_t state[5];   /**< Context state */
-	uint32_t count[2];   /**< Counter       */
-	uint8_t  buffer[64]; /**< SHA-1 buffer  */
-} SHA1_CTX;
-
-/** SHA-1 Context (OpenSSL compat) */
-typedef SHA1_CTX SHA_CTX;
-
 /** SHA-1 Digest size in bytes */
 #define SHA1_DIGEST_SIZE 20
+
+#ifndef SHA_DIGEST_LENGTH
 /** SHA-1 Digest size in bytes (OpenSSL compat) */
 #define SHA_DIGEST_LENGTH SHA1_DIGEST_SIZE
-
-void SHA1_Init(SHA1_CTX* context);
-void SHA1_Update(SHA1_CTX* context, const void *p, size_t len);
-void SHA1_Final(uint8_t digest[SHA1_DIGEST_SIZE], SHA1_CTX* context);
-
 #endif
+
+void sha1(const uint8_t *d, size_t n, uint8_t *md);

--- a/src/hmac/hmac_sha1.c
+++ b/src/hmac/hmac_sha1.c
@@ -10,7 +10,7 @@
 #include <openssl/hmac.h>
 #include <openssl/err.h>
 #else
-#include <re_sha.h>
+#include "../sha/sha.h"
 #endif
 #include <re_hmac.h>
 

--- a/src/sha/mod.mk
+++ b/src/sha/mod.mk
@@ -7,3 +7,4 @@
 ifeq ($(USE_OPENSSL),)
 SRCS	+= sha/sha1.c
 endif
+SRCS	+= sha/wrap.c

--- a/src/sha/sha.h
+++ b/src/sha/sha.h
@@ -1,0 +1,26 @@
+/**
+ * @file re_sha.h  Interface to SHA (Secure Hash Standard) functions
+ *
+ * Copyright (C) 2010 Creytiv.com
+ */
+
+/* this file is in the public domain */
+
+/** SHA-1 Context */
+typedef struct {
+	uint32_t state[5];   /**< Context state */
+	uint32_t count[2];   /**< Counter       */
+	uint8_t  buffer[64]; /**< SHA-1 buffer  */
+} SHA1_CTX;
+
+/** SHA-1 Context (OpenSSL compat) */
+typedef SHA1_CTX SHA_CTX;
+
+/** SHA-1 Digest size in bytes */
+#define SHA1_DIGEST_SIZE 20
+/** SHA-1 Digest size in bytes (OpenSSL compat) */
+#define SHA_DIGEST_LENGTH SHA1_DIGEST_SIZE
+
+void SHA1_Init(SHA1_CTX* context);
+void SHA1_Update(SHA1_CTX* context, const void *p, size_t len);
+void SHA1_Final(uint8_t digest[SHA1_DIGEST_SIZE], SHA1_CTX* context);

--- a/src/sha/sha1.c
+++ b/src/sha/sha1.c
@@ -88,7 +88,7 @@ A million repetitions of "a"
 #include <stdio.h>
 #include <string.h>
 #include <re_types.h>
-#include <re_sha.h>
+#include "sha.h"
 
 void SHA1_Transform(uint32_t state[5], const uint8_t buffer[64]);
 

--- a/src/sha/wrap.c
+++ b/src/sha/wrap.c
@@ -1,0 +1,33 @@
+/**
+ * @file wrap.c  SHA wrappers
+ *
+ * Copyright (C) 2022 Sebastian Reimers <hallo@studio-link.de>
+ */
+
+#include <re_types.h>
+#ifdef USE_OPENSSL
+#include <openssl/sha.h>
+#else
+#include "sha.h"
+#endif
+#include <re_sha.h>
+
+
+/**
+ * Calculate the SHA1 hash from a buffer
+ *
+ * @param d  Data buffer (input)
+ * @param n  Number of input bytes
+ * @param md Calculated SHA1 hash (output)
+ */
+void sha1(const uint8_t *d, size_t n, uint8_t *md)
+{
+#ifdef USE_OPENSSL
+	(void)SHA1(d, n, md);
+#else
+	SHA_CTX ctx;
+	SHA1_Init(&ctx);
+	SHA1_Update(&ctx, d, n);
+	SHA1_Final(md, &ctx);
+#endif
+}

--- a/src/websock/websock.c
+++ b/src/websock/websock.c
@@ -371,7 +371,7 @@ static int accept_print(struct re_printf *pf, const struct pl *key)
 {
 	uint8_t digest[SHA_DIGEST_LENGTH];
 	uint8_t *data;
-	size_t len = key->l + sizeof(magic)-1; 
+	size_t len = key->l + sizeof(magic)-1;
 
 	data = mem_zalloc(len, NULL);
 	if (!data)

--- a/src/websock/websock.c
+++ b/src/websock/websock.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2010 Creytiv.com
  */
 
+#include <string.h>
 #include <re_types.h>
 #include <re_fmt.h>
 #include <re_mem.h>
@@ -369,12 +370,18 @@ static void close_handler(int err, void *arg)
 static int accept_print(struct re_printf *pf, const struct pl *key)
 {
 	uint8_t digest[SHA_DIGEST_LENGTH];
-	SHA_CTX ctx;
+	uint8_t *data;
+	size_t len = key->l + sizeof(magic)-1; 
 
-	SHA1_Init(&ctx);
-	SHA1_Update(&ctx, key->p, key->l);
-	SHA1_Update(&ctx, magic, sizeof(magic)-1);
-	SHA1_Final(digest, &ctx);
+	data = mem_zalloc(len, NULL);
+	if (!data)
+		return ENOMEM;
+
+	memcpy(data, key->p, key->l);
+	memcpy(data + key->l, magic, sizeof(magic)-1);
+
+	sha1(data, len, digest);
+	mem_deref(data);
 
 	return base64_print(pf, digest, sizeof(digest));
 }


### PR DESCRIPTION
refs #197 

fixes deprecation warnings:

```c
src/websock/websock.c:374:2: warning: 'SHA1_Init' is deprecated [-Wdeprecated-declarations] 
        SHA1_Init(&ctx);                                                                                                                                                               
        ^                                                                                  
.././include/openssl/sha.h:49:1: note: 'SHA1_Init' has been explicitly marked deprecated here
OSSL_DEPRECATEDIN_3_0 int SHA1_Init(SHA_CTX *c);                                                                                                                                       
^                                                                                                                                                                                      
.././include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'    
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)                       
                                                ^                                                                                                                                      
.././include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'           
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))                            
                                                   ^                                       
src/websock/websock.c:375:2: warning: 'SHA1_Update' is deprecated [-Wdeprecated-declarations]
        SHA1_Update(&ctx, key->p, key->l);                                                 
        ^                                                                                  
.././include/openssl/sha.h:50:1: note: 'SHA1_Update' has been explicitly marked deprecated here
OSSL_DEPRECATEDIN_3_0 int SHA1_Update(SHA_CTX *c, const void *data, size_t len);                                                                                                       
^                                                                                                                                                                                      
.././include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)                       
                                                ^                                                                                                                                      
.././include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'           
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))                                                                                                                        
                                                   ^                                       
src/websock/websock.c:376:2: warning: 'SHA1_Update' is deprecated [-Wdeprecated-declarations]
        SHA1_Update(&ctx, magic, sizeof(magic)-1);                                                                                                                                     
        ^                                                                                  
.././include/openssl/sha.h:50:1: note: 'SHA1_Update' has been explicitly marked deprecated here
OSSL_DEPRECATEDIN_3_0 int SHA1_Update(SHA_CTX *c, const void *data, size_t len);           
^                                                                                          
.././include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'    
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)                       
                                                ^                                          
.././include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'                                                                                                       
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))                                                                                                                        
                                                   ^                                                                                                                                   
src/websock/websock.c:377:2: warning: 'SHA1_Final' is deprecated [-Wdeprecated-declarations]
        SHA1_Final(digest, &ctx);                                                                                                                                                      
        ^                                                                                  
.././include/openssl/sha.h:51:1: note: 'SHA1_Final' has been explicitly marked deprecated here
OSSL_DEPRECATEDIN_3_0 int SHA1_Final(unsigned char *md, SHA_CTX *c);
^
.././include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)
                                                ^
.././include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))
                                                   ^
```