### PR TITLE
main: refactor libre_init and re_global handling

### DIFF
--- a/src/main/init.c
+++ b/src/main/init.c
@@ -31,7 +31,6 @@ int libre_init(void)
 	if (err)
 		net_sock_close();
 
-
 	err = re_thread_init();
 
 	return err;

--- a/src/main/init.c
+++ b/src/main/init.c
@@ -28,8 +28,10 @@ int libre_init(void)
 #endif
 
 	err = net_sock_init();
-	if (err)
+	if (err) {
 		net_sock_close();
+		return err;
+	}
 
 	err = re_thread_init();
 

--- a/src/main/init.c
+++ b/src/main/init.c
@@ -31,6 +31,9 @@ int libre_init(void)
 	if (err)
 		net_sock_close();
 
+
+	err = re_thread_init();
+
 	return err;
 }
 
@@ -42,4 +45,5 @@ void libre_close(void)
 {
 	(void)fd_setsize(0);
 	net_sock_close();
+	re_thread_close();
 }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -131,7 +131,7 @@ static int re_init(struct re **re)
 	if (!re_alloc)
 		return ENOMEM;
 
-	memset(re_alloc, 0, sizeof(*re_alloc));
+	memset(re_alloc, 0, sizeof(struct re));
 
 	err = mtx_init(&re_alloc->mutex, mtx_plain);
 	if (err) {
@@ -154,7 +154,7 @@ static int re_init(struct re **re)
 
 out:
 	if (err)
-		mem_deref(re_alloc);
+		free(re_alloc);
 	else
 		*re = re_alloc;
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1197,22 +1197,14 @@ int re_thread_init(void)
 		DEBUG_WARNING("thread_init: already added for thread\n");
 		return EALREADY;
 	}
-
-	if (!re_global) {
-		err = re_alloc(&re_global);
-		if (err) {
-			DEBUG_WARNING("re_init_global failed: %d\n", err);
-			exit(err);
-		}
-		re = re_global;
-		goto out;
-	}
-
+	
 	err = re_alloc(&re);
 	if (err)
 		return err;
 
-out:
+	if (!re_global)
+		re_global = re;
+
 	err = tss_set(key, re);
 	if (err)
 		DEBUG_WARNING("thread_init: tss_set error\n");

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -112,10 +112,10 @@ static once_flag flag = ONCE_FLAG_INIT;
 static void poll_close(struct re *re);
 
 
-static void re_destruct(void *arg)
+static void re_destructor(void *arg)
 {
 	struct re *re = arg;
-	
+
 	poll_close(re);
 	mtx_destroy(&re->mutex);
 }
@@ -133,7 +133,6 @@ static void thread_destructor(void *arg)
 }
 
 
