### PR TITLE
set TCP source port in Via and Contact header

### DIFF
--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -244,7 +244,7 @@ struct sip_keepalive;
 struct dnsc;
 
 typedef bool(sip_msg_h)(const struct sip_msg *msg, void *arg);
-typedef int(sip_send_h)(enum sip_transp tp, const struct sa *src,
+typedef int(sip_send_h)(enum sip_transp tp, struct sa *src,
 			const struct sa *dst, struct mbuf *mb,
 			struct mbuf **contp, void *arg);
 typedef void(sip_resp_h)(int err, const struct sip_msg *msg, void *arg);

--- a/src/sip/request.c
+++ b/src/sip/request.c
@@ -167,7 +167,6 @@ static int request(struct sip_request *req, enum sip_transp tp,
 	char *branch = NULL;
 	int err = ENOMEM;
 	struct sa laddr;
-	struct sip_conncfg *conncfg;
 
 	req->provrecv = false;
 
@@ -190,12 +189,6 @@ static int request(struct sip_request *req, enum sip_transp tp,
 		goto out;
 
 	mbuf_set_pos(mbs, 0);
-	if (tp==SIP_TRANSP_TCP || tp==SIP_TRANSP_TLS) {
-		conncfg = sip_conncfg_find(req->sip, dst);
-		if (conncfg && conncfg->srcport)
-			sa_set_port(&laddr, conncfg->srcport);
-	}
-
 	err  = mbuf_printf(mb, "%s %s SIP/2.0\r\n", req->met, req->uri);
 	err |= mbuf_printf(mb, "Via: SIP/2.0/%s %J;branch=%s;rport\r\n",
 			   sip_transp_name(tp), &laddr, branch);

--- a/src/sip/request.c
+++ b/src/sip/request.c
@@ -166,6 +166,7 @@ static int request(struct sip_request *req, enum sip_transp tp,
 	char *branch = NULL;
 	int err = ENOMEM;
 	struct sa laddr;
+	struct sip_conncfg *conncfg;
 
 	req->provrecv = false;
 
@@ -180,6 +181,11 @@ static int request(struct sip_request *req, enum sip_transp tp,
 	err = sip_transp_laddr(req->sip, &laddr, tp, dst);
 	if (err)
 		goto out;
+
+	conncfg = sip_conncfg_find(req->sip, dst);
+	if (conncfg && conncfg->srcport && (tp==SIP_TRANSP_TCP ||
+					    tp==SIP_TRANSP_TLS))
+		sa_set_port(&laddr, conncfg->srcport);
 
 	err  = mbuf_printf(mb, "%s %s SIP/2.0\r\n", req->met, req->uri);
 	err |= mbuf_printf(mb, "Via: SIP/2.0/%s %J;branch=%s;rport\r\n",

--- a/src/sip/request.c
+++ b/src/sip/request.c
@@ -183,8 +183,8 @@ static int request(struct sip_request *req, enum sip_transp tp,
 	if (err)
 		goto out;
 
-	err |= req->sendh ? req->sendh(tp, &laddr, dst, mbs, &cont, req->arg) :
-			    0;
+	err = req->sendh ? req->sendh(tp, &laddr, dst, mbs, &cont, req->arg) :
+			   0;
 	if (err)
 		goto out;
 

--- a/src/sip/sip.c
+++ b/src/sip/sip.c
@@ -282,3 +282,23 @@ void sip_set_trace_handler(struct sip *sip, sip_trace_h *traceh)
 
 	sip->traceh = traceh;
 }
+
+
+struct sip_conncfg *sip_conncfg_find(struct sip *sip,
+				     const struct sa *paddr)
+{
+	struct le *le;
+
+	le = list_head(hash_list(sip->ht_conncfg, sa_hash(paddr, SA_ALL)));
+	for (; le; le = le->next) {
+
+		struct sip_conncfg *cfg = le->data;
+
+		if (!sa_cmp(&cfg->paddr, paddr, SA_ALL))
+			continue;
+
+		return cfg;
+	}
+
+	return NULL;
+}

--- a/src/sip/sip.h
+++ b/src/sip/sip.h
@@ -98,3 +98,7 @@ int  sip_keepalive_tcp(struct sip_keepalive *ka, struct sip_conn *conn,
 int  sip_keepalive_udp(struct sip_keepalive *ka, struct sip *sip,
 		       struct udp_sock *us, const struct sa *paddr,
 		       uint32_t interval);
+
+/* sip_conncfg */
+struct sip_conncfg *sip_conncfg_find(struct sip *sip,
+				     const struct sa *paddr);

--- a/src/sip/transp.c
+++ b/src/sip/transp.c
@@ -191,26 +191,6 @@ static const struct sip_transport *transp_find(struct sip *sip,
 }
 
 
-static struct sip_conncfg *conncfg_find(struct sip *sip,
-					const struct sa *paddr)
-{
-	struct le *le;
-
-	le = list_head(hash_list(sip->ht_conncfg, sa_hash(paddr, SA_ALL)));
-	for (; le; le = le->next) {
-
-		struct sip_conncfg *cfg = le->data;
-
-		if (!sa_cmp(&cfg->paddr, paddr, SA_ALL))
-			continue;
-
-		return cfg;
-	}
-
-	return NULL;
-}
-
-
 static struct sip_conn *conn_find(struct sip *sip, const struct sa *paddr,
 				  bool secure)
 {
@@ -787,7 +767,7 @@ static int conn_send(struct sip_connqent **qentp, struct sip *sip, bool secure,
 	conn->sip   = sip;
 	conn->tp    = secure ? SIP_TRANSP_TLS : SIP_TRANSP_TCP;
 
-	conncfg = conncfg_find(sip, dst);
+	conncfg = sip_conncfg_find(sip, dst);
 	if (conncfg && conncfg->srcport) {
 		struct sa src;
 		sa_init(&src, sa_af(dst));
@@ -1894,7 +1874,7 @@ int sip_conncfg_set(struct sip *sip, const struct sa *paddr,
 	if (!sip || !sa_isset(paddr, SA_ALL))
 		return EINVAL;
 
-	cfg = conncfg_find(sip, paddr);
+	cfg = sip_conncfg_find(sip, paddr);
 	if (cfg) {
 		cfg->srcport = conncfg.srcport;
 		return 0;

--- a/src/sip/transp.c
+++ b/src/sip/transp.c
@@ -1506,6 +1506,7 @@ int sip_transp_laddr(struct sip *sip, struct sa *laddr, enum sip_transp tp,
 		      const struct sa *dst)
 {
 	const struct sip_transport *transp;
+	struct sip_conncfg *conncfg;
 
 	if (!sip || !laddr)
 		return EINVAL;
@@ -1515,6 +1516,11 @@ int sip_transp_laddr(struct sip *sip, struct sa *laddr, enum sip_transp tp,
 		return EPROTONOSUPPORT;
 
 	*laddr = transp->laddr;
+	if (tp != SIP_TRANSP_UDP) {
+		conncfg = sip_conncfg_find(sip, dst);
+		if (conncfg && conncfg->srcport)
+			sa_set_port(laddr, conncfg->srcport);
+	}
 
 	return 0;
 }

--- a/src/sipevent/notify.c
+++ b/src/sipevent/notify.c
@@ -174,7 +174,7 @@ static void response_handler(int err, const struct sip_msg *msg, void *arg)
 }
 
 
-static int send_handler(enum sip_transp tp, const struct sa *src,
+static int send_handler(enum sip_transp tp, struct sa *src,
 			const struct sa *dst, struct mbuf *mb,
 			struct mbuf **contp, void *arg)
 {

--- a/src/sipevent/subscribe.c
+++ b/src/sipevent/subscribe.c
@@ -295,7 +295,7 @@ static void response_handler(int err, const struct sip_msg *msg, void *arg)
 }
 
 
-static int send_handler(enum sip_transp tp, const struct sa *src,
+static int send_handler(enum sip_transp tp, struct sa *src,
 			const struct sa *dst, struct mbuf *mb,
 			struct mbuf **contp, void *arg)
 {

--- a/src/sipreg/reg.c
+++ b/src/sipreg/reg.c
@@ -278,6 +278,8 @@ static int send_handler(enum sip_transp tp, const struct sa *src,
 
 	reg->laddr = *src;
 	reg->tp = tp;
+	if (reg->srcport && tp != SIP_TRANSP_UDP)
+		sa_set_port(&reg->laddr, reg->srcport);
 
 	err = mbuf_printf(mb, "Contact: <sip:%s@%J%s>;expires=%u%s%s",
 			  reg->cuser, &reg->laddr, sip_transp_param(reg->tp),

--- a/src/sipreg/reg.c
+++ b/src/sipreg/reg.c
@@ -266,7 +266,7 @@ static void response_handler(int err, const struct sip_msg *msg, void *arg)
 }
 
 
-static int send_handler(enum sip_transp tp, const struct sa *src,
+static int send_handler(enum sip_transp tp, struct sa *src,
 			const struct sa *dst, struct mbuf *mb,
 			struct mbuf **contp, void *arg)
 {
@@ -276,11 +276,11 @@ static int send_handler(enum sip_transp tp, const struct sa *src,
 	(void)dst;
 	(void)contp;
 
-	reg->laddr = *src;
 	reg->tp = tp;
 	if (reg->srcport && tp != SIP_TRANSP_UDP)
-		sa_set_port(&reg->laddr, reg->srcport);
+		sa_set_port(src, reg->srcport);
 
+	reg->laddr = *src;
 	err = mbuf_printf(mb, "Contact: <sip:%s@%J%s>;expires=%u%s%s",
 			  reg->cuser, &reg->laddr, sip_transp_param(reg->tp),
 			  reg->expires,

--- a/src/sipsess/ack.c
+++ b/src/sipsess/ack.c
@@ -50,7 +50,7 @@ static void tmr_handler(void *arg)
 }
 
 
-static int send_handler(enum sip_transp tp, const struct sa *src,
+static int send_handler(enum sip_transp tp, struct sa *src,
 			const struct sa *dst, struct mbuf *mb,
 			struct mbuf **contp, void *arg)
 {

--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -22,7 +22,7 @@
 static int invite(struct sipsess *sess);
 
 
-static int send_handler(enum sip_transp tp, const struct sa *src,
+static int send_handler(enum sip_transp tp, struct sa *src,
 			const struct sa *dst, struct mbuf *mb,
 			struct mbuf **contp, void *arg)
 {

--- a/src/sipsess/modify.c
+++ b/src/sipsess/modify.c
@@ -106,7 +106,7 @@ static void reinvite_resp_handler(int err, const struct sip_msg *msg,
 }
 
 
-static int send_handler(enum sip_transp tp, const struct sa *src,
+static int send_handler(enum sip_transp tp, struct sa *src,
 			const struct sa *dst, struct mbuf *mb,
 			struct mbuf **contp, void *arg)
 {


### PR DESCRIPTION
- sipreg: use optional TCP src port for Contact port
- sip: use local TCP port also for Via header
- sip: set TCP src port in Via and Contact also for first REGISTER
- sip: set TCP src port at laddr in all Via and Contact headers

An SBC (Session Border Controller) may block SIP requests where the Via/Contact
header port does not match the configured TCP port. The change only affects
transport TCP and TLS.
