### PR TITLE
OpenSSL 3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: install macOS homebrew packages
-      if: ${{ runner.os == 'macOS' }}
-      run: |
-        brew install openssl@1.1
-        rm -f /usr/local/opt/openssl
-        cp -a /usr/local/opt/openssl@1.1 /usr/local/opt/openssl
-
     - name: make info
       run: |
         echo "OS: ${{ matrix.os }}"


### PR DESCRIPTION
closes #197 

Fixes:
```c
src/tls/openssl/tls.c:512:10: warning: 'EC_KEY_new_by_curve_name' is deprecated [-Wdeprecated-declarations]                                                                 
        eckey = EC_KEY_new_by_curve_name(eccgrp);                                                                                                                           
                ^                                                                                                                                                           
.././include/openssl/ec.h:996:1: note: 'EC_KEY_new_by_curve_name' has been explicitly marked deprecated here                                                                
OSSL_DEPRECATEDIN_3_0 EC_KEY *EC_KEY_new_by_curve_name(int nid);                                                                                                            
^                                                                                                                                                                           
.././include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'                                                                                     
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)                                                                                                        
                                                ^                                                                                                                           
.././include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'                                                                                            
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))                                                                                                             
                                                   ^                                                                                                                        
src/tls/openssl/tls.c:516:7: warning: 'EC_KEY_generate_key' is deprecated [-Wdeprecated-declarations]                                                                       
        if (!EC_KEY_generate_key(eckey))                                                                                                                                    
             ^                                                                                                                                                              
.././include/openssl/ec.h:1099:1: note: 'EC_KEY_generate_key' has been explicitly marked deprecated here                                                                    
OSSL_DEPRECATEDIN_3_0 int EC_KEY_generate_key(EC_KEY *key);                                                                                                                 
^                                                                                                                                                                           
.././include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'                                                                                     
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)                                                                                                        
                                                ^                                                                                                                           
.././include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'                                                                                            
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))                                                                                                             
                                                   ^                                                                                                                        
src/tls/openssl/tls.c:520:2: warning: 'EC_KEY_set_asn1_flag' is deprecated [-Wdeprecated-declarations]                                                                      
        EC_KEY_set_asn1_flag(eckey, OPENSSL_EC_NAMED_CURVE);                                                                                                                
        ^                                                                                                                                                                   
.././include/openssl/ec.h:1085:1: note: 'EC_KEY_set_asn1_flag' has been explicitly marked deprecated here                                                                   
OSSL_DEPRECATEDIN_3_0 void EC_KEY_set_asn1_flag(EC_KEY *eckey, int asn1_flag);                                                                                              
^                                                                                                                                                                           
.././include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'                                                                                     
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)                                                                                                        
                                                ^                                                                                                                           
.././include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'                                                                                            
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))                                                                                                             
                                                   ^                                                                                                                        
src/tls/openssl/tls.c:529:7: warning: 'EVP_PKEY_set1_EC_KEY' is deprecated [-Wdeprecated-declarations]                                                                      
        if (!EVP_PKEY_set1_EC_KEY(key, eckey))                                                                                                                              
             ^                                                                                                                                                              
.././include/openssl/evp.h:1369:1: note: 'EVP_PKEY_set1_EC_KEY' has been explicitly marked deprecated here                                                                  
OSSL_DEPRECATEDIN_3_0                                                                                                                                                       
^                                                                                                                                                                           
.././include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'                                                                                     
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)                                                                                                        
                                                ^                                                                                                                           
.././include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'                                                                                            
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))                                                                                                             
                                                   ^                                                                                                                        
src/tls/openssl/tls.c:559:3: warning: 'EC_KEY_free' is deprecated [-Wdeprecated-declarations]                                                                               
                EC_KEY_free(eckey);                                                                                                                                         
                ^                                                                                                                                                           
.././include/openssl/ec.h:1001:1: note: 'EC_KEY_free' has been explicitly marked deprecated here                                                                            
OSSL_DEPRECATEDIN_3_0 void EC_KEY_free(EC_KEY *key);                                                                                                                        
^                                                                                                                                                           
.././include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'                    
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)                                                                                        
                                                ^                             
.././include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'                            
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))                                                                                             
                                                   ^             
```

```c
src/tls/openssl/tls.c:583:8: warning: 'RSA_new' is deprecated [-Wdeprecated-declarations]
        rsa = RSA_new();                   
              ^                            
.././include/openssl/rsa.h:201:1: note: 'RSA_new' has been explicitly marked deprecated here                                                                                
OSSL_DEPRECATEDIN_3_0 RSA *RSA_new(void);                                             
^                                          
.././include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'                                                                                     
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)                  
                                                ^                                     
.././include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'                                                                                            
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))                       
                                                   ^                                  
src/tls/openssl/tls.c:592:7: warning: 'RSA_generate_key_ex' is deprecated [-Wdeprecated-declarations]                                                                       
        if (!RSA_generate_key_ex(rsa, (int)bits, bn, NULL))                           
             ^                             
.././include/openssl/rsa.h:260:1: note: 'RSA_generate_key_ex' has been explicitly marked deprecated here                                                                    
OSSL_DEPRECATEDIN_3_0 int RSA_generate_key_ex(RSA *rsa, int bits, BIGNUM *e,          
^                                          
.././include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'                                                                                     
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)                  
                                                ^                                     
.././include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'                                                                                            
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))                       
                                                   ^                                  
src/tls/openssl/tls.c:599:7: warning: 'EVP_PKEY_set1_RSA' is deprecated [-Wdeprecated-declarations]                                                                         
        if (!EVP_PKEY_set1_RSA(key, rsa))                                             
             ^                             
.././include/openssl/evp.h:1343:1: note: 'EVP_PKEY_set1_RSA' has been explicitly marked deprecated here                                                                     
OSSL_DEPRECATEDIN_3_0                      
^                                          
.././include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'                                                                                     
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)                  
                                                ^                                     
.././include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'                                                                                            
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))                       
                                                   ^                                  
src/tls/openssl/tls.c:635:3: warning: 'RSA_free' is deprecated [-Wdeprecated-declarations]                                                                                  
                RSA_free(rsa);             
                ^                          
.././include/openssl/rsa.h:293:1: note: 'RSA_free' has been explicitly marked deprecated here                                                                               
OSSL_DEPRECATEDIN_3_0 void RSA_free(RSA *r);                                          
^                                          
.././include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'                                                                                     
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)                  
                                                ^                                     
.././include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'                                                                                            
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))                       
                                                   ^              
```