### PR TITLE
cmake: add detection of HAVE_ARC4RANDOM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,10 @@ find_package(Backtrace)
 find_package(Threads)
 find_package(OpenSSL)
 
+check_symbol_exists("arc4random" "stdlib.h" HAVE_ARC4RANDOM)
+if(HAVE_ARC4RANDOM)
+  add_definitions(-DHAVE_ARC4RANDOM)
+endif()
 
 ##############################################################################
 #


### PR DESCRIPTION
some platforms provide arc4random (openbsd, freebsd, darwin, ...)

it is used in src/sys/rand.c:

```c
#elif defined(HAVE_ARC4RANDOM)
	v = arc4random();
```

arc4random provides better randomness than posix `rand()`.

I am wondering if we should try to use random functions that are
cryptographically strong and/or provides strong "randomness" ?

see libsodium randbytes.c for inspiration

ref: can RtlGenRandom be used on Windows ?

