### PR TITLE
doxygen: update comments

### DIFF
--- a/mk/Doxyfile
+++ b/mk/Doxyfile
@@ -115,7 +115,7 @@ VERBATIM_HEADERS       = YES
 # configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
 ALPHABETICAL_INDEX     = YES
-COLS_IN_ALPHA_INDEX    = 5
+#COLS_IN_ALPHA_INDEX    = 5
 IGNORE_PREFIX          = 
 #---------------------------------------------------------------------------
 # configuration options related to the HTML output
@@ -145,7 +145,7 @@ LATEX_OUTPUT           = latex
 LATEX_CMD_NAME         = latex
 MAKEINDEX_CMD_NAME     = makeindex
 COMPACT_LATEX          = NO
-PAPER_TYPE             = a4wide
+#PAPER_TYPE             = a4wide
 EXTRA_PACKAGES         = 
 LATEX_HEADER           = 
 PDF_HYPERLINKS         = NO
@@ -204,11 +204,11 @@ TAGFILES               =
 GENERATE_TAGFILE       = 
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
-PERL_PATH              = /usr/bin/perl
+#PERL_PATH              = /usr/bin/perl
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool   
 #---------------------------------------------------------------------------
-CLASS_DIAGRAMS         = YES
+#CLASS_DIAGRAMS         = YES
 HIDE_UNDOC_RELATIONS   = YES
 HAVE_DOT               = YES
 CLASS_GRAPH            = YES

--- a/src/sa/sa.c
+++ b/src/sa/sa.c
@@ -180,8 +180,6 @@ int sa_set_str(struct sa *sa, const char *addr, uint16_t port)
  * @param sa   Socket Address
  * @param addr IPv4 address in host order
  * @param port Port number
