### PR TITLE
ci: test centos -> fedora

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    container: centos:7
+    container: fedora
 
     strategy:
       matrix:

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -1,4 +1,4 @@
-name: Centos 7
+name: Fedora
 
 on: [push, pull_request]
 


### PR DESCRIPTION
centos has been abandoned by RedHat I am wondering if we should support it anymore:

https://en.wikipedia.org/wiki/CentOS

I am wondering if we should support only recent versions of OpenSSL,
i.e. the same as is supported by openssl.org
CentOS 7 is using OpenSSL 1.0.2 which is not supported anymore.
Proposal for support:

* OpenSSL 1.1.1
* OpenSSL 3.0.0
* LibreSSL (from recent OpenBSD release)

Perhaps we should switch to a different RedHat based distro,
such as Fedora or RockyLinux ?

This PR switches the container from centos to fedora. Looks like it is working, but
it needs to be verified.

This is a proposal, feel free to discuss :)