-
 static int re_alloc(struct re **rep)
 {
 	struct re *re;
@@ -142,7 +141,7 @@ static int re_alloc(struct re **rep)
 	if (!rep)
 		return EINVAL;
 
-	re = mem_zalloc(sizeof(struct re), re_destruct);
+	re = mem_zalloc(sizeof(struct re), re_destructor);
 	if (!re)
 		return ENOMEM;
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -593,6 +593,11 @@ int fd_listen(re_sock_t fd, int flags, fd_h *fh, void *arg)
 	int err = 0;
 	int i;
 
+	if (!re) {
+		DEBUG_WARNING("fd_listen: re not ready");
+		return EINVAL;
+	}
+
 	DEBUG_INFO("fd_listen: fd=%d flags=0x%02x\n", fd, flags);
 
 #ifndef RELEASE
@@ -979,6 +984,11 @@ void fd_debug(void)
 	const struct re *re = re_get();
 	int i;
 
+	if (!re) {
+		DEBUG_WARNING("fd_debug: re not ready");
+		return;
+	}
+
 	if (!re->fhs)
 		return;
 
@@ -999,8 +1009,15 @@ void fd_debug(void)
 /* Thread-safe signal handling */
 static void signal_handler(int sig)
 {
+	struct re *re = re_get();
+
+	if (!re) {
+		DEBUG_WARNING("signal_handler: re not ready");
+		return;
+	}
+
 	(void)signal(sig, signal_handler);
-	re_get()->sig = sig;
+	re->sig = sig;
 }
 #endif
 
@@ -1017,6 +1034,11 @@ int re_main(re_signal_h *signalh)
 {
 	struct re *re = re_get();
 	int err;
+
+	if (!re) {
+		DEBUG_WARNING("re_main: re not ready");
+		return EINVAL;
+	}
 
 #ifdef HAVE_SIGNAL
 	if (signalh) {
@@ -1094,6 +1116,11 @@ void re_cancel(void)
 {
 	struct re *re = re_get();
 
+	if (!re) {
+		DEBUG_WARNING("re_cancel: re not ready");
+		return;
+	}
+
 	re->polling = false;
 }
 
@@ -1112,6 +1139,11 @@ int re_debug(struct re_printf *pf, void *unused)
 	int err = 0;
 
 	(void)unused;
+
+	if (!re) {
+		DEBUG_WARNING("re_debug: re not ready");
+		return EINVAL;
+	}
 
 	err |= re_hprintf(pf, "re main loop:\n");
 	err |= re_hprintf(pf, "  maxfds:  %d\n", re->maxfds);
@@ -1246,6 +1278,11 @@ void re_thread_enter(void)
 {
 	struct re *re = re_get();
 
+	if (!re) {
+		DEBUG_WARNING("re_thread_enter: re not ready");
+		return;
+	}
+
 	re->thread_enter = true;
 	re_lock(re);
 }
@@ -1260,6 +1297,11 @@ void re_thread_leave(void)
 {
 	struct re *re = re_get();
 
+	if (!re) {
+		DEBUG_WARNING("re_thread_leave: re not ready");
+		return;
+	}
+
 	re->thread_enter = false;
 	re_unlock(re);
 }
@@ -1273,6 +1315,11 @@ void re_thread_leave(void)
 void re_set_mutex(void *mutexp)
 {
 	struct re *re = re_get();
+
+	if (!re) {
+		DEBUG_WARNING("re_set_mutex: re not ready");
+		return;
+	}
 
 	re->mutexp = mutexp ? mutexp : &re->mutex;
 }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1180,7 +1180,7 @@ int poll_method_set(enum poll_method method)
 
 /**
  * Add a worker thread for this thread
- * 
+ *
  * @note: for main thread this is called by libre_init
  *
  * @return 0 if success, otherwise errorcode

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -187,6 +187,7 @@ static struct re *re_get(void)
 	re = tss_get(key);
 	if (!re)
 		re = re_global;
+
 	return re;
 }
 
@@ -913,8 +914,8 @@ static int fd_poll(struct re *re)
 /**
  * Set the maximum number of file descriptors
  *
- * @note Only first call inits maxfds and fhs, so call before re_main() in
- * custom applications.
+ * @note Only first call inits maxfds and fhs, so call after libre_init() and
+ * before re_main() in custom applications.
  *
  * @param maxfds Max FDs. 0 to free and -1 for RLIMIT_NOFILE (Linux/Unix only)
  *
@@ -924,6 +925,11 @@ static int fd_poll(struct re *re)
 int fd_setsize(int maxfds)
 {
 	struct re *re = re_get();
+
+	if (!re) {
+		DEBUG_WARNING("fd_setsize: libre_init is not ready\n");
+		return EINVAL;
+	}
 
 	if (!maxfds) {
 		fd_debug();
@@ -1179,7 +1185,7 @@ int poll_method_set(enum poll_method method)
 /**
  * Add a worker thread for this thread
  *
- * @note: for main thread this is called by libre_init
+ * @note: for main thread this is called by libre_init()
  *
  * @return 0 if success, otherwise errorcode
  */

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1297,8 +1297,8 @@ void re_thread_enter(void)
 		return;
 	}
 
-	re->thread_enter = true;
 	re_lock(re);
+	re->thread_enter = true;
 }
 
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -179,6 +179,13 @@ static void re_once(void)
 }
 
 
+/**
+ * Get thread specific re pointer (fallback to re_global if called by non re
+ * thread)
+ *
+ * @return re pointer on success, otherwise NULL if libre_init() or
+ * re_thread_init() is missing
+ */
 static struct re *re_get(void)
 {
 	struct re *re;

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -133,11 +133,9 @@ static int re_alloc(struct re **rep)
 	if (!rep)
 		return EINVAL;
 
-	re = mem_alloc(sizeof(struct re), NULL);
+	re = mem_zalloc(sizeof(struct re), NULL);
 	if (!re)
 		return ENOMEM;
-
-	memset(re, 0, sizeof(struct re));
 
 	err = mtx_init(&re->mutex, mtx_plain);
 	if (err) {

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -932,7 +932,7 @@ int fd_setsize(int maxfds)
 	struct re *re = re_get();
 
 	if (!re) {
-		DEBUG_WARNING("fd_setsize: libre_init is not ready\n");
+		DEBUG_WARNING("fd_setsize: re not ready\n");
 		return EINVAL;
 	}
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1346,7 +1346,6 @@ void re_set_mutex(void *mutexp)
 int re_thread_check(void)
 {
 	struct re *re = re_get();
-	struct btrace trace;
 
 	if (!re)
 		return EINVAL;
@@ -1357,10 +1356,14 @@ int re_thread_check(void)
 	if (thrd_equal(re->tid, thrd_current()))
 		return 0;
 
-	btrace(&trace);
-
 	DEBUG_WARNING("thread check: called from a NON-RE thread without "
-		      "thread_enter()!\n %H", btrace_println, &trace);
+		      "thread_enter()!\n");
+
+#if DEBUG_LEVEL > 5
+	struct btrace trace;
+	btrace(&trace);
+	DEBUG_INFO("%H", btrace_println, &trace);
+#endif
 
 	return EPERM;
 }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1197,7 +1197,7 @@ int re_thread_init(void)
 		DEBUG_WARNING("thread_init: already added for thread\n");
 		return EALREADY;
 	}
