### PR TITLE
uag: add timestamps to SIP trace

### DIFF
--- a/include/re_fmt.h
+++ b/include/re_fmt.h
@@ -132,6 +132,7 @@ static inline bool str_isset(const char *s)
 
 /* time */
 int  fmt_gmtime(struct re_printf *pf, void *ts);
+int  fmt_timestamp(struct re_printf *pf, void *ts);
 int  fmt_human_time(struct re_printf *pf, const uint32_t *seconds);
 
 

--- a/src/fmt/time.c
+++ b/src/fmt/time.c
@@ -92,12 +92,12 @@ int fmt_human_time(struct re_printf *pf, const uint32_t *seconds)
 /**
  * Print local time stamp including milli seconds relative to user's timezone
  *
- * @param pf Print function for output
- * @param ts Time in seconds since the Epoch or NULL for current time
+ * @param pf  Print function for output
+ * @param arg Not used
  *
  * @return 0 if success, otherwise errorcode
  */
-int fmt_timestamp(struct re_printf *pf, void *ts)
+int fmt_timestamp(struct re_printf *pf, void *arg)
 {
 	int h, m, s;
 	uint64_t ms;
@@ -122,7 +122,7 @@ int fmt_timestamp(struct re_printf *pf, void *ts)
 	m = tm.tm_min;
 	s = tm.tm_sec;
 #endif
-	(void) ts;
+	(void) arg;
 
 	return re_hprintf(pf, "%02u:%02u:%02u.%03d", h, m, s, ms);
 }

--- a/src/fmt/time.c
+++ b/src/fmt/time.c
@@ -8,6 +8,10 @@
 #define __USE_POSIX 1 /**< Use POSIX flag */
 #include <time.h>
 
+#ifdef WIN32
+#include <windows.h>
+#endif
+
 #include <re_types.h>
 #include <re_fmt.h>
 


### PR DESCRIPTION
Adds a print function for timestamps to module `fmt`.