### PR TITLE
main: Add support for external threads attaching/detaching re context

### DIFF
--- a/include/re_main.h
+++ b/include/re_main.h
@@ -4,6 +4,7 @@
  * Copyright (C) 2010 Creytiv.com
  */
 
+struct re;
 
 enum {
 #ifndef FD_READ
@@ -43,6 +44,10 @@ void  libre_close(void);
 int   re_main(re_signal_h *signalh);
 void  re_cancel(void);
 int   re_debug(struct re_printf *pf, void *unused);
+
+int  re_alloc(struct re **rep);
+int  re_thread_attach(struct re *re);
+void re_thread_detach(void);
 
 int  re_thread_init(void);
 void re_thread_close(void);


### PR DESCRIPTION
This commit allows to create an event loop context and keep a reference to it in the caller application. After that, this and other threads are allowed to attach to and detach from this context as needed. Threads are synchronized by calling `re_thread_enter`/`leave`. The re context can be destroyed by calling `mem_deref`.

This is useful to allow threads that are not running event loop to invoke methods on an event loop context that is created and managed by another thread.