### PR TITLE
fix coverity scan warnings

### DIFF
--- a/src/srtp/srtcp.c
+++ b/src/srtp/srtcp.c
@@ -108,7 +108,7 @@ int srtcp_encrypt(struct srtp *srtp, struct mbuf *mb)
 		return err;
 
 	if (rtcp->hmac) {
-		uint8_t tag[SHA_DIGEST_LENGTH];
+		uint8_t tag[SHA_DIGEST_LENGTH] = {0};
 
 		mb->pos = start;
 
@@ -168,7 +168,8 @@ int srtcp_decrypt(struct srtp *srtp, struct mbuf *mb)
 	ix = v & 0x7fffffff;
 
 	if (rtcp->hmac) {
-		uint8_t tag[SHA_DIGEST_LENGTH], tag_pkt[SHA_DIGEST_LENGTH];
+		uint8_t tag[SHA_DIGEST_LENGTH] = {0};
+		uint8_t tag_pkt[SHA_DIGEST_LENGTH] = {0};
 		const size_t tag_start = mb->pos;
 
 		err = mbuf_read_mem(mb, tag_pkt, rtcp->tag_len);

--- a/src/srtp/srtp.c
+++ b/src/srtp/srtp.c
@@ -252,7 +252,7 @@ int srtp_encrypt(struct srtp *srtp, struct mbuf *mb)
 
 	if (comp->hmac) {
 		const size_t tag_start = mb->end;
-		uint8_t tag[SHA_DIGEST_LENGTH];
+		uint8_t tag[SHA_DIGEST_LENGTH] = {0};
 
 		mb->pos = tag_start;
 
@@ -321,8 +321,8 @@ int srtp_decrypt(struct srtp *srtp, struct mbuf *mb)
 	ix = srtp_get_index(strm->roc, strm->s_l, hdr.seq);
 
 	if (comp->hmac) {
-		uint8_t tag_calc[SHA_DIGEST_LENGTH];
-		uint8_t tag_pkt[SHA_DIGEST_LENGTH];
+		uint8_t tag_calc[SHA_DIGEST_LENGTH] = {0};
+		uint8_t tag_pkt[SHA_DIGEST_LENGTH] = {0};
 		size_t pld_start, tag_start;
 
 		if (mbuf_get_left(mb) < comp->tag_len)

--- a/src/stun/msg.c
+++ b/src/stun/msg.c
@@ -390,7 +390,7 @@ int stun_msg_encode(struct mbuf *mb, uint16_t method, uint8_t class,
 int stun_msg_chk_mi(const struct stun_msg *msg, const uint8_t *key,
 		    size_t keylen)
 {
-	uint8_t hmac[SHA_DIGEST_LENGTH];
+	uint8_t hmac[SHA_DIGEST_LENGTH] = {0};
 	struct stun_attr *mi, *fp;
 
 	if (!msg)

--- a/src/sys/fs.c
+++ b/src/sys/fs.c
@@ -193,10 +193,10 @@ int fs_fopen(FILE **fp, const char *file, const char *mode)
 		goto fopen;
 
 	fd = open(file, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR);
-	if (!fd)
+	if (fd == -1)
 		return errno;
-	else
-		(void)close(fd);
+
+	(void)close(fd);
 
 fopen:
 	pfile = fopen(file, mode);


### PR DESCRIPTION
Found by coverity scan.
```
** CID 250123:  Uninitialized variables  (UNINIT)
/src/stun/msg.c: 422 in stun_msg_chk_mi()


________________________________________________________________________________________________________
*** CID 250123:  Uninitialized variables  (UNINIT)
/src/stun/msg.c: 422 in stun_msg_chk_mi()
416     	if (fp) {
417     		((struct stun_msg *)msg)->hdr.len += FP_SIZE;
418     		(void)stun_hdr_encode(msg->mb, &msg->hdr);
419     		msg->mb->pos -= STUN_HEADER_SIZE;
420     	}
421     
>>>     CID 250123:  Uninitialized variables  (UNINIT)
>>>     Using uninitialized element of array "hmac" when calling "memcmp".
422     	if (memcmp(mi->v.msg_integrity, hmac, SHA_DIGEST_LENGTH))
423     		return EBADMSG;
424     
425     	return 0;
426     }
427     

** CID 250122:  Error handling issues  (NEGATIVE_RETURNS)
/src/sys/fs.c: 199 in fs_fopen()


________________________________________________________________________________________________________
*** CID 250122:  Error handling issues  (NEGATIVE_RETURNS)
/src/sys/fs.c: 199 in fs_fopen()
193     		goto fopen;
194     
195     	fd = open(file, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR);
196     	if (!fd)
197     		return errno;
198     	else
>>>     CID 250122:  Error handling issues  (NEGATIVE_RETURNS)
>>>     "fd" is passed to a parameter that cannot be negative.
199     		(void)close(fd);
200     
201     fopen:
202     	pfile = fopen(file, mode);
203     	if (!pfile)
204     		return errno;

** CID 250121:  Uninitialized variables  (UNINIT)


________________________________________________________________________________________________________
*** CID 250121:  Uninitialized variables  (UNINIT)
/src/srtp/srtp.c: 272 in srtp_encrypt()
266     				  mbuf_buf(mb), mbuf_get_left(mb));
267     		if (err)
268     			return err;
269     
270     		mb->pos = mb->end = tag_start;
271     
>>>     CID 250121:  Uninitialized variables  (UNINIT)
>>>     Using uninitialized value "*tag" when calling "mbuf_write_mem".
272     		err = mbuf_write_mem(mb, tag, comp->tag_len);
273     		if (err)
274     			return err;
275     	}
276     
277     	if (hdr.seq > strm->s_l)

** CID 250120:  Uninitialized variables  (UNINIT)
/src/srtp/srtp.c: 356 in srtp_decrypt()


________________________________________________________________________________________________________
*** CID 250120:  Uninitialized variables  (UNINIT)
/src/srtp/srtp.c: 356 in srtp_decrypt()
350     		if (err)
351     			return err;
352     
353     		mb->pos = pld_start;
354     		mb->end = tag_start;
355     
>>>     CID 250120:  Uninitialized variables  (UNINIT)
>>>     Using uninitialized value "*tag_calc" when calling "memcmp".
356     		if (0 != memcmp(tag_calc, tag_pkt, comp->tag_len))
357     			return EAUTH;
358     
359     		/*
360     		 * 3.3.2.  Replay Protection
361     		 *

** CID 250119:  Uninitialized variables  (UNINIT)


________________________________________________________________________________________________________
*** CID 250119:  Uninitialized variables  (UNINIT)
/src/srtp/srtcp.c: 122 in srtcp_encrypt()
116     				  mbuf_buf(mb), mbuf_get_left(mb));
117     		if (err)
118     			return err;
119     
120     		mb->pos = mb->end;
121     
>>>     CID 250119:  Uninitialized variables  (UNINIT)
>>>     Using uninitialized value "*tag" when calling "mbuf_write_mem".
122     		err = mbuf_write_mem(mb, tag, rtcp->tag_len);
123     		if (err)
124     			return err;
125     	}
126     
127     	mb->pos = start;

** CID 250118:  Uninitialized variables  (UNINIT)
/src/srtp/srtcp.c: 186 in srtcp_decrypt()


________________________________________________________________________________________________________
*** CID 250118:  Uninitialized variables  (UNINIT)
/src/srtp/srtcp.c: 186 in srtcp_decrypt()
180     
181     		err = hmac_digest(rtcp->hmac, tag, sizeof(tag),
182     				  mbuf_buf(mb), mbuf_get_left(mb));
183     		if (err)
184     			return err;
185     
>>>     CID 250118:  Uninitialized variables  (UNINIT)
>>>     Using uninitialized value "*tag" when calling "memcmp".
186     		if (0 != memcmp(tag, tag_pkt, rtcp->tag_len))
187     			return EAUTH;
188     
189     		/*
190     		 * SRTCP replay protection is as defined in Section 3.3.2,
191     		 * but using the SRTCP index as the index i and a separate

```