### PR TITLE
Bump ABI version

### DIFF
--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-          ref: 'v2.0.1'
+          ref: 'v2.1.0'
           path: old
 
     - uses: actions/checkout@v2

--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -29,8 +29,3 @@ jobs:
     - name: abidiff compare
       id: abidiff
       run: abidiff old/libre.so current/libre.so
-      continue-on-error: true
-
-    - name: display warning
-      if: steps.abidiff.outcome != 'success'
-      run: echo "::warning::ABI Check failed - bump ABI version"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ project(re VERSION 2.1.0 LANGUAGES C)
 # Increment for breaking changes (dev2, dev3...)
 # set(PROJECT_VERSION_PRE dev)
 
+set(ABI_MAJOR 3)
+
 if(PROJECT_VERSION_PRE)
   set(PROJECT_VERSION_FULL ${PROJECT_VERSION}-${PROJECT_VERSION_PRE})
 else()
@@ -482,7 +484,7 @@ endif()
 
 set_target_properties(re-shared PROPERTIES PUBLIC_HEADER include/re.h)
 set_target_properties(re-shared PROPERTIES VERSION ${PROJECT_VERSION})
-set_target_properties(re-shared PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})
+set_target_properties(re-shared PROPERTIES SOVERSION ${ABI_MAJOR})
 set_target_properties(re-shared PROPERTIES OUTPUT_NAME "re")
 
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ VER_PATCH := 0
 # Increment for breaking changes (dev2, dev3...)
 # VER_PRE   := dev
 
-ABI_MAJOR := $(VER_MAJOR)
+ABI_MAJOR := 3
 
 # Verbose and silent build modes
 ifeq ($(V),)


### PR DESCRIPTION
Since we decided to release v2.1.0 instead of 3.0.0, we have broken the ABI version. So we have to keep a separate version for this.