### PR TITLE
aubuf insert auframes sorted

### DIFF
--- a/include/re_list.h
+++ b/include/re_list.h
@@ -58,6 +58,8 @@ void list_insert_before(struct list *list, struct le *le, struct le *ile,
 			void *data);
 void list_insert_after(struct list *list, struct le *le, struct le *ile,
 		       void *data);
+void list_insert_sorted(struct list *list, list_sort_h *sh, void *arg,
+			struct le *ile, void *data);
 void list_unlink(struct le *le);
 void list_sort(struct list *list, list_sort_h *sh, void *arg);
 struct le *list_apply(const struct list *list, bool fwd, list_apply_h *ah,

--- a/src/list/list.c
+++ b/src/list/list.c
@@ -211,6 +211,42 @@ void list_insert_after(struct list *list, struct le *le, struct le *ile,
 
 
 /**
+ * Sorted insert into linked list with order defined by the sort handler
+ *
+ * @param list  Linked list
+ * @param sh    Sort handler
+ * @param arg   Handler argument
+ * @param ile   List element to insert
+ * @param data  Element data
+ */
+void list_insert_sorted(struct list *list, list_sort_h *sh, void *arg,
+			struct le *ile, void *data)
+{
+	struct le *le;
+
+	if (!list || !sh)
+		return;
+
+	le = list->head;
+	ile->data = data;
+
+	while (le) {
+
+		if (sh(le, ile, arg)) {
+
+			le = le->next;
+		}
+		else {
+			list_insert_before(list, le, ile, ile->data);
+			return;
+		}
+	}
+
+	list_append(list, ile, ile->data);
+}
+
+
+/**
  * Remove a list element from a linked list
  *
  * @param le    List element to remove


### PR DESCRIPTION
This adds a function that inserts elements sorted. The sort order is defined by a given `list_sort_h`.

The list sort handler seems to be always a less-equal handler. I found notes like this in rem and retest.
```
       /* NOTE: important to use less than OR equal to, otherwise
          the list_sort function may be stuck in a loop */
```

Should we change doxygen in re_list.h? To something like:
```
* Defines a less-equal handler to define the order of elements for the sort algorithm
```