### PR TITLE
sa/sa_is_loopback: check full IPv4 loopback range (127.0.0.0/8)

### DIFF
--- a/src/sa/sa.c
+++ b/src/sa/sa.c
@@ -643,7 +643,7 @@ bool sa_is_linklocal(const struct sa *sa)
 
 
 /**
- * Check if socket address is a loopback address
+ * Check if socket address is a loopback address (127.0.0.0/8 or ::1/128)
  *
  * @param sa Socket address
  *
@@ -657,7 +657,8 @@ bool sa_is_loopback(const struct sa *sa)
 	switch (sa_af(sa)) {
 
 	case AF_INET:
-		return INADDR_LOOPBACK == ntohl(sa->u.in.sin_addr.s_addr);
+		return (ntohl(sa->u.in.sin_addr.s_addr) & 0xff000000) ==
+		       0x7f000000;
 
 #ifdef HAVE_INET6
 	case AF_INET6:


### PR DESCRIPTION
Proposal for discussion. Should we check the full IPv4 loopback range?

```bash
ip addr add 127.0.0.2/8 dev lo
```

Is currently recognized as valid address within baresip network detection:

```
--- Network debug ---
enabled interfaces:
         lo:  127.0.0.2
     wlp4s0:  ...
     wlp4s0: ...
```

This restund fork uses a similiar workaround:

https://github.com/wireapp/restund/commit/87ca8fcf490cf1094c9107094db7c8f2e62d13ed


Will fix the failed retest if we agree (fixed now: https://github.com/baresip/retest/pull/55)