### PR TITLE
tls: Switch from EVP_sha1() to EVP_sha256() when using it for X509_sign()

### DIFF
--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -692,7 +692,7 @@ int tls_set_selfsigned_rsa(struct tls *tls, const char *cn, size_t bits)
 	if (!X509_set_pubkey(cert, key))
 		goto out;
 
-	if (!X509_sign(cert, key, EVP_sha1()))
+	if (!X509_sign(cert, key, EVP_sha256()))
 		goto out;
 
 	r = SSL_CTX_use_certificate(tls->ctx, cert);


### PR DESCRIPTION
Red Hat Enterprise Linux 9 does not support SHA-1 (by default) in digital signatures and certificates, see also their "security hardening" document: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening

Without this change, baresip's `./selftest` fails with "dtls_srtp: failed to self-sign certificate (Cannot allocate memory)" on both, CentOS Stream 9 and Red Hat Enterprise Linux 9. Fedora will likely inherit this behaviour: https://fedoraproject.org/wiki/Changes/StrongCryptoSettings3Forewarning1

For me this pull request fixes https://github.com/baresip/baresip/issues/1869