### PR TITLE
json/decode: fix possible out of bound access, if code changes

### DIFF
--- a/src/json/decode.c
+++ b/src/json/decode.c
@@ -54,11 +54,11 @@ static bool is_number(long double *d, bool *isfloat, const struct pl *pl)
 	if (!pl->l)
 		return false;
 
-	p = &pl->p[pl->l];
+	p = &pl->p[pl->l - 1];
 
-	while (p > pl->p) {
-
-		const char ch = *--p;
+	while (p >= pl->p) {
+		const char ch = *p;
+		--p;
 
 		if (ch == 'e' || ch == 'E') {
 


### PR DESCRIPTION
Since the pointer was directly decremented, the operation was normaly safe.
But setting the pointer not to a out-of-bound index should be safer for
future changes.

ref: https://sonarcloud.io/project/issues?issues=AX9vBNAyYH-a2i9ountj&open=AX9vBNAyYH-a2i9ountj&id=baresip_re