### PR TITLE
fmt/pl: use unsigned type before negation

### DIFF
--- a/src/fmt/pl.c
+++ b/src/fmt/pl.c
@@ -63,7 +63,7 @@ void pl_set_mbuf(struct pl *pl, const struct mbuf *mb)
  */
 int32_t pl_i32(const struct pl *pl)
 {
-	int32_t v = 0;
+	uint32_t v = 0;
 	uint32_t mul = 1;
 	const char *p;
 	bool neg = false;
@@ -104,7 +104,7 @@ int32_t pl_i32(const struct pl *pl)
  */
 int64_t pl_i64(const struct pl *pl)
 {
-	int64_t v = 0;
+	uint64_t v = 0;
 	uint64_t mul = 1;
 	const char *p;
 	bool neg = false;


### PR DESCRIPTION
fixes "-fsanitize=undefined"
src/fmt/pl.c:94:15: runtime error: negation of 2147483648 cannot be
represented in type 'int32_t' (aka 'int'); cast to an unsigned type to
negate this value to itself