### PR TITLE
cmake: fix MSVC ninja

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,4 +466,6 @@ target_link_libraries(re-static
 )
 
 set_target_properties(re-static PROPERTIES PUBLIC_HEADER include/re.h)
+if(NOT MSVC)
 set_target_properties(re-static PROPERTIES OUTPUT_NAME "re")
+endif()


### PR DESCRIPTION
Looks like ninja with MSVC does not like duplicate OUTPUT_NAME.