### PR TITLE
av1 obu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,8 @@ set(HEADERS
 
 set(SRCS
 
+  src/av1/obu.c
+
   src/base64/b64.c
 
   src/btrace/btrace.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,7 @@ endif()
 set(HEADERS
   include/re_aes.h
   include/re_atomic.h
+  include/re_av1.h
   include/re_base64.h
   include/re_bfcp.h
   include/re_bitv.h

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ MODULES += rtmp
 MODULES += shim
 MODULES += trice
 MODULES += pcp
+MODULES += av1
 
 INSTALL := install
 ifeq ($(DESTDIR),)

--- a/include/re_av1.h
+++ b/include/re_av1.h
@@ -1,0 +1,30 @@
+/**
+ * @file re_av1.c AV1 Open Bitstream Unit (OBU)
+ *
+ * Copyright (C) 2010 - 2022 Alfred E. Heggestad
+ */
+
+
+/* OBU (Open Bitstream Units) */
+
+/*
+ * OBU Header
+ *
+ *     0 1 2 3 4 5 6 7
+ *    +-+-+-+-+-+-+-+-+
+ *    |F| type  |X|S|-| (REQUIRED)
+ *    +-+-+-+-+-+-+-+-+
+ */
+struct av1_obu_hdr {
+	unsigned type:4;  /* type           */
+	bool x;           /* extension flag */
+	bool s;           /* has size field */
+	size_t size;      /* payload size   */
+};
+
+int av1_leb128_encode(struct mbuf *mb, size_t value);
+int av1_leb128_decode(struct mbuf *mb, size_t *value);
+int av1_obu_encode(struct mbuf *mb, uint8_t type, bool has_size,
+		   size_t len, const uint8_t *payload);
+int av1_obu_decode(struct av1_obu_hdr *hdr, struct mbuf *mb);
+int av1_obu_print(struct re_printf *pf, const struct av1_obu_hdr *hdr);

--- a/src/av1/mod.mk
+++ b/src/av1/mod.mk
@@ -1,0 +1,7 @@
+#
+# mod.mk
+#
+# Copyright (C) 2010 Alfred E. Heggestad
+#
+
+SRCS	+= av1/obu.c

--- a/src/av1/obu.c
+++ b/src/av1/obu.c
@@ -32,7 +32,7 @@ int av1_leb128_encode(struct mbuf *mb, size_t value)
 		value >>= 7;
 	}
 
-	err |= mbuf_write_u8(mb, value);
+	err |= mbuf_write_u8(mb, (uint8_t)value);
 
 	return err;
 }

--- a/src/av1/obu.c
+++ b/src/av1/obu.c
@@ -1,0 +1,161 @@
+/**
+ * @file av1/obu.c AV1 Open Bitstream Unit (OBU)
+ *
+ * Copyright (C) 2010 - 2022 Alfred E. Heggestad
+ */
+
+#include <string.h>
+#include <re_types.h>
+#include <re_fmt.h>
+#include <re_mbuf.h>
+#include <re_av1.h>
+
+
+#define DEBUG_MODULE "av1"
+#define DEBUG_LEVEL 5
+#include <re_dbg.h>
+
+
+int av1_leb128_encode(struct mbuf *mb, size_t value)
+{
+	int err = 0;
+
+	if (!mb)
+		return EINVAL;
+
+	while (value >= 0x80) {
+
+		uint8_t u8 = 0x80 | (value & 0x7f);
+
+		err |= mbuf_write_u8(mb, u8);
+
+		value >>= 7;
+	}
+
+	err |= mbuf_write_u8(mb, value);
+
+	return err;
+}
+
+
+int av1_leb128_decode(struct mbuf *mb, size_t *value)
+{
+	size_t ret = 0;
+	unsigned i;
+
+	if (!mb || !value)
+		return EINVAL;
+
+	for (i = 0; i < 8; i++) {
+
+		size_t byte;
+
+		if (mbuf_get_left(mb) < 1)
+			return EBADMSG;
+
+		byte = mbuf_read_u8(mb);
+
+		ret |= (size_t)(byte & 0x7f) << (i * 7);
+
+		if (!(byte & 0x80))
+			break;
+	}
+
+	*value = ret;
+
+	return 0;
+}
+
+
+int av1_obu_encode(struct mbuf *mb, uint8_t type, bool has_size,
+		   size_t len, const uint8_t *payload)
+{
+	uint8_t val;
+	int err;
+
+	if (!mb || type==0)
+		return EINVAL;
+
+	val  = (type&0xf) << 3;
+	val |= (unsigned)has_size << 1;
+
+	err  = mbuf_write_u8(mb, val);
+
+	if (has_size)
+		err |= av1_leb128_encode(mb, len);
+
+	if (payload && len)
+		err |= mbuf_write_mem(mb, payload, len);
+
+	return err;
+}
+
+
+int av1_obu_decode(struct av1_obu_hdr *hdr, struct mbuf *mb)
+{
+	uint8_t val;
+	bool f;
+	int err;
+
+	if (!hdr || !mb)
+		return EINVAL;
+
+	if (mbuf_get_left(mb) < 1)
+		return EBADMSG;
+
+	memset(hdr, 0, sizeof(*hdr));
+
+	val = mbuf_read_u8(mb);
+
+	f         = (val >> 7) & 0x1;
+	hdr->type = (val >> 3) & 0xf;
+	hdr->x    = (val >> 2) & 0x1;
+	hdr->s    = (val >> 1) & 0x1;
+
+	if (f) {
+		DEBUG_WARNING("av1: header: obu forbidden bit!"
+			" [type=%u, x=%d, s=%d, left=%zu bytes]\n",
+			hdr->type, hdr->x, hdr->s, mbuf_get_left(mb));
+		return EBADMSG;
+	}
+
+	if (hdr->type == 0) {
+		DEBUG_WARNING("av1: header: obu type 0 is reserved [%H]\n",
+			      av1_obu_print, hdr);
+		return EBADMSG;
+	}
+
+	if (hdr->x) {
+		DEBUG_WARNING("av1: header: extension not supported (%u)\n",
+			      hdr->type);
+		return ENOTSUP;
+	}
+
+	if (hdr->s) {
+		err = av1_leb128_decode(mb, &hdr->size);
+		if (err)
+			return err;
+
+		if (hdr->size > mbuf_get_left(mb)) {
+			DEBUG_WARNING("av1: obu decode: short packet:"
+				      " %zu > %zu\n",
+				      hdr->size, mbuf_get_left(mb));
+			return EBADMSG;
+		}
+	}
+	else {
+		hdr->size = mbuf_get_left(mb);
+	}
+
+	return 0;
+}
+
+
+int av1_obu_print(struct re_printf *pf, const struct av1_obu_hdr *hdr)
+{
+	if (!hdr)
+		return 0;
+
+	return re_hprintf(pf, "type=%u x=%d s=%d size=%zu",
+			  hdr->type, hdr->x, hdr->s, hdr->size);
+}


### PR DESCRIPTION
move av1 obu code from baresip/av1 to re.
AV1 codec is using Open Bitstream Unit (OBU) format.

Ref:

https://github.com/baresip/re/pull/345
https://github.com/baresip/baresip/pull/1835
