### PR TITLE
cmake: fixes for Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,6 +428,10 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     src/net/linux/rt.c
     src/main/epoll.c
   )
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Android")
+  list(APPEND SRCS
+    src/net/linux/rt.c
+  )
 endif()
 
 


### PR DESCRIPTION
build error with CMake on Android:

```
Scanning dependencies of target re-shared
[ 99%] Linking C shared library libre.so
src/net/net.c:184: error: undefined reference to 'net_rt_list'
src/net/rt.c:77: error: undefined reference to 'net_rt_list'
src/net/rt.c:142: error: undefined reference to 'net_rt_list'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [CMakeFiles/re-shared.dir/build.make:452: libre.so] Error 1
make[1]: *** [CMakeFiles/Makefile2:99: CMakeFiles/re-shared.dir/all] Error 2
make: *** [Makefile:103: all] Error 2
Build step 'Execute shell' marked build as failure
Finished: FAILURE
```

invoked like this:

```
+ cmake -DCMAKE_TOOLCHAIN_FILE=/usr/lib/android-ndk/build/cmake/android.toolchain.cmake -DANDROID_ABI=armeabi-v7a -DANDROID_PLATFORM=24 -DOPENSSL_ROOT_DIR=/home/alfredh/tmp/OpenSSL-for-Android-Prebuilt/openssl-1.1.1k-clang/ -DOPENSSL_INCLUDE_DIR=/home/alfredh/tmp/OpenSSL-for-Android-Prebuilt/openssl-1.1.1k-clang//include -DOPENSSL_CRYPTO_LIBRARY=/home/alfredh/tmp/OpenSSL-for-Android-Prebuilt/openssl-1.1.1k-clang//armeabi-v7a/lib/libcrypto.a -DOPENSSL_SSL_LIBRARY=/home/alfredh/tmp/OpenSSL-for-Android-Prebuilt/openssl-1.1.1k-clang//armeabi-v7a/lib/libssl.a -DUSE_OPENSSL=ON .
```
