### PR TITLE
mem: init g_memLock directly

### DIFF
--- a/src/mem/mem.c
+++ b/src/mem/mem.c
@@ -78,8 +78,9 @@ static BOOL CALLBACK InitHandleFunction(PINIT_ONCE initOnce,
 {
 	(void)initOnce;
 	(void)parameter;
+	(void)lpContext;
 
-	InitializeCriticalSection((LPCRITICAL_SECTION)lpContext);
+	InitializeCriticalSection(&g_memLock);
 
 	return TRUE;
 }
@@ -88,7 +89,7 @@ static BOOL CALLBACK InitHandleFunction(PINIT_ONCE initOnce,
 static inline void mem_lock(void)
 {
 	InitOnceExecuteOnce(&g_initMemLockOnce, InitHandleFunction,
-			    NULL, (PVOID*)&g_memLock);
+			    NULL, NULL);
 	EnterCriticalSection(&g_memLock);
 }
 


### PR DESCRIPTION
it turns out that InitOnceExecuteOnce crashes if the address of g_memlock
is sent as the 4th parameter.

in order to avoid this, refer directly to g_memlock in the initonce callback handler.

Please review and test on Windows.