### PR TITLE
tls: fix win32 warnings

### DIFF
--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -763,7 +763,7 @@ int tls_set_certificate_der(struct tls *tls, enum tls_keytype keytype,
 
 	buf_cert = cert;
 
-	x509 = d2i_X509(NULL, &buf_cert, len_cert);
+	x509 = d2i_X509(NULL, &buf_cert, (long)len_cert);
 	if (!x509)
 		goto out;
 
@@ -772,7 +772,7 @@ int tls_set_certificate_der(struct tls *tls, enum tls_keytype keytype,
 		len_key = len_cert - (buf_cert - cert);
 	}
 
-	pkey = d2i_PrivateKey(type, NULL, &key, len_key);
+	pkey = d2i_PrivateKey(type, NULL, &key, (long)len_key);
 	if (!pkey)
 		goto out;
 

--- a/src/tls/openssl/tls_udp.c
+++ b/src/tls/openssl/tls_udp.c
@@ -149,7 +149,7 @@ static long bio_ctrl(BIO *b, int cmd, long num, void *ptr)
 
 #if defined (BIO_CTRL_DGRAM_QUERY_MTU)
 	case BIO_CTRL_DGRAM_QUERY_MTU:
-		return tc ? tc->sock->mtu : MTU_DEFAULT;
+		return tc ? (long)tc->sock->mtu : MTU_DEFAULT;
 #endif
 
 #if defined (BIO_CTRL_DGRAM_GET_FALLBACK_MTU)


### PR DESCRIPTION
fixes some warnings on windows/amd64
