### PR TITLE
tmr: add tmr_start_dbg

### DIFF
--- a/include/re_tmr.h
+++ b/include/re_tmr.h
@@ -33,7 +33,10 @@ int      tmr_status(struct re_printf *pf, void *unused);
 void     tmr_init(struct tmr *tmr);
 void     tmr_start_dbg(struct tmr *tmr, uint64_t delay, tmr_h *th, void *arg,
 		   char *file, int line);
+
 /**
+ * @def tmr_start(tmr, delay, th, arg)
+ *
  * Start a timer
  *
  * @param tmr   Timer to start
@@ -41,8 +44,8 @@ void     tmr_start_dbg(struct tmr *tmr, uint64_t delay, tmr_h *th, void *arg,
  * @param th    Timeout handler
  * @param arg   Handler argument
  */
-#define  tmr_start(tmr, delay, th, arg)                                       \
-	 tmr_start_dbg(tmr, delay, th, arg, __FILE__, __LINE__)
+#define tmr_start(tmr, delay, th, arg)                                        \
+	tmr_start_dbg(tmr, delay, th, arg, __FILE__, __LINE__)
 
 void     tmr_cancel(struct tmr *tmr);
 uint64_t tmr_get_expire(const struct tmr *tmr);

--- a/include/re_tmr.h
+++ b/include/re_tmr.h
@@ -18,6 +18,8 @@ struct tmr {
 	tmr_h *th;          /**< Timeout handler     */
 	void *arg;          /**< Handler argument    */
 	uint64_t jfs;       /**< Jiffies for timeout */
+	char *file;
+	int line;
 };
 
 
@@ -29,7 +31,19 @@ void     tmr_debug(void);
 int      tmr_status(struct re_printf *pf, void *unused);
 
 void     tmr_init(struct tmr *tmr);
-void     tmr_start(struct tmr *tmr, uint64_t delay, tmr_h *th, void *arg);
+void     tmr_start_dbg(struct tmr *tmr, uint64_t delay, tmr_h *th, void *arg,
+		   char *file, int line);
+/**
+ * Start a timer
+ *
+ * @param tmr   Timer to start
+ * @param delay Timer delay in [ms]
+ * @param th    Timeout handler
+ * @param arg   Handler argument
+ */
+#define  tmr_start(tmr, delay, th, arg)                                       \
+	 tmr_start_dbg(tmr, delay, th, arg, __FILE__, __LINE__)
+
 void     tmr_cancel(struct tmr *tmr);
 uint64_t tmr_get_expire(const struct tmr *tmr);
 

--- a/src/tmr/tmr.c
+++ b/src/tmr/tmr.c
@@ -211,10 +211,10 @@ int tmr_status(struct re_printf *pf, void *unused)
 
 	for (le = tmrl->head; le; le = le->next) {
 		const struct tmr *tmr = le->data;
-
-		err |= re_hprintf(pf, "  %p: th=%p expire=%llums\n",
+		err |= re_hprintf(pf, "  %p: th=%p expire=%llums file=%s:%d\n",
 				  tmr, tmr->th,
-				  (unsigned long long)tmr_get_expire(tmr));
+				  (unsigned long long)tmr_get_expire(tmr),
+				  tmr->file, tmr->line);
 	}
 
 	if (n > 100)
@@ -248,15 +248,8 @@ void tmr_init(struct tmr *tmr)
 }
 
 
-/**
- * Start a timer
- *
- * @param tmr   Timer to start
- * @param delay Timer delay in [ms]
- * @param th    Timeout handler
- * @param arg   Handler argument
- */
-void tmr_start(struct tmr *tmr, uint64_t delay, tmr_h *th, void *arg)
+void tmr_start_dbg(struct tmr *tmr, uint64_t delay, tmr_h *th, void *arg,
+		   char *file, int line)
 {
 	struct list *tmrl = tmrl_get();
 	struct le *le;
@@ -268,8 +261,10 @@ void tmr_start(struct tmr *tmr, uint64_t delay, tmr_h *th, void *arg)
 		list_unlink(&tmr->le);
 	}
 
-	tmr->th  = th;
-	tmr->arg = arg;
+	tmr->th	  = th;
+	tmr->arg  = arg;
+	tmr->file = file;
+	tmr->line = line;
 
 	if (!th)
 		return;


### PR DESCRIPTION
```
Timers (7):
  0x55ed532a83f0: th=0x55ed5112b300 expire=250ms file=modules/stdio/stdio.c:89
  0x55ed533f9838: th=0x55ed51140480 expire=20199ms file=src/sipreg/reg.c:263
  0x55ed511d5b68: th=0x55ed511278c0 expire=57578ms file=modules/netroam/netroam.c:206
  0x55ed533a14d0: th=0x55ed5115bd90 expire=119579ms file=src/dns/client.c:350
  0x55ed533850d0: th=0x55ed5115bd90 expire=119676ms file=src/dns/client.c:350
  0x55ed53371710: th=0x55ed5115bd90 expire=297676ms file=src/dns/client.c:350
  0x55ed534e1ef0: th=0x55ed5113bcb0 expire=897699ms file=src/sip/transp.c:526
```