### PR TITLE
tls: deprecate old version specific tls methods

### DIFF
--- a/include/re_tls.h
+++ b/include/re_tls.h
@@ -15,10 +15,11 @@ typedef struct ssl_ctx_st SSL_CTX;
 
 /** Defines the TLS method */
 enum tls_method {
-	TLS_METHOD_SSLV23,
-	TLS_METHOD_DTLSV1,
+	TLS_METHOD_TLS,
+	TLS_METHOD_SSLV23,    /* deprecated - fallback to TLS_METHOD_TLS */
 	TLS_METHOD_DTLS,      /* DTLS 1.0 and 1.2 */
-	TLS_METHOD_DTLSV1_2,  /* DTLS 1.2 */
+	TLS_METHOD_DTLSV1,    /* deprecated - fallback to TLS_METHOD_DTLS */
+	TLS_METHOD_DTLSV1_2,  /* deprecated - fallback to TLS_METHOD_DTLS */
 };
 
 enum tls_fingerprint {

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -205,40 +205,16 @@ int tls_alloc(struct tls **tlsp, enum tls_method method, const char *keyfile,
 	tls->verify_server = true;
 	switch (method) {
 
+	case TLS_METHOD_TLS:
 	case TLS_METHOD_SSLV23:
-		tls->ctx = SSL_CTX_new(SSLv23_method());
+		tls->ctx = SSL_CTX_new(TLS_method());
 		break;
-
-#ifdef USE_OPENSSL_DTLS
-	case TLS_METHOD_DTLSV1:
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	!defined(LIBRESSL_VERSION_NUMBER)
-
-		tls->ctx = SSL_CTX_new(DTLS_method());
-#else
-		tls->ctx = SSL_CTX_new(DTLSv1_method());
-#endif
-		break;
-
-#ifdef SSL_OP_NO_DTLSv1_2
-		/* DTLS v1.2 is available in OpenSSL 1.0.2 and later */
 
 	case TLS_METHOD_DTLS:
-		tls->ctx = SSL_CTX_new(DTLS_method());
-		break;
-
+	case TLS_METHOD_DTLSV1:
 	case TLS_METHOD_DTLSV1_2:
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	!defined(LIBRESSL_VERSION_NUMBER)
-
 		tls->ctx = SSL_CTX_new(DTLS_method());
-#else
-		tls->ctx = SSL_CTX_new(DTLSv1_2_method());
-#endif
 		break;
-#endif
-
-#endif
 
 	default:
 		DEBUG_WARNING("tls method %d not supported\n", method);


### PR DESCRIPTION
only TLS_method() and DTLS_method() should be used now