### PR TITLE
Improve WIN32 UDP socket handling

### DIFF
--- a/include/re_net.h
+++ b/include/re_net.h
@@ -105,3 +105,15 @@ int net_rt_debug(struct re_printf *pf, void *unused);
 /* Net strings */
 const char *net_proto2name(int proto);
 const char *net_af2name(int af);
+
+
+/* Socket helpers */
+#ifdef WIN32
+#define ERRNO_SOCK WSAGetLastError()
+#define BAD_SOCK INVALID_SOCKET
+typedef size_t re_sock_t;
+#else
+#define ERRNO_SOCK errno
+#define BAD_SOCK -1
+typedef int re_sock_t;
+#endif

--- a/include/re_types.h
+++ b/include/re_types.h
@@ -262,10 +262,3 @@ typedef bool _Bool;
  */
 #define likely(x)       __builtin_expect(!!(x), 1)
 #define unlikely(x)     __builtin_expect(!!(x), 0)
-
-
-#ifdef WIN32
-#define ERRNO_SOCKET WSAGetLastError()
-#else
-#define ERRNO_SOCKET errno
-#endif

--- a/include/re_udp.h
+++ b/include/re_udp.h
@@ -36,7 +36,6 @@ void udp_handler_set(struct udp_sock *us, udp_recv_h *rh, void *arg);
 void udp_error_handler_set(struct udp_sock *us, udp_error_h *eh);
 int  udp_thread_attach(struct udp_sock *us);
 void udp_thread_detach(struct udp_sock *us);
-re_sock_t udp_sock_fd(const struct udp_sock *us, int af);
 
 int  udp_multicast_join(struct udp_sock *us, const struct sa *group);
 int  udp_multicast_leave(struct udp_sock *us, const struct sa *group);

--- a/include/re_udp.h
+++ b/include/re_udp.h
@@ -36,7 +36,7 @@ void udp_handler_set(struct udp_sock *us, udp_recv_h *rh, void *arg);
 void udp_error_handler_set(struct udp_sock *us, udp_error_h *eh);
 int  udp_thread_attach(struct udp_sock *us);
 void udp_thread_detach(struct udp_sock *us);
-int  udp_sock_fd(const struct udp_sock *us, int af);
+re_sock_t udp_sock_fd(const struct udp_sock *us, int af);
 
 int  udp_multicast_join(struct udp_sock *us, const struct sa *group);
 int  udp_multicast_leave(struct udp_sock *us, const struct sa *group);

--- a/src/sa/sa.c
+++ b/src/sa/sa.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <re_types.h>
 #include <re_fmt.h>
+#include <re_net.h>
 #include <re_list.h>
 #include <re_sa.h>
 
@@ -422,7 +423,7 @@ int sa_ntop(const struct sa *sa, char *buf, int size)
 	}
 
 	if (!ret)
-		return ERRNO_SOCKET;
+		return ERRNO_SOCK;
 
 	return 0;
 }

--- a/src/udp/udp.c
+++ b/src/udp/udp.c
@@ -781,28 +781,6 @@ void udp_error_handler_set(struct udp_sock *us, udp_error_h *eh)
 
 
 /**
- * Get the File Descriptor from a UDP Socket
- *
- * @param us  UDP Socket
- * @param af  Address Family
- *
- * @return File Descriptor, or BAD_SOCK for errors
- */
-re_sock_t udp_sock_fd(const struct udp_sock *us, int af)
-{
-	if (!us)
-		return BAD_SOCK;
-
-	switch (af) {
-
-	default:
-	case AF_INET:  return us->fd;
-	case AF_INET6: return (us->fd6 != BAD_SOCK) ? us->fd6 : us->fd;
-	}
-}
-
-
-/**
  * Attach the current thread to the UDP Socket
  *
  * @param us UDP Socket


### PR DESCRIPTION
The socket handling (especially the error handling) is a bit different on win32 (see https://github.com/baresip/re/wiki/Socket-Handling).

This PR also removes unused `udp_sock_fd()` to keep fd hidden from API.