### PR TITLE
tls/dtls: fix handle timeout

### DIFF
--- a/src/tls/openssl/tls_udp.c
+++ b/src/tls/openssl/tls_udp.c
@@ -212,7 +212,7 @@ static void timeout(void *arg)
 
 	DEBUG_INFO("timeout\n");
 
-	if (0 <= DTLSv1_handle_timeout(tc->ssl)) {
+	if (0 >= DTLSv1_handle_timeout(tc->ssl)) {
 
 		check_timer(tc);
 	}


### PR DESCRIPTION
DTLSv1_handle_timeout is called when a DTLS handshake timeout expires. If no timeout had expired, it returns 0. Otherwise, it retransmits the previous flight of handshake messages and returns 1. If too many timeouts had expired without progress or an error occurs, it returns -1.

https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#DTLSv1_handle_timeout