### PR TITLE
http/client: use mem_zalloc in read_file

### DIFF
--- a/src/http/client.c
+++ b/src/http/client.c
@@ -634,7 +634,7 @@ static int read_file(char **pbuf, const char *path)
 	}
 	fseek(f, 0L, SEEK_SET);
 
-	buf = mem_alloc(s + 1, NULL);
+	buf = mem_zalloc(s + 1, NULL);
 	if (!buf) {
 		DEBUG_WARNING("Could not allocate cert file buffer\n");
 		fclose(f);
@@ -643,7 +643,6 @@ static int read_file(char **pbuf, const char *path)
 
 	n = fread(buf, 1, s, f);
 	fclose(f);
-	buf[s] = 0;
 	if (n < (size_t)s) {
 		mem_deref(buf);
 		return EIO;


### PR DESCRIPTION
I'm not seeing a out of bound write here, but maybe sonarcloud is smarter than me ;-) mem_zalloc should do the same trick.

https://sonarcloud.io/project/issues?resolved=false&types=BUG&id=baresip_re&open=AYEfQMmCkjI3J5RdCqEz