### PR TITLE
main: add support for external poll

### DIFF
--- a/include/re_main.h
+++ b/include/re_main.h
@@ -4,20 +4,6 @@
  * Copyright (C) 2010 Creytiv.com
  */
 
-#ifdef HAVE_SELECT
-#include <sys/select.h>
-#endif
-#ifdef HAVE_POLL
-#include <poll.h>
-#endif
-#ifdef HAVE_EPOLL
-#include <sys/epoll.h>
-#endif
-#ifdef HAVE_KQUEUE
-#include <sys/types.h>
-#include <sys/event.h>
-#include <sys/time.h>
-#endif
 
 enum {
 #ifndef FD_READ
@@ -57,22 +43,6 @@ void  libre_close(void);
 int   re_main(re_signal_h *signalh);
 void  re_cancel(void);
 int   re_debug(struct re_printf *pf, void *unused);
-
-#ifdef HAVE_SELECT
-int re_prepare_select(int maxfds,
-		fd_set *rfds, fd_set *wfds, fd_set *efds);
-#endif
-#ifdef HAVE_POLL
-int re_prepare_poll(int maxfds, struct pollfd *fds);
-#endif
-#ifdef HAVE_EPOLL
-int re_prepare_epoll(int maxfds, struct epoll_event *events, int epfd);
-#endif
-#ifdef HAVE_KQUEUE
-int re_prepare_kqueue(int maxfds, struct kevent *evlist, int kqfd);
-#endif
-int re_process(int n);
-uint64_t re_next_timeout(void);
 
 int  re_thread_init(void);
 void re_thread_close(void);

--- a/include/re_poll.h
+++ b/include/re_poll.h
@@ -1,0 +1,22 @@
+/**
+ * @file re_poll.h  Interface to external main polling
+ *
+ * Copyright (C) 2022 Commend.com - c.spielberger@commend.com
+ */
+
+#ifdef HAVE_SELECT
+int re_prepare_select(int maxfds,
+		fd_set *rfds, fd_set *wfds, fd_set *efds);
+#endif
+#ifdef HAVE_POLL
+int re_prepare_poll(int maxfds, struct pollfd *fds);
+#endif
+#ifdef HAVE_EPOLL
+int re_prepare_epoll(int maxfds, struct epoll_event *events, int epfd);
+#endif
+#ifdef HAVE_KQUEUE
+int re_prepare_kqueue(int maxfds, struct kevent *evlist, int kqfd);
+#endif
+int re_process(int n);
+uint64_t re_next_timeout(void);
+

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -46,6 +46,7 @@
 #include <re_list.h>
 #include <re_tmr.h>
 #include <re_main.h>
+#include <re_poll.h>
 #include <re_thread.h>
 #include "main.h"
 


### PR DESCRIPTION
Adds functions re_prepare_select, re_prepare_poll, re_prepare_epoll and
re_prepare_kqueue for passing external file descriptor polling data to libre.
This can be used in order to run libres file descriptor processing in
the applications thread.

If an application has it's own polling loop, one of the new prepare-functions
will prepare libre for the external polling. In the polling loop the new
function re_process should be called, instead of the blocking function re_main.

Example:
```c
struct epoll_event *events = mem_zalloc(MAXFDS * sizeof(*events), NULL);
int epfd = epoll_create(MAXFDS);

re_prepare_epoll(MAXFDS, events, epfd);
...
while (run)  {
    long int to;
    int n;

    to = re_next_timeout();
    n = epoll_wait(epfd, events, MAXFDS, to ? (int)to : -1);

    re_process(n);
}
```

Note: I realized that this commit should go mainline first. If you find this useful. The PR for the planned real-time polling loop will follow.