### PR TITLE
rand: init only needed for libc rand

### DIFF
--- a/include/re_sys.h
+++ b/include/re_sys.h
@@ -57,7 +57,6 @@ uint64_t sys_ntohll(uint64_t v);
 
 
 /* Random */
-void     rand_init(void);
 uint16_t rand_u16(void);
 uint32_t rand_u32(void);
 uint64_t rand_u64(void);

--- a/src/main/init.c
+++ b/src/main/init.c
@@ -21,8 +21,6 @@ int libre_init(void)
 {
 	int err;
 
-	rand_init();
-
 #ifdef USE_OPENSSL
 	err = openssl_init();
 	if (err)


### PR DESCRIPTION
this is a proposal

when openssl or arc4random is used as random function, the rand_init function is obsolete.
proposal is to automatically check this instead, and init rand the first time rand is called.

the advantage is that you are not required to call `rand_init` before rand functions can be used.

