### PR TITLE
dns: add query cache

### DIFF
--- a/include/re_dns.h
+++ b/include/re_dns.h
@@ -200,7 +200,7 @@ struct dnsc_conf {
 	uint32_t tcp_hash_size;
 	uint32_t conn_timeout;  /* in [ms] */
 	uint32_t idle_timeout;  /* in [ms] */
-	bool cache;
+	uint32_t cache_ttl_max; /* in [s] 0 for disabled */
 };
 
 int  dnsc_alloc(struct dnsc **dcpp, const struct dnsc_conf *conf,
@@ -219,7 +219,7 @@ int  dnsc_notify(struct dns_query **qp, struct dnsc *dnsc, const char *name,
 		 int proto, const struct sa *srvv, const uint32_t *srvc,
 		 dns_query_h *qh, void *arg);
 void dnsc_cache_flush(struct dnsc *dnsc);
-void dnsc_set_cache(struct dnsc *dnsc, bool enabled);
+void dnsc_cache_max(struct dnsc *dnsc, uint32_t max);
 
 
 /* DNS System functions */

--- a/include/re_dns.h
+++ b/include/re_dns.h
@@ -218,6 +218,7 @@ int  dnsc_notify(struct dns_query **qp, struct dnsc *dnsc, const char *name,
 		 uint16_t type, uint16_t dnsclass, const struct dnsrr *ans_rr,
 		 int proto, const struct sa *srvv, const uint32_t *srvc,
 		 dns_query_h *qh, void *arg);
+void dnsc_cache_flush(struct dnsc *dnsc);
 
 
 /* DNS System functions */

--- a/include/re_dns.h
+++ b/include/re_dns.h
@@ -200,6 +200,7 @@ struct dnsc_conf {
 	uint32_t tcp_hash_size;
 	uint32_t conn_timeout;  /* in [ms] */
 	uint32_t idle_timeout;  /* in [ms] */
+	bool cache;
 };
 
 int  dnsc_alloc(struct dnsc **dcpp, const struct dnsc_conf *conf,

--- a/include/re_dns.h
+++ b/include/re_dns.h
@@ -219,6 +219,7 @@ int  dnsc_notify(struct dns_query **qp, struct dnsc *dnsc, const char *name,
 		 int proto, const struct sa *srvv, const uint32_t *srvc,
 		 dns_query_h *qh, void *arg);
 void dnsc_cache_flush(struct dnsc *dnsc);
+void dnsc_set_cache(struct dnsc *dnsc, bool enabled);
 
 
 /* DNS System functions */

--- a/src/dns/client.c
+++ b/src/dns/client.c
@@ -321,10 +321,10 @@ static int reply_recv(struct dnsc *dnsc, struct mbuf *mb)
 		goto out;
 	}
 
-	/* 
+	/**
 	 * Don't cache empty RR answer if authority is also empty.
-	 * Otherwise negative answer is cached with respecting the SOA TTL. 
-	 * */
+	 * Otherwise negative answer is cached with respecting the SOA TTL.
+	 */
 	if ((!dq.hdr.nans && !dq.hdr.nauth)) {
 		mem_deref(q);
 		goto out;

--- a/src/dns/client.c
+++ b/src/dns/client.c
@@ -890,9 +890,11 @@ static void dnsc_destructor(void *data)
 
 	(void)hash_apply(dnsc->ht_query, query_close_handler, NULL);
 	hash_flush(dnsc->ht_tcpconn);
+	hash_flush(dnsc->ht_query_cache);
 
 	mem_deref(dnsc->ht_tcpconn);
 	mem_deref(dnsc->ht_query);
+	mem_deref(dnsc->ht_query_cache);
 	mem_deref(dnsc->us6);
 	mem_deref(dnsc->us);
 }

--- a/src/dns/client.c
+++ b/src/dns/client.c
@@ -984,7 +984,7 @@ int dnsc_conf_set(struct dnsc *dnsc, const struct dnsc_conf *conf)
 	err = hash_alloc(&dnsc->ht_query, dnsc->conf.query_hash_size);
 	if (err)
 		return err;
-	
+
 	err = hash_alloc(&dnsc->ht_query_cache, dnsc->conf.query_hash_size);
 	if (err)
 		return err;

--- a/src/dns/client.c
+++ b/src/dns/client.c
@@ -304,7 +304,7 @@ static int reply_recv(struct dnsc *dnsc, struct mbuf *mb)
 	hash_append(dnsc->ht_query_cache, hash_joaat_str_ci(q->name), &q->le,
 		    q);
 	/*@TODO use shortest RR TTL */
-	tmr_start(&q->tmr, 60, ttl_timeout_handler, q);
+	tmr_start(&q->tmr, 60 * 1000, ttl_timeout_handler, q);
 
  out:
 	mem_deref(dq.name);


### PR DESCRIPTION
If `dnsc_query` is used on a server its possible to add a local dns resolver for caching (like unbound). But on desktop or mobile  this is not always possible. Some nameservers/resolvers (e.g. cheap routers) can't handle many dns requests. This PR introduces a query caching (takes into account the lowest resource record TTL).