### PR TITLE
sip: fix gcc 6.3.0 warning for logical expression (#256)

### DIFF
--- a/src/sip/transp.c
+++ b/src/sip/transp.c
@@ -222,7 +222,10 @@ static struct sip_conn *conn_find(struct sip *sip, const struct sa *paddr,
 
 		struct sip_conn *conn = le->data;
 
-		if (!secure != (conn->sc == NULL))
+		if (secure && !conn->sc)
+			continue;
+
+		if (!secure && conn->sc)
 			continue;
 
 		if (!sa_cmp(&conn->paddr, paddr, SA_ALL))


### PR DESCRIPTION
transp.c:225:15: warning: logical not is only applied to the left hand side of
comparison [-Wlogical-not-parentheses]

This should solve the warning. I have no gcc-6 for testing. With gcc-5, gcc-7
and newer the warning is not printed.
