### PR TITLE
workflow: upgrade to openssl 3.0.2

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -39,14 +39,14 @@ jobs:
       id: openssl
       with:
         path: baresip-win32/openssl
-        key: ${{ runner.os }}-mingw-openssl-1.1.1m
+        key: ${{ runner.os }}-mingw-openssl-3.0.2
 
     - name: "build openssl"
       if: steps.openssl.outputs.cache-hit != 'true'
       run: |
-        wget https://www.openssl.org/source/openssl-1.1.1m.tar.gz
-        tar -xzf openssl-1.1.1m.tar.gz
-        mv openssl-1.1.1m baresip-win32/openssl
+        wget https://www.openssl.org/source/openssl-3.0.2.tar.gz
+        tar -xzf openssl-3.0.2.tar.gz
+        mv openssl-3.0.2 baresip-win32/openssl
         make -j$(nproc) -C baresip-win32 openssl
     
     - name: "build"


### PR DESCRIPTION
this is a proposal to upgrade to openssl 3.0.2 used for the build scripts.
