### PR TITLE
cmake: define RELEASE for release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,11 @@ add_definitions(
   -DVER_PATCH=${PROJECT_VERSION_PATCH}
 )
 
+if(${CMAKE_BUILD_TYPE} MATCHES "[Rr]el")
+  add_definitions(-DRELEASE)
+endif()
+
+
 ##############################################################################
 #
 # Source/Header section


### PR DESCRIPTION
Build type can be set using:

```
$ cmake -DCMAKE_BUILD_TYPE=Release
```

Possible values are empty, Debug, Release, RelWithDebInfo and MinSizeRel
