### PR TITLE
sha: add sha 256 and 512 digest length OpenSSL compats

### DIFF
--- a/include/re_sha.h
+++ b/include/re_sha.h
@@ -6,10 +6,22 @@
 
 /** SHA-1 Digest size in bytes */
 #define SHA1_DIGEST_SIZE 20
+#define SHA256_DIGEST_SIZE 32
+#define SHA512_DIGEST_SIZE 64
 
 #ifndef SHA_DIGEST_LENGTH
 /** SHA-1 Digest size in bytes (OpenSSL compat) */
 #define SHA_DIGEST_LENGTH SHA1_DIGEST_SIZE
+#endif
+
+#ifndef SHA256_DIGEST_LENGTH
+/** SHA-256 Digest size in bytes (OpenSSL compat) */
+#define SHA256_DIGEST_LENGTH SHA256_DIGEST_SIZE
+#endif
+
+#ifndef SHA512_DIGEST_LENGTH
+/** SHA-512 Digest size in bytes (OpenSSL compat) */
+#define SHA512_DIGEST_LENGTH SHA512_DIGEST_SIZE
 #endif
 
 void sha1(const uint8_t *d, size_t n, uint8_t *md);


### PR DESCRIPTION
Fixes [restund](https://github.com/wireapp/restund) compilation (was broken since new sha wrapper)

```c
modules/zrest/zrest.c: In Function »generate_password«:                                                                                                     
modules/zrest/zrest.c:67:24: Error: »SHA512_DIGEST_LENGTH
```