### PR TITLE
Mem lock win32

### DIFF
--- a/src/mem/mem.c
+++ b/src/mem/mem.c
@@ -8,6 +8,8 @@
 #include <string.h>
 #ifdef HAVE_PTHREAD
 #include <pthread.h>
+#elif defined (WIN32)
+#include <windows.h>
 #endif
 #include <re_types.h>
 #include <re_list.h>


### PR DESCRIPTION
add missing locking for Windows where no pthreads is available.

Original author: Michael Rodda <mrodda@nvidia.com>


