### PR TITLE
udp: fix coverity defect

### DIFF
--- a/include/re_udp.h
+++ b/include/re_udp.h
@@ -41,7 +41,7 @@ int  udp_sock_fd(const struct udp_sock *us, int af);
 int  udp_multicast_join(struct udp_sock *us, const struct sa *group);
 int  udp_multicast_leave(struct udp_sock *us, const struct sa *group);
 int  udp_settos(struct udp_sock *us, uint8_t tos);
-int  udp_flush(struct udp_sock *us);
+void udp_flush(struct udp_sock *us);
 
 
 /* Helper API */

--- a/src/rtp/rtp.c
+++ b/src/rtp/rtp.c
@@ -616,13 +616,12 @@ int rtcp_send(struct rtp_sock *rs, struct mbuf *mb)
  */
 int rtp_clear(struct rtp_sock *rs)
 {
-	int err;
-
 	if (!rs)
 		return EINVAL;
 
-	err  = udp_flush(rs->sock_rtp);
-	return err;
+	udp_flush(rs->sock_rtp);
+
+	return 0;
 }
 
 

--- a/src/udp/udp.c
+++ b/src/udp/udp.c
@@ -992,28 +992,25 @@ struct udp_helper *udp_helper_find(const struct udp_sock *us, int layer)
  * Flush a given UDP socket
  *
  * @param us UDP socket
- *
- * @return 0 if success, otherwise errorcode
  */
-int  udp_flush(struct udp_sock *us)
+void udp_flush(struct udp_sock *us)
 {
-	char *buf;
-	size_t sz;
-
 	if (!us)
-		return EINVAL;
+		return;
 
-	sz = us->rxsz;
-	buf = mem_zalloc(sz, NULL);
-	if (!buf)
-		return ENOMEM;
+	if (-1 != us->fd) {
+		uint8_t buf[4096];
 
-	while (-1 != us->fd  &&
-	       recvfrom(us->fd,  buf, SIZ_CAST sz, 0, NULL, 0) > 0);
+		while (recvfrom(us->fd, buf, SIZ_CAST sizeof(buf),
+				0, NULL, 0) > 0)
+			;
+	}
 
-	while (-1 != us->fd6 &&
-	       recvfrom(us->fd6, buf, SIZ_CAST sz, 0, NULL, 0) > 0);
+	if (-1 != us->fd6) {
+		uint8_t buf[4096];
 
-	mem_deref(buf);
-	return 0;
+		while (recvfrom(us->fd6, buf, SIZ_CAST sizeof(buf),
+				0, NULL, 0) > 0)
+			;
+	}
 }

--- a/src/udp/udp.c
+++ b/src/udp/udp.c
@@ -1001,7 +1001,7 @@ void udp_flush(struct udp_sock *us)
 	if (-1 != us->fd) {
 		uint8_t buf[4096];
 
-		while (recvfrom(us->fd, buf, SIZ_CAST sizeof(buf),
+		while (recvfrom(us->fd, buf, sizeof(buf),
 				0, NULL, 0) > 0)
 			;
 	}
@@ -1009,7 +1009,7 @@ void udp_flush(struct udp_sock *us)
 	if (-1 != us->fd6) {
 		uint8_t buf[4096];
 
-		while (recvfrom(us->fd6, buf, SIZ_CAST sizeof(buf),
+		while (recvfrom(us->fd6, buf, sizeof(buf),
 				0, NULL, 0) > 0)
 			;
 	}


### PR DESCRIPTION
```
** CID 350672:    (TAINTED_SCALAR)


________________________________________________________________________________________________________
*** CID 350672:    (TAINTED_SCALAR)
/src/udp/udp.c: 1017 in udp_flush()
1011     	while (-1 != us->fd  &&
1012     	       recvfrom(us->fd,  buf, SIZ_CAST sz, 0, NULL, 0) > 0);
1013     
1014     	while (-1 != us->fd6 &&
1015     	       recvfrom(us->fd6, buf, SIZ_CAST sz, 0, NULL, 0) > 0);
1016     
>>>     CID 350672:    (TAINTED_SCALAR)
>>>     Passing tainted expression "*buf" to "mem_deref", which uses it as an offset.
1017     	mem_deref(buf);
1018     	return 0;
/src/udp/udp.c: 1017 in udp_flush()
1011     	while (-1 != us->fd  &&
1012     	       recvfrom(us->fd,  buf, SIZ_CAST sz, 0, NULL, 0) > 0);
1013     
1014     	while (-1 != us->fd6 &&
1015     	       recvfrom(us->fd6, buf, SIZ_CAST sz, 0, NULL, 0) > 0);
1016     
>>>     CID 350672:    (TAINTED_SCALAR)
>>>     Passing tainted expression "*buf" to "mem_deref", which uses it as an offset.
1017     	mem_deref(buf);
1018     	return 0;
```
