### PR TITLE
sa/sa_ntop: check inet_ntop() return value

### DIFF
--- a/include/re_types.h
+++ b/include/re_types.h
@@ -262,3 +262,10 @@ typedef bool _Bool;
  */
 #define likely(x)       __builtin_expect(!!(x), 1)
 #define unlikely(x)     __builtin_expect(!!(x), 0)
+
+
+#ifdef WIN32
+#define ERRNO_SOCKET WSAGetLastError()
+#else
+#define ERRNO_SOCKET errno
+#endif

--- a/src/sa/sa.c
+++ b/src/sa/sa.c
@@ -422,7 +422,7 @@ int sa_ntop(const struct sa *sa, char *buf, int size)
 	}
 
 	if (!ret)
-		return errno;
+		return ERRNO_SOCKET;
 
 	return 0;
 }

--- a/src/sa/sa.c
+++ b/src/sa/sa.c
@@ -400,24 +400,29 @@ void sa_in6(const struct sa *sa, uint8_t *addr)
  */
 int sa_ntop(const struct sa *sa, char *buf, int size)
 {
+	const char *ret;
+
 	if (!sa || !buf || !size)
 		return EINVAL;
 
 	switch (sa->u.sa.sa_family) {
 
 	case AF_INET:
-		inet_ntop(AF_INET, &sa->u.in.sin_addr, buf, size);
+		ret = inet_ntop(AF_INET, &sa->u.in.sin_addr, buf, size);
 		break;
 
 #ifdef HAVE_INET6
 	case AF_INET6:
-		inet_ntop(AF_INET6, &sa->u.in6.sin6_addr, buf, size);
+		ret = inet_ntop(AF_INET6, &sa->u.in6.sin6_addr, buf, size);
 		break;
 #endif
 
 	default:
 		return EAFNOSUPPORT;
 	}
+
+	if (!ret)
+		return errno;
 
 	return 0;
 }


### PR DESCRIPTION
On success, inet_ntop() returns a non-null pointer to dst.  NULL is
returned if there was an error, with errno set to indicate the error.