- *
- * @return 0 if success, otherwise errorcode
  */
 void sa_set_in(struct sa *sa, uint32_t addr, uint16_t port)
 {
@@ -202,8 +200,6 @@ void sa_set_in(struct sa *sa, uint32_t addr, uint16_t port)
  * @param sa   Socket Address
  * @param addr IPv6 address
  * @param port Port number
- *
- * @return 0 if success, otherwise errorcode
  */
 void sa_set_in6(struct sa *sa, const uint8_t *addr, uint16_t port)
 {

--- a/src/sipsess/sess.c
+++ b/src/sipsess/sess.c
@@ -282,6 +282,7 @@ int sipsess_set_close_headers(struct sipsess *sess, const char *hdrs, ...)
 /**
  * Send BYE and terminate session (useful when ACK has not been received)
  *
+ * @param sess      SIP Session
  */
 void sipsess_abort(struct sipsess *sess)
 {

--- a/src/stun/keepalive.c
+++ b/src/stun/keepalive.c
@@ -232,8 +232,6 @@ int stun_keepalive_alloc(struct stun_keepalive **skap,
  *
  * @param ska      Keepalive object
  * @param interval Interval in seconds (0 to disable)
- *
- * @return 0 if success, otherwise errorcode
  */
 void stun_keepalive_enable(struct stun_keepalive *ska, uint32_t interval)
 {

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -1452,6 +1452,8 @@ void tls_disable_verify_server(struct tls *tls)
  *
  * @param tls     TLS Object
  * @param version Minimum version, e.g.: TLS1_2_VERSION
+ *
+ * @return 0 if success, otherwise errorcode
  */
 int tls_set_min_proto_version(struct tls *tls, int version)
 {
@@ -1474,6 +1476,8 @@ int tls_set_min_proto_version(struct tls *tls, int version)
  *
  * @param tls     TLS Object
  * @param version Maximum version, e.g. TLS1_2_VERSION
+ *
+ * @return 0 if success, otherwise errorcode
  */
 int tls_set_max_proto_version(struct tls *tls, int version)
 {


### PR DESCRIPTION
this patch fixes some doxygen comments.

```
alfredh@debian:~/git/re$ make dox
warning: Tag 'COLS_IN_ALPHA_INDEX' at line 118 of file '../re-dox/Doxyfile' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'PERL_PATH' at line 207 of file '../re-dox/Doxyfile' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: argument 'a4wide' for option PAPER_TYPE is not a valid enum value
Using the default: a4!
/home/alfredh/git/re/src/trice/candpair.c:141: warning: parameters of member trice_candpair_prio_order are not (all) documented
/home/alfredh/git/re/src/trice/chklist.c:158: warning: parameters of member trice_conncheck_schedule_check are not (all) documented
/home/alfredh/git/re/src/trice/chklist.c:206: warning: parameters of member trice_checklist_set_waiting are not (all) documented
/home/alfredh/git/re/src/sipsess/connect.c:189: warning: argument 'desc' of command @param is not found in the argument list of sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock, const char *to_uri, const char *from_name, const char *from_uri, const char *cuser, const char *routev[], uint32_t routec, const char *ctype, sip_auth_h *authh, void *aarg, bool aref, const char *callid, sipsess_desc_h *desch, sipsess_offer_h *offerh, sipsess_answer_h *answerh, sipsess_progr_h *progrh, sipsess_estab_h *estabh, sipsess_info_h *infoh, sipsess_refer_h *referh, sipsess_close_h *closeh, void *arg, const char *fmt,...)
/home/alfredh/git/re/src/sipsess/connect.c:214: warning: The following parameters of sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock, const char *to_uri, const char *from_name, const char *from_uri, const char *cuser, const char *routev[], uint32_t routec, const char *ctype, sip_auth_h *authh, void *aarg, bool aref, const char *callid, sipsess_desc_h *desch, sipsess_offer_h *offerh, sipsess_answer_h *answerh, sipsess_progr_h *progrh, sipsess_estab_h *estabh, sipsess_info_h *infoh, sipsess_refer_h *referh, sipsess_close_h *closeh, void *arg, const char *fmt,...) are not documented:
  parameter 'callid'
  parameter 'desch'
/home/alfredh/git/re/src/stun/keepalive.c:238: warning: documented empty return type of stun_keepalive_enable
/home/alfredh/git/re/src/mod/mod_internal.h:15: warning: argument 'h' from the argument list of _mod_close has multiple @param documentation sections
/home/alfredh/git/re/src/mod/mod_internal.h:13: warning: argument 'name' from the argument list of _mod_open has multiple @param documentation sections
/home/alfredh/git/re/src/mod/mod_internal.h:14: warning: argument 'h' from the argument list of _mod_sym has multiple @param documentation sections
/home/alfredh/git/re/src/mod/mod_internal.h:14: warning: argument 'symbol' from the argument list of _mod_sym has multiple @param documentation sections
/home/alfredh/git/re/src/thread/posix.c:59: warning: return type of member thrd_current is not documented
/home/alfredh/git/re/include/re_thread.h:163: warning: argument 'lock' of command @param is not found in the argument list of cnd_wait(cnd_t *cnd, mtx_t *mtx)
/home/alfredh/git/re/src/thread/posix.c:115: warning: The following parameter of cnd_wait(cnd_t *cnd, mtx_t *mtx) is not documented:
  parameter 'mtx'
/home/alfredh/git/re/src/thread/posix.c:65: warning: parameters of member thrd_detach are not (all) documented
/home/alfredh/git/re/src/thread/posix.c:53: warning: parameters of member thrd_equal are not (all) documented
/home/alfredh/git/re/include/re_net.h:84: warning: argument 'ifh' from the argument list of net_if_list has multiple @param documentation sections
/home/alfredh/git/re/include/re_net.h:84: warning: argument 'arg' from the argument list of net_if_list has multiple @param documentation sections
/home/alfredh/git/re/include/re_sa.h:41: warning: documented empty return type of sa_set_in
/home/alfredh/git/re/include/re_sa.h:42: warning: documented empty return type of sa_set_in6
/home/alfredh/git/re/include/re_sipsess.h:70: warning: parameters of member sipsess_abort are not (all) documented
/home/alfredh/git/re/src/sipsess/connect.c:189: warning: argument 'desc' of command @param is not found in the argument list of sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock, const char *to_uri, const char *from_name, const char *from_uri, const char *cuser, const char *routev[], uint32_t routec, const char *ctype, sip_auth_h *authh, void *aarg, bool aref, const char *callid, sipsess_desc_h *desch, sipsess_offer_h *offerh, sipsess_answer_h *answerh, sipsess_progr_h *progrh, sipsess_estab_h *estabh, sipsess_info_h *infoh, sipsess_refer_h *referh, sipsess_close_h *closeh, void *arg, const char *fmt,...)
/home/alfredh/git/re/include/re_sipsess.h:31: warning: The following parameters of sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock, const char *to_uri, const char *from_name, const char *from_uri, const char *cuser, const char *routev[], uint32_t routec, const char *ctype, sip_auth_h *authh, void *aarg, bool aref, const char *callid, sipsess_desc_h *desch, sipsess_offer_h *offerh, sipsess_answer_h *answerh, sipsess_progr_h *progrh, sipsess_estab_h *estabh, sipsess_info_h *infoh, sipsess_refer_h *referh, sipsess_close_h *closeh, void *arg, const char *fmt,...) are not documented:
  parameter 'callid'
  parameter 'desch'
/home/alfredh/git/re/include/re_stun.h:278: warning: documented empty return type of stun_keepalive_enable
/home/alfredh/git/re/include/re_thread.h:86: warning: return type of member thrd_current is not documented
/home/alfredh/git/re/include/re_thread.h:163: warning: argument 'lock' of command @param is not found in the argument list of cnd_wait(cnd_t *cnd, mtx_t *mtx)
/home/alfredh/git/re/include/re_thread.h:168: warning: The following parameter of cnd_wait(cnd_t *cnd, mtx_t *mtx) is not documented:
  parameter 'mtx'
/home/alfredh/git/re/include/re_thread.h:94: warning: parameters of member thrd_detach are not (all) documented
/home/alfredh/git/re/include/re_thread.h:80: warning: parameters of member thrd_equal are not (all) documented
/home/alfredh/git/re/include/re_tls.h:74: warning: return type of member tls_set_max_proto_version is not documented
/home/alfredh/git/re/include/re_tls.h:73: warning: return type of member tls_set_min_proto_version is not documented
/home/alfredh/git/re/src/sa/sa.c:186: warning: documented empty return type of sa_set_in
/home/alfredh/git/re/src/sa/sa.c:208: warning: documented empty return type of sa_set_in6
/home/alfredh/git/re/src/sipsess/sess.c:286: warning: parameters of member sipsess_abort are not (all) documented
/home/alfredh/git/re/src/tls/openssl/tls.c:1478: warning: return type of member tls_set_max_proto_version is not documented
/home/alfredh/git/re/src/tls/openssl/tls.c:1456: warning: return type of member tls_set_min_proto_version is not documented
Doxygen docs in /home/alfredh/git/re-dox-2.3.0.tar.gz
alfredh@debian:~/git/re$ 
```
