### PR TITLE
add transport-cc rtcp feedback support

### DIFF
--- a/include/re_rtp.h
+++ b/include/re_rtp.h
@@ -62,7 +62,7 @@ enum rtcp_sdes_type {
 /** Transport Layer Feedback Messages */
 enum rtcp_rtpfb {
 	RTCP_RTPFB_GNACK = 1,  /**< Generic NACK */
-	RTCP_RTPFB_TWCC  = 15  /**< draft-holmer-rmcat-transport-wide-cc-extensions-01 */
+	RTCP_RTPFB_TWCC  = 15  /**< transport-wide-cc-extensions-01 */
 };
 
 /** Payload-Specific Feedback Messages */

--- a/include/re_rtp.h
+++ b/include/re_rtp.h
@@ -61,7 +61,8 @@ enum rtcp_sdes_type {
 
 /** Transport Layer Feedback Messages */
 enum rtcp_rtpfb {
-	RTCP_RTPFB_GNACK = 1  /**< Generic NACK */
+	RTCP_RTPFB_GNACK = 1,  /**< Generic NACK */
+	RTCP_RTPFB_TWCC  = 15  /**< draft-holmer-rmcat-transport-wide-cc-extensions-01 */
 };
 
 /** Payload-Specific Feedback Messages */
@@ -166,6 +167,14 @@ struct rtcp_msg {
 					uint16_t number;
 					uint8_t picid;
 				} *sliv;
+				struct twcc {
+					uint16_t seq;
+					uint16_t count;
+					uint32_t reftime;
+					uint8_t fbcount;
+					struct mbuf *chunks;
+					struct mbuf *deltas;
+				} *twccv;
 				struct mbuf *afb;
 				void *p;
 			} fci;

--- a/src/rtp/fb.c
+++ b/src/rtp/fb.c
@@ -154,6 +154,7 @@ int rtcp_rtpfb_twcc_decode(struct mbuf *mb, struct twcc *msg, int n)
 int rtcp_rtpfb_decode(struct mbuf *mb, struct rtcp_msg *msg)
 {
 	size_t i, sz;
+	int err;
 
 	if (!msg)
 		return EINVAL;
@@ -177,13 +178,14 @@ int rtcp_rtpfb_decode(struct mbuf *mb, struct rtcp_msg *msg)
 	case RTCP_RTPFB_TWCC:
 		if (mbuf_get_left(mb) < 8)
 			return EBADMSG;
-		msg->r.fb.fci.twccv = mem_alloc(sizeof(*msg->r.fb.fci.twccv),
+		msg->r.fb.fci.twccv = mem_zalloc(sizeof(*msg->r.fb.fci.twccv),
 			NULL);
 		if (!msg->r.fb.fci.twccv)
 			return ENOMEM;
-		if (0 != rtcp_rtpfb_twcc_decode(mb, msg->r.fb.fci.twccv,
-			msg->r.fb.n))
-			return EBADMSG;
+		err = rtcp_rtpfb_twcc_decode(mb, msg->r.fb.fci.twccv,
+			msg->r.fb.n);
+		if (err)
+			return err;
 
 		break;
 

--- a/src/rtp/fb.c
+++ b/src/rtp/fb.c
@@ -69,6 +69,70 @@ int rtcp_psfb_sli_encode(struct mbuf *mb, uint16_t first, uint16_t number,
 
 
 /**
+ * Decode an RTCP Transport-wide congestion control Feedback Message
+ *
+ * @param mb  Buffer to decode
+ * @param msg transport-cc struct to decode into
+ * @param n   length of the RTCP packet in 32bit words minus one
+ *
+ * @return 0 for success, otherwise errorcode
+ */
+int rtcp_rtpfb_twcc_decode(struct mbuf *mb, struct twcc *msg, int n)
+{
+	size_t i, j, sz;
+
+	if (!msg)
+		return EINVAL;
+
+	msg->seq = ntohs(mbuf_read_u16(mb));
+	msg->count = ntohs(mbuf_read_u16(mb));
+	if (msg->count == 0)
+		return EBADMSG;
+	msg->reftime = ntohl(mbuf_read_u32(mb));
+	msg->fbcount = msg->reftime & 0xff;
+	msg->reftime >>= 8;
+
+	msg->chunks = mbuf_alloc_ref(mb);
+	msg->chunks->end = msg->chunks->pos;
+	sz = 0;
+	for (i = msg->count; i > 0;) {
+		uint16_t chunk;
+
+		if (mbuf_get_left(mb) < 2)
+			return EBADMSG;
+		chunk  = ntohs(mbuf_read_u16(mb));
+		msg->chunks->end += 2;
+		if (chunk & 0x8000) {
+			/* status vector chunk */
+			if (chunk & 0x4000) {
+				for (j = 0; j < i && j < 7; j++)
+					sz += chunk >> (2 * (7 - 1 - j)) & 0x03;
+			}
+			else {
+				for (j = 0; j < i && j < 14; j++)
+					sz += (chunk >> (14 - 1 - j)) & 0x01;
+			}
+		} else {
+			/* run length chunk */
+			for (j = 0; j < i && j < (chunk & 0x1fff); j++)
+				sz += (chunk >> 13) & 0x03;
+		}
+		i -= j;
+	}
+	if (mbuf_get_left(mb) < sz)
+		return EBADMSG;
+	msg->deltas = mbuf_alloc_ref(mb);
+	msg->deltas->end = msg->deltas->pos + sz;
+
+	sz = n * sizeof(uint32_t) - 8 - mbuf_get_left(msg->chunks);
+	if (mbuf_get_left(mb) < sz)
+		return EBADMSG;
+	mbuf_advance(mb, sz);
+
+	return 0;
+}
+
+/**
  * Decode an RTCP Transport Layer Feedback Message
  *
  * @param mb  Buffer to decode
@@ -97,6 +161,17 @@ int rtcp_rtpfb_decode(struct mbuf *mb, struct rtcp_msg *msg)
 			msg->r.fb.fci.gnackv[i].pid = ntohs(mbuf_read_u16(mb));
 			msg->r.fb.fci.gnackv[i].blp = ntohs(mbuf_read_u16(mb));
 		}
+		break;
+
+	case RTCP_RTPFB_TWCC:
+		if (mbuf_get_left(mb) < 8)
+			return EBADMSG;
+		msg->r.fb.fci.twccv = mem_alloc(sizeof(*msg->r.fb.fci.twccv), NULL);
+		if (!msg->r.fb.fci.twccv)
+			return ENOMEM;
+		if (0 != rtcp_rtpfb_twcc_decode(mb, msg->r.fb.fci.twccv, msg->r.fb.n))
+			return EBADMSG;
+
 		break;
 
 	default:

--- a/src/rtp/fb.c
+++ b/src/rtp/fb.c
@@ -106,13 +106,15 @@ int rtcp_rtpfb_twcc_decode(struct mbuf *mb, struct twcc *msg, int n)
 			/* status vector chunk */
 			if (chunk & 0x4000) {
 				for (j = 0; j < i && j < 7; j++)
-					sz += chunk >> (2 * (7 - 1 - j)) & 0x03;
+					sz += chunk >> (2 * (7 - 1 - j))
+						& 0x03;
 			}
 			else {
 				for (j = 0; j < i && j < 14; j++)
 					sz += (chunk >> (14 - 1 - j)) & 0x01;
 			}
-		} else {
+		}
+		else {
 			/* run length chunk */
 			for (j = 0; j < i && j < (chunk & 0x1fff); j++)
 				sz += (chunk >> 13) & 0x03;
@@ -166,10 +168,12 @@ int rtcp_rtpfb_decode(struct mbuf *mb, struct rtcp_msg *msg)
 	case RTCP_RTPFB_TWCC:
 		if (mbuf_get_left(mb) < 8)
 			return EBADMSG;
-		msg->r.fb.fci.twccv = mem_alloc(sizeof(*msg->r.fb.fci.twccv), NULL);
+		msg->r.fb.fci.twccv = mem_alloc(sizeof(*msg->r.fb.fci.twccv),
+			NULL);
 		if (!msg->r.fb.fci.twccv)
 			return ENOMEM;
-		if (0 != rtcp_rtpfb_twcc_decode(mb, msg->r.fb.fci.twccv, msg->r.fb.n))
+		if (0 != rtcp_rtpfb_twcc_decode(mb, msg->r.fb.fci.twccv,
+			msg->r.fb.n))
 			return EBADMSG;
 
 		break;

--- a/src/rtp/pkt.c
+++ b/src/rtp/pkt.c
@@ -61,6 +61,12 @@ static void rtcp_destructor(void *data)
 		break;
 
 	case RTCP_RTPFB:
+		if (msg->hdr.count == RTCP_RTPFB_TWCC && msg->r.fb.fci.twccv) {
+			mem_deref(msg->r.fb.fci.twccv->chunks);
+			mem_deref(msg->r.fb.fci.twccv->deltas);
+		}
+		/* Fall-through */
+
 	case RTCP_PSFB:
 		mem_deref(msg->r.fb.fci.p);
 		break;

--- a/src/rtp/rtcp.h
+++ b/src/rtp/rtcp.h
@@ -83,6 +83,7 @@ int rtcp_sdes_decode(struct mbuf *mb, struct rtcp_sdes *sdes);
 int rtcp_rtpfb_gnack_encode(struct mbuf *mb, uint16_t pid, uint16_t blp);
 int rtcp_psfb_sli_encode(struct mbuf *mb, uint16_t first, uint16_t number,
 			 uint8_t picid);
+int rtcp_rtpfb_twcc_decode(struct mbuf *mb, struct twcc *msg, int n);
 int rtcp_rtpfb_decode(struct mbuf *mb, struct rtcp_msg *msg);
 int rtcp_psfb_decode(struct mbuf *mb, struct rtcp_msg *msg);
 


### PR DESCRIPTION
as described in
  https://datatracker.ietf.org/doc/html/draft-holmer-rmcat-transport-wide-cc-extensions-01#section-3.1
Note that the draft is unclear or not matching the implementation in
libwebrtc in some cases.

The libre change extends the FCI union at a low level without parsing the
packet feedback and receive deltas which will be interpreted at
application level.