-	
+
 	err = re_alloc(&re);
 	if (err)
 		return err;

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -594,7 +594,7 @@ int fd_listen(re_sock_t fd, int flags, fd_h *fh, void *arg)
 	int i;
 
 	if (!re) {
-		DEBUG_WARNING("fd_listen: re not ready");
+		DEBUG_WARNING("fd_listen: re not ready\n");
 		return EINVAL;
 	}
 
@@ -985,7 +985,7 @@ void fd_debug(void)
 	int i;
 
 	if (!re) {
-		DEBUG_WARNING("fd_debug: re not ready");
+		DEBUG_WARNING("fd_debug: re not ready\n");
 		return;
 	}
 
@@ -1012,7 +1012,7 @@ static void signal_handler(int sig)
 	struct re *re = re_get();
 
 	if (!re) {
-		DEBUG_WARNING("signal_handler: re not ready");
+		DEBUG_WARNING("signal_handler: re not ready\n");
 		return;
 	}
 
@@ -1036,7 +1036,7 @@ int re_main(re_signal_h *signalh)
 	int err;
 
 	if (!re) {
-		DEBUG_WARNING("re_main: re not ready");
+		DEBUG_WARNING("re_main: re not ready\n");
 		return EINVAL;
 	}
 
@@ -1117,7 +1117,7 @@ void re_cancel(void)
 	struct re *re = re_get();
 
 	if (!re) {
-		DEBUG_WARNING("re_cancel: re not ready");
+		DEBUG_WARNING("re_cancel: re not ready\n");
 		return;
 	}
 
@@ -1141,7 +1141,7 @@ int re_debug(struct re_printf *pf, void *unused)
 	(void)unused;
 
 	if (!re) {
-		DEBUG_WARNING("re_debug: re not ready");
+		DEBUG_WARNING("re_debug: re not ready\n");
 		return EINVAL;
 	}
 
@@ -1279,7 +1279,7 @@ void re_thread_enter(void)
 	struct re *re = re_get();
 
 	if (!re) {
-		DEBUG_WARNING("re_thread_enter: re not ready");
+		DEBUG_WARNING("re_thread_enter: re not ready\n");
 		return;
 	}
 
@@ -1298,7 +1298,7 @@ void re_thread_leave(void)
 	struct re *re = re_get();
 
 	if (!re) {
-		DEBUG_WARNING("re_thread_leave: re not ready");
+		DEBUG_WARNING("re_thread_leave: re not ready\n");
 		return;
 	}
 
@@ -1317,7 +1317,7 @@ void re_set_mutex(void *mutexp)
 	struct re *re = re_get();
 
 	if (!re) {
-		DEBUG_WARNING("re_set_mutex: re not ready");
+		DEBUG_WARNING("re_set_mutex: re not ready\n");
 		return;
 	}
 
@@ -1365,8 +1365,10 @@ struct list *tmrl_get(void)
 {
 	struct re *re = re_get();
 
-	if (!re)
+	if (!re) {
+		DEBUG_WARNING("tmrl_get: re not ready\n");
 		return NULL;
+	}
 
 	return &re->tmrl;
 }


### PR DESCRIPTION
Fixes #403

`re_global` is now created by `libre_init` (first `re_thread_init`) and deleted with `libre_close` and leaves a clean state (no leaking re_global pointer). This breaks `tmr_debug`  (shows nothing) if called after `libre_close`.  

These changes are needed on application side:

```c
/* check for open timers */
tmr_debug();

libre_close();

/* check for memory leaks */
mem_debug();
```

Also `fd_setsize` is affected if called before `libre_init`, new order:

```c
libre_init();
fd_setsize(-1);
```

I think leaving libre in a clean state after `libre_close` is worth it. I added sanity checks and warnings (like `fd_setsize: re not ready`) for applications.