### PR TITLE
list: O(1) sorted insert if we expect append in most cases

### DIFF
--- a/include/re_list.h
+++ b/include/re_list.h
@@ -58,7 +58,7 @@ void list_insert_before(struct list *list, struct le *le, struct le *ile,
 			void *data);
 void list_insert_after(struct list *list, struct le *le, struct le *ile,
 		       void *data);
-void list_insert_sorted(struct list *list, list_sort_h *sh, void *arg,
+void list_insert_sorted(struct list *list, list_sort_h *leq, void *arg,
 			struct le *ile, void *data);
 void list_unlink(struct le *le);
 void list_sort(struct list *list, list_sort_h *sh, void *arg);

--- a/src/list/list.c
+++ b/src/list/list.c
@@ -210,39 +210,47 @@ void list_insert_after(struct list *list, struct le *le, struct le *ile,
 }
 
 
+static bool le_less(list_sort_h *leq,
+		       struct le *le1, struct le *le2, void *arg)
+{
+	return    leq(le1, le2, arg) &&
+		!(leq(le1, le2, arg) && leq(le2, le1, arg));
+}
+
+
 /**
  * Sorted insert into linked list with order defined by the sort handler
  *
  * @param list  Linked list
- * @param sh    Sort handler
+ * @param leq   Less-equal operator
  * @param arg   Handler argument
  * @param ile   List element to insert
  * @param data  Element data
  */
-void list_insert_sorted(struct list *list, list_sort_h *sh, void *arg,
+void list_insert_sorted(struct list *list, list_sort_h *leq, void *arg,
 			struct le *ile, void *data)
 {
 	struct le *le;
 
-	if (!list || !sh)
+	if (!list || !leq)
 		return;
 
-	le = list->head;
+	le = list->tail;
 	ile->data = data;
 
 	while (le) {
 
-		if (sh(le, ile, arg)) {
+		if (le_less(leq, ile, le, arg)) {
 
-			le = le->next;
+			le = le->prev;
 		}
 		else {
-			list_insert_before(list, le, ile, ile->data);
+			list_insert_after(list, le, ile, ile->data);
 			return;
 		}
 	}
 
-	list_append(list, ile, ile->data);
+	list_prepend(list, ile, ile->data);
 }
 
 


### PR DESCRIPTION
Append means putting to tail. When the loop for the sorted insert is started
at the tail, then for a rising sequence we need only one check with a "less"
operator to know that the element has to be appended to the list.

Like `list_sort()` also `list_insert_sorted()` takes a less-equal operator.
Because we don't want to change this API detail, we declare an internal
function `le_less` by means of the given less-equal operator.
