### PR TITLE
thread: use pthread as default fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ include(GNUInstallDirs)
 include(CheckIncludeFile)
 include(CheckFunctionExists)
 find_package(Backtrace)
-find_package(Threads)
+find_package(Threads REQUIRED)
 find_package(OpenSSL)
 
 check_symbol_exists("arc4random" "stdlib.h" HAVE_ARC4RANDOM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,6 +401,8 @@ set(SRCS
 
   src/telev/telev.c
 
+  src/thread/thread.c
+
   src/tmr/tmr.c
 
   src/trace/trace.c
@@ -549,19 +551,13 @@ elseif(HAVE_PTHREAD)
   )
 endif()
 
-if(HAVE_THREADS)
+if(CMAKE_USE_WIN32_THREADS_INIT)
   list(APPEND SRCS
-    src/thread/thread.c
-  )
-elseif(HAVE_PTHREAD)
-  list(APPEND SRCS
-    src/thread/thread.c
-    src/thread/posix.c
-  )
-elseif(CMAKE_USE_WIN32_THREADS_INIT)
-  list(APPEND SRCS
-    src/thread/thread.c
     src/thread/win32.c
+  )
+else()
+  list(APPEND SRCS
+    src/thread/posix.c
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,7 +551,9 @@ elseif(HAVE_PTHREAD)
   )
 endif()
 
-if(CMAKE_USE_WIN32_THREADS_INIT)
+if(HAVE_THREADS)
+  #Do nothing
+elseif(CMAKE_USE_WIN32_THREADS_INIT)
   list(APPEND SRCS
     src/thread/win32.c
   )

--- a/include/re_thread.h
+++ b/include/re_thread.h
@@ -7,8 +7,8 @@
  * Preferred order:
  *
  * - C11 threads (glibc>=2.28, musl, FreeBSD>=10)
- * - POSIX PTHREAD (Linux/UNIX, winpthreads)
  * - Windows Thread API
+ * - POSIX PTHREAD (Linux/UNIX)
  *
  * Copyright (C) 2022 Sebastian Reimers
  */
@@ -18,17 +18,7 @@
 
 #else
 
-#if defined(HAVE_PTHREAD)
-
-#include <pthread.h>
-#include <time.h>
-#define ONCE_FLAG_INIT PTHREAD_ONCE_INIT
-typedef pthread_once_t once_flag;
-typedef pthread_t thrd_t;
-typedef pthread_cond_t cnd_t;
-typedef pthread_mutex_t mtx_t;
-
-#elif defined(WIN32)
+#if defined(WIN32)
 
 #include <windows.h>
 #define ONCE_FLAG_INIT INIT_ONCE_STATIC_INIT
@@ -39,7 +29,13 @@ typedef CRITICAL_SECTION mtx_t;
 
 #else
 
-#error "thread: system not supported"
+#include <pthread.h>
+#include <time.h>
+#define ONCE_FLAG_INIT PTHREAD_ONCE_INIT
+typedef pthread_once_t once_flag;
+typedef pthread_t thrd_t;
+typedef pthread_cond_t cnd_t;
+typedef pthread_mutex_t mtx_t;
 
 #endif
 

--- a/src/thread/mod.mk
+++ b/src/thread/mod.mk
@@ -1,4 +1,5 @@
-ifeq ($(OS),win32)
+ifdef HAVE_THREADS
+else ifeq ($(OS),win32)
 SRCS	+= thread/win32.c
 else
 SRCS	+= thread/posix.c

--- a/src/thread/mod.mk
+++ b/src/thread/mod.mk
@@ -1,9 +1,6 @@
-ifdef HAVE_THREADS
-SRCS	+= thread/thread.c
-else ifdef HAVE_PTHREAD
-SRCS	+= thread/thread.c
-SRCS	+= thread/posix.c
-else ifeq ($(OS),win32)
-SRCS	+= thread/thread.c
+ifeq ($(OS),win32)
 SRCS	+= thread/win32.c
+else
+SRCS	+= thread/posix.c
 endif
+SRCS	+= thread/thread.c


### PR DESCRIPTION
This way HAVE_PTHREAD does not need to be defined and can be deprecated (was mostly used for WIN32 exceptions).

Ref #353 