### PR TITLE
jbuf: Add drain method

### DIFF
--- a/include/re_jbuf.h
+++ b/include/re_jbuf.h
@@ -32,6 +32,7 @@ int  jbuf_alloc(struct jbuf **jbp, uint32_t min, uint32_t max);
 int  jbuf_set_type(struct jbuf *jb, enum jbuf_type jbtype);
 int  jbuf_put(struct jbuf *jb, const struct rtp_header *hdr, void *mem);
 int  jbuf_get(struct jbuf *jb, struct rtp_header *hdr, void **mem);
+int  jbuf_drain(struct jbuf *jb, struct rtp_header *hdr, void **mem);
 void jbuf_flush(struct jbuf *jb);
 int  jbuf_stats(const struct jbuf *jb, struct jbuf_stat *jstat);
 int  jbuf_debug(struct re_printf *pf, const struct jbuf *jb);


### PR DESCRIPTION
Draining jitter buffer is useful when the inbound RTP stream is closed, and the application wishes to process buffered packets (e.g. to assemble the last received video frame).