### PR TITLE
make,cmake: set SOVERSION to major version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,6 +342,7 @@ endif()
 target_link_libraries(re -L/opt/local/lib -lssl -lcrypto -lpthread)
 
 set_target_properties(re PROPERTIES VERSION ${PROJECT_VERSION})
+set_target_properties(re PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})
 
 set_target_properties(re PROPERTIES PUBLIC_HEADER include/re.h)
 

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,7 @@ VER_PATCH := 1
 # Increment for breaking changes (dev2, dev3...)
 VER_PRE   := dev13
 
-# Libtool similar ABI versioning
-# https://github.com/baresip/re/wiki/ABI-Versioning
-ABI_CUR   := 1
-ABI_REV   := 1
-ABI_AGE   := 0
-
-ABI_MAJOR := $(shell expr $(ABI_CUR) - $(ABI_AGE))
+ABI_MAJOR := $(VER_MAJOR)
 
 # Verbose and silent build modes
 ifeq ($(V),)


### PR DESCRIPTION
For libre, it is sufficient to use the API major version as ABI major version.