### PR TITLE
sip: add RFC 3262 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,6 +491,7 @@ if(USE_SIP)
     src/sip/keepalive.c
     src/sip/keepalive_udp.c
     src/sip/msg.c
+    src/sip/rack.c
     src/sip/reply.c
     src/sip/request.c
     src/sip/sip.c
@@ -512,6 +513,7 @@ if(USE_SIP)
     src/sipsess/info.c
     src/sipsess/listen.c
     src/sipsess/modify.c
+    src/sipsess/prack.c
     src/sipsess/reply.c
     src/sipsess/request.c
     src/sipsess/sess.c

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ legend:
 * [RFC 2782](https://tools.ietf.org/html/rfc2782) - A DNS RR for Specifying the Location of Services (DNS SRV)
 * [RFC 2915](https://tools.ietf.org/html/rfc2915) - The Naming Authority Pointer (NAPTR) DNS Resource Record
 * [RFC 3261](https://tools.ietf.org/html/rfc3261) - SIP: Session Initiation Protocol
+* [RFC 3262](https://tools.ietf.org/html/rfc3262) - SIP Reliability of Provisional Responses
 * [RFC 3263](https://tools.ietf.org/html/rfc3263) - Locating SIP Servers
 * [RFC 3264](https://tools.ietf.org/html/rfc3264) - An Offer/Answer Model with SDP
 * [RFC 3265](https://tools.ietf.org/html/rfc3265) - SIP-Specific Event Notification

--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -135,6 +135,13 @@ enum sip_hdrid {
 };
 
 
+enum rel100_mode {
+	REL100_DISABLED = 0,
+	REL100_ENABLED,
+	REL100_REQUIRED,
+};
+
+
 enum {
 	SIP_T1 =  500,
 	SIP_T2 = 4000,
@@ -176,6 +183,13 @@ struct sip_cseq {
 	uint32_t num;
 };
 
+/** SIP RAck header (RFC 3262) */
+struct sip_rack {
+	struct pl met;
+	uint32_t rel_seq;
+	uint32_t cseq;
+};
+
 /** SIP Header */
 struct sip_hdr {
 	struct le le;          /**< Linked-list element    */
@@ -200,6 +214,8 @@ struct sip_msg {
 	struct sip_taddr to;   /**< Parsed To header                     */
 	struct sip_taddr from; /**< Parsed From header                   */
 	struct sip_cseq cseq;  /**< Parsed CSeq header                   */
+	struct sip_rack rack;  /**< Parsed RAck header (RFC 3262)        */
+	uint32_t rel_seq;	   /**< RSeq number (RFC 3262)               */
 	struct msg_ctype ctyp; /**< Content Type                         */
 	struct pl callid;      /**< Cached Call-ID header                */
 	struct pl maxfwd;      /**< Cached Max-Forwards header           */
@@ -397,6 +413,7 @@ void sip_msg_dump(const struct sip_msg *msg);
 int sip_addr_decode(struct sip_addr *addr, const struct pl *pl);
 int sip_via_decode(struct sip_via *via, const struct pl *pl);
 int sip_cseq_decode(struct sip_cseq *cseq, const struct pl *pl);
+int sip_rack_decode(struct sip_rack *rack, const struct pl *pl);
 
 
 /* keepalive */

--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -215,7 +215,7 @@ struct sip_msg {
 	struct sip_taddr from; /**< Parsed From header                   */
 	struct sip_cseq cseq;  /**< Parsed CSeq header                   */
 	struct sip_rack rack;  /**< Parsed RAck header (RFC 3262)        */
-	uint32_t rel_seq;	   /**< RSeq number (RFC 3262)               */
+	uint32_t rel_seq;      /**< RSeq number (RFC 3262)               */
 	struct msg_ctype ctyp; /**< Content Type                         */
 	struct pl callid;      /**< Cached Call-ID header                */
 	struct pl maxfwd;      /**< Cached Max-Forwards header           */

--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -137,8 +137,8 @@ enum sip_hdrid {
 
 enum rel100_mode {
 	REL100_DISABLED = 0,
-	REL100_ENABLED,
-	REL100_REQUIRED,
+	REL100_ENABLED = 1,
+	REL100_REQUIRED = 2,
 };
 
 

--- a/include/re_sipsess.h
+++ b/include/re_sipsess.h
@@ -43,20 +43,21 @@ int  sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock,
 
 int  sipsess_accept(struct sipsess **sessp, struct sipsess_sock *sock,
 		    const struct sip_msg *msg, uint16_t scode,
-		    const char *reason, enum rel100_mode rel100, const char *cuser,
-			const char *ctype, struct mbuf *desc,
-		    sip_auth_h *authh, void *aarg, bool aref,
-		    sipsess_offer_h *offerh, sipsess_answer_h *answerh,
-		    sipsess_estab_h *estabh, sipsess_info_h *infoh,
-		    sipsess_refer_h *referh, sipsess_close_h *closeh,
-		    void *arg, const char *fmt, ...);
+		    const char *reason, enum rel100_mode rel100,
+		    const char *cuser, const char *ctype,
+		    struct mbuf *desc, sip_auth_h *authh, void *aarg,
+		    bool aref, sipsess_offer_h *offerh,
+		    sipsess_answer_h *answerh, sipsess_estab_h *estabh,
+		    sipsess_info_h *infoh, sipsess_refer_h *referh,
+		    sipsess_close_h *closeh, void *arg,
+		    const char *fmt, ...);
 
 int  sipsess_set_redirect_handler(struct sipsess *sess,
 				  sipsess_redirect_h *redirecth);
 
 int  sipsess_progress(struct sipsess *sess, uint16_t scode,
-		      const char *reason, enum rel100_mode rel100, struct mbuf *desc,
-		      const char *fmt, ...);
+		      const char *reason, enum rel100_mode rel100,
+		      struct mbuf *desc, const char *fmt, ...);
 int  sipsess_answer(struct sipsess *sess, uint16_t scode, const char *reason,
 		    struct mbuf *desc, const char *fmt, ...);
 int  sipsess_reject(struct sipsess *sess, uint16_t scode, const char *reason,

--- a/include/re_sipsess.h
+++ b/include/re_sipsess.h
@@ -43,8 +43,8 @@ int  sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock,
 
 int  sipsess_accept(struct sipsess **sessp, struct sipsess_sock *sock,
 		    const struct sip_msg *msg, uint16_t scode,
-		    const char *reason, const char *cuser, const char *ctype,
-		    struct mbuf *desc,
+		    const char *reason, enum rel100_mode rel100, const char *cuser,
+			const char *ctype, struct mbuf *desc,
 		    sip_auth_h *authh, void *aarg, bool aref,
 		    sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		    sipsess_estab_h *estabh, sipsess_info_h *infoh,
@@ -55,7 +55,7 @@ int  sipsess_set_redirect_handler(struct sipsess *sess,
 				  sipsess_redirect_h *redirecth);
 
 int  sipsess_progress(struct sipsess *sess, uint16_t scode,
-		      const char *reason, struct mbuf *desc,
+		      const char *reason, enum rel100_mode rel100, struct mbuf *desc,
 		      const char *fmt, ...);
 int  sipsess_answer(struct sipsess *sess, uint16_t scode, const char *reason,
 		    struct mbuf *desc, const char *fmt, ...);

--- a/src/sip/mod.mk
+++ b/src/sip/mod.mk
@@ -13,6 +13,7 @@ SRCS	+= sip/dialog.c
 SRCS	+= sip/keepalive.c
 SRCS	+= sip/keepalive_udp.c
 SRCS	+= sip/msg.c
+SRCS	+= sip/rack.c
 SRCS	+= sip/reply.c
 SRCS	+= sip/request.c
 SRCS	+= sip/sip.c

--- a/src/sip/msg.c
+++ b/src/sip/msg.c
@@ -222,6 +222,14 @@ static inline int hdr_add(struct sip_msg *msg, const struct pl *name,
 		err = sip_cseq_decode(&msg->cseq, &hdr->val);
 		break;
 
+	case SIP_HDR_RSEQ:
+		msg->rel_seq = pl_u32(&hdr->val);
+		break;
+
+	case SIP_HDR_RACK:
+		err = sip_rack_decode(&msg->rack, &hdr->val);
+		break;
+
 	case SIP_HDR_MAX_FORWARDS:
 		msg->maxfwd = hdr->val;
 		break;

--- a/src/sip/rack.c
+++ b/src/sip/rack.c
@@ -1,0 +1,41 @@
+/**
+ * @file rack.c  SIP RAck decode (RFC 3262)
+ *
+ * Copyright (C) 2022 commend.com - m.fridrich@commend.com
+ */
+#include <re_types.h>
+#include <re_fmt.h>
+#include <re_mbuf.h>
+#include <re_uri.h>
+#include <re_list.h>
+#include <re_sa.h>
+#include <re_msg.h>
+#include <re_sip.h>
+
+/**
+ * Decode a pointer-length string into a SIP RAck header
+ *
+ * @param rack SIP RAck header
+ * @param pl   Pointer-length string
+ *
+ * @return 0 for success, otherwise errorcode
+ */
+int sip_rack_decode(struct sip_rack *rack, const struct pl *pl)
+{
+	struct pl rel_seq;
+	struct pl cseq;
+	int err;
+
+	if (!rack || !pl)
+		return EINVAL;
+
+	err = re_regex(pl->p, pl->l, "[0-9]+[ \t\r\n]+[0-9]+[ \t\r\n]+[^ \t\r\n]+",
+		       &rel_seq, NULL, &cseq, NULL, &rack->met);
+	if (err)
+		return err;
+
+	rack->rel_seq = pl_u32(&rel_seq);
+	rack->cseq = pl_u32(&cseq);
+
+	return 0;
+}

--- a/src/sip/rack.c
+++ b/src/sip/rack.c
@@ -29,8 +29,9 @@ int sip_rack_decode(struct sip_rack *rack, const struct pl *pl)
 	if (!rack || !pl)
 		return EINVAL;
 
-	err = re_regex(pl->p, pl->l, "[0-9]+[ \t\r\n]+[0-9]+[ \t\r\n]+[^ \t\r\n]+",
-		       &rel_seq, NULL, &cseq, NULL, &rack->met);
+	err = re_regex(pl->p, pl->l,
+			"[0-9]+[ \t\r\n]+[0-9]+[ \t\r\n]+[^ \t\r\n]+",
+			&rel_seq, NULL, &cseq, NULL, &rack->met);
 	if (err)
 		return err;
 

--- a/src/sip/rack.c
+++ b/src/sip/rack.c
@@ -30,13 +30,12 @@ int sip_rack_decode(struct sip_rack *rack, const struct pl *pl)
 		return EINVAL;
 
 	err = re_regex(pl->p, pl->l,
-			"[0-9]+[ \t\r\n]+[0-9]+[ \t\r\n]+[^ \t\r\n]+",
-			&rel_seq, NULL, &cseq, NULL, &rack->met);
+		       "[0-9]+[ \t\r\n]+[0-9]+[ \t\r\n]+[^ \t\r\n]+",
+		       &rel_seq, NULL, &cseq, NULL, &rack->met);
 	if (err)
 		return err;
 
 	rack->rel_seq = pl_u32(&rel_seq);
 	rack->cseq = pl_u32(&cseq);
-
 	return 0;
 }

--- a/src/sipsess/accept.c
+++ b/src/sipsess/accept.c
@@ -62,8 +62,8 @@ static void cancel_handler(void *arg)
  */
 int sipsess_accept(struct sipsess **sessp, struct sipsess_sock *sock,
 		   const struct sip_msg *msg, uint16_t scode,
-		   const char *reason, enum rel100_mode rel100, const char *cuser,
-		   const char *ctype, struct mbuf *desc,
+		   const char *reason, enum rel100_mode rel100,
+		   const char *cuser, const char *ctype, struct mbuf *desc,
 		   sip_auth_h *authh, void *aarg, bool aref,
 		   sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		   sipsess_estab_h *estabh, sipsess_info_h *infoh,
@@ -104,9 +104,11 @@ int sipsess_accept(struct sipsess **sessp, struct sipsess_sock *sock,
 	if (scode > 100 && scode < 200) {
 		err = sipsess_reply_1xx(sess, msg, scode, reason, rel100, desc,
 					fmt, &ap);
-	} else if (scode >= 200)
+	}
+	else if (scode >= 200) {
 		err = sipsess_reply_2xx(sess, msg, scode, reason, desc,
 					fmt, &ap);
+	}
 	else {
 		struct sip_contact contact;
 
@@ -158,7 +160,8 @@ int sipsess_accept(struct sipsess **sessp, struct sipsess_sock *sock,
  * @return 0 if success, otherwise errorcode
  */
 int sipsess_progress(struct sipsess *sess, uint16_t scode, const char *reason,
-		     enum rel100_mode rel100, struct mbuf *desc, const char *fmt, ...)
+		     enum rel100_mode rel100, struct mbuf *desc,
+		     const char *fmt, ...)
 {
 	va_list ap;
 	int err;
@@ -194,8 +197,9 @@ int sipsess_answer(struct sipsess *sess, uint16_t scode, const char *reason,
 	va_list ap;
 	int err;
 
-	if (!sess || (!sess->st && (sess->established || sess->awaiting_answer))
-		|| !sess->msg || scode < 200 || scode > 299)
+	if (!sess || (!sess->st
+	    && (sess->established || sess->awaiting_answer))
+	    || !sess->msg || scode < 200 || scode > 299)
 		return EINVAL;
 
 	va_start(ap, fmt);

--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -92,7 +92,7 @@ static void invite_resp_handler(int err, const struct sip_msg *msg, void *arg)
 					sip_dialog_update(sess->dlg, msg) :
 					sip_dialog_create(sess->dlg, msg);
 			err |= sipsess_prack(sess, msg->cseq.num, msg->rel_seq,
-								&msg->cseq.met, desc);
+					     &msg->cseq.met, desc);
 			mem_deref(desc);
 			sess->desc = mem_deref(sess->desc);
 			if (err)

--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -272,6 +272,7 @@ int sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock,
 
 		if (err)
 			goto out;
+
 		pl_set_mbuf(&hdrs, sess->hdrs);
 	}
 

--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -98,6 +98,7 @@ static void invite_resp_handler(int err, const struct sip_msg *msg, void *arg)
 			if (err)
 				goto out;
 		}
+
 		return;
 	}
 	else if (msg->scode < 300) {

--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -84,13 +84,29 @@ static void invite_resp_handler(int err, const struct sip_msg *msg, void *arg)
 
 	if (msg->scode < 200) {
 		sess->progrh(msg, sess->arg);
+
+		if (sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE, "100rel")
+				&& sess->rel100_supported) {
+
+			err = sip_dialog_established(sess->dlg) ?
+					sip_dialog_update(sess->dlg, msg) :
+					sip_dialog_create(sess->dlg, msg);
+			err |= sipsess_prack(sess, msg->cseq.num, msg->rel_seq,
+								&msg->cseq.met, desc);
+			mem_deref(desc);
+			sess->desc = mem_deref(sess->desc);
+			if (err)
+				goto out;
+		}
 		return;
 	}
 	else if (msg->scode < 300) {
 
 		sess->hdrs = mem_deref(sess->hdrs);
 
-		err = sip_dialog_create(sess->dlg, msg);
+		err = sip_dialog_established(sess->dlg) ?
+				sip_dialog_update(sess->dlg, msg) :
+				sip_dialog_create(sess->dlg, msg);
 		if (err)
 			goto out;
 
@@ -226,6 +242,7 @@ int sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock,
 		    sipsess_close_h *closeh, void *arg, const char *fmt, ...)
 {
 	struct sipsess *sess;
+	struct pl hdrs;
 	int err;
 
 	if (!sessp || !sock || !to_uri || !from_uri || !cuser || !ctype)
@@ -255,9 +272,11 @@ int sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock,
 
 		if (err)
 			goto out;
+		pl_set_mbuf(&hdrs, sess->hdrs);
 	}
 
 	sess->owner = true;
+	sess->rel100_supported = fmt && !re_regex(hdrs.p, hdrs.l, "100rel");
 
 	err = sip_dialog_alloc(&sess->dlg, to_uri, to_uri, from_name,
 			       from_uri, routev, routec);

--- a/src/sipsess/listen.c
+++ b/src/sipsess/listen.c
@@ -194,10 +194,8 @@ static void prack_handler(struct sipsess_sock *sock, const struct sip_msg *msg)
 	int err = 0;
 
 	sess = sipsess_find(sock, msg);
-	if (!sess)
-		return;
 
-	if (sipsess_reply_prack(sess, msg, &awaiting_answer)) {
+	if (!sess || sipsess_reply_prack(sess, msg, &awaiting_answer)) {
 		(void)sip_reply(sock->sip, msg, 481,
 				"Transaction Does Not Exist");
 		return;
@@ -208,6 +206,7 @@ static void prack_handler(struct sipsess_sock *sock, const struct sip_msg *msg)
 			sess->established = true;
 			mem_deref(sess);
 		}
+
 		return;
 	}
 

--- a/src/sipsess/listen.c
+++ b/src/sipsess/listen.c
@@ -198,7 +198,8 @@ static void prack_handler(struct sipsess_sock *sock, const struct sip_msg *msg)
 		return;
 
 	if (sipsess_reply_prack(sess, msg, &awaiting_answer)) {
-		(void)sip_reply(sock->sip, msg, 481, "Transaction Does Not Exist");
+		(void)sip_reply(sock->sip, msg, 481,
+				"Transaction Does Not Exist");
 		return;
 	}
 

--- a/src/sipsess/mod.mk
+++ b/src/sipsess/mod.mk
@@ -12,5 +12,6 @@ SRCS	+= sipsess/connect.c
 SRCS	+= sipsess/info.c
 SRCS	+= sipsess/listen.c
 SRCS	+= sipsess/modify.c
+SRCS	+= sipsess/prack.c
 SRCS	+= sipsess/reply.c
 SRCS	+= sipsess/request.c

--- a/src/sipsess/prack.c
+++ b/src/sipsess/prack.c
@@ -77,8 +77,8 @@ static void resp_handler(int err, const struct sip_msg *msg, void *arg)
 	if (err || !msg)
 		goto out;
 
-	if (msg->scode > 100 && msg->scode < 200 &&
-			sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE, "100rel")) {
+	if (msg->scode > 100 && msg->scode < 200
+	    && sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE, "100rel")) {
 		(void)sipsess_prack_again(prack->sock, msg);
 		return;
 	}
@@ -109,11 +109,13 @@ int sipsess_prack(struct sipsess *sess, uint32_t cseq, uint32_t rel_seq,
 	prack->cseq = cseq;
 
 	(void)pl_strcpy(met, method, sizeof(method));
-	re_snprintf(rack_header, sizeof(rack_header), "%d %d %s", rel_seq, cseq, method);
+	re_snprintf(rack_header, sizeof(rack_header), "%d %d %s", rel_seq,
+		    cseq, method);
 
-	err = sip_drequestf(&prack->req, sess->sock->sip, true, "PRACK", sess->dlg, cseq,
-			    sess->auth, send_handler, resp_handler, prack,
-				"RAck: %s\n"
+	err = sip_drequestf(&prack->req, sess->sock->sip, true, "PRACK",
+			    sess->dlg, cseq, sess->auth, send_handler,
+			    resp_handler, prack,
+			    "RAck: %s\n"
 			    "%s%s%s"
 			    "Content-Length: %zu\r\n"
 			    "\r\n"

--- a/src/sipsess/prack.c
+++ b/src/sipsess/prack.c
@@ -1,0 +1,162 @@
+/**
+ * @file prack.c  SIP Session PRACK (RFC 3262)
+ *
+ * Copyright (C) 2022 commend.com - m.fridrich@commend.com
+ */
+#include <re_types.h>
+#include <re_mem.h>
+#include <re_mbuf.h>
+#include <re_sa.h>
+#include <re_list.h>
+#include <re_hash.h>
+#include <re_fmt.h>
+#include <re_uri.h>
+#include <re_tmr.h>
+#include <re_msg.h>
+#include <re_sip.h>
+#include <re_sipsess.h>
+#include "sipsess.h"
+
+
+struct sipsess_prack {
+	struct le he;
+	struct tmr tmr;
+	struct sa dst;
+	struct sip_request *req;
+	struct sip_dialog *dlg;
+	struct sipsess_sock *sock;
+	struct mbuf *mb;
+	enum sip_transp tp;
+	uint32_t cseq;
+};
+
+
+static void destructor(void *arg)
+{
+	struct sipsess_prack *prack = arg;
+
+	hash_unlink(&prack->he);
+	tmr_cancel(&prack->tmr);
+	mem_deref(prack->req);
+	mem_deref(prack->dlg);
+	mem_deref(prack->sock);
+	mem_deref(prack->mb);
+}
+
+
+static void tmr_handler(void *arg)
+{
+	struct sipsess_prack *prack = arg;
+
+	mem_deref(prack);
+}
+
+
+static int send_handler(enum sip_transp tp, struct sa *src,
+			const struct sa *dst, struct mbuf *mb,
+			struct mbuf **contp, void *arg)
+{
+	struct sipsess_prack *prack = arg;
+	(void)src;
+	(void)contp;
+
+	mem_deref(prack->mb);
+	prack->mb = mem_ref(mb);
+	prack->dst = *dst;
+	prack->tp  = tp;
+
+	tmr_start(&prack->tmr, 64 * SIP_T1, tmr_handler, prack);
+
+	return 0;
+}
+
+
+static void resp_handler(int err, const struct sip_msg *msg, void *arg)
+{
+	struct sipsess_prack *prack = arg;
+	if (err || !msg)
+		goto out;
+
+	if (msg->scode > 100 && msg->scode < 200 &&
+			sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE, "100rel")) {
+		(void)sipsess_prack_again(prack->sock, msg);
+		return;
+	}
+
+out:
+	mem_deref(prack);
+}
+
+
+int sipsess_prack(struct sipsess *sess, uint32_t cseq, uint32_t rel_seq,
+		const struct pl *met, struct mbuf *desc)
+{
+	struct sipsess_prack *prack;
+	char rack_header[256];
+	char method[64];
+	int err;
+
+	prack = mem_zalloc(sizeof(*prack), destructor);
+	if (!prack)
+		return ENOMEM;
+
+	hash_append(sess->sock->ht_prack,
+		    hash_joaat_str(sip_dialog_callid(sess->dlg)),
+		    &prack->he, prack);
+
+	prack->dlg  = mem_ref(sess->dlg);
+	prack->sock  = mem_ref(sess->sock);
+	prack->cseq = cseq;
+
+	(void)pl_strcpy(met, method, sizeof(method));
+	re_snprintf(rack_header, sizeof(rack_header), "%d %d %s", rel_seq, cseq, method);
+
+	err = sip_drequestf(&prack->req, sess->sock->sip, true, "PRACK", sess->dlg, cseq,
+			    sess->auth, send_handler, resp_handler, prack,
+				"RAck: %s\n"
+			    "%s%s%s"
+			    "Content-Length: %zu\r\n"
+			    "\r\n"
+			    "%b",
+				rack_header,
+			    desc ? "Content-Type: " : "",
+			    desc ? sess->ctype : "",
+			    desc ? "\r\n" : "",
+			    desc ? mbuf_get_left(desc) : (size_t)0,
+			    desc ? mbuf_buf(desc) : NULL,
+			    desc ? mbuf_get_left(desc) : (size_t)0);
+
+	if (err)
+		mem_deref(prack);
+
+	return err;
+}
+
+
+static bool cmp_handler(struct le *le, void *arg)
+{
+	struct sipsess_prack *prack = le->data;
+	const struct sip_msg *msg = arg;
+
+	if (!sip_dialog_cmp(prack->dlg, msg))
+		return false;
+
+	if (prack->cseq != msg->cseq.num)
+		return false;
+
+	return true;
+}
+
+
+int sipsess_prack_again(struct sipsess_sock *sock, const struct sip_msg *msg)
+{
+	struct sipsess_prack *prack;
+
+	prack = list_ledata(hash_lookup(sock->ht_prack,
+				      hash_joaat_pl(&msg->callid),
+				      cmp_handler, (void *)msg));
+	if (!prack)
+		return ENOENT;
+
+	return sip_send(sock->sip, NULL, prack->tp, &prack->dst, prack->mb);
+}

--- a/src/sipsess/prack.c
+++ b/src/sipsess/prack.c
@@ -66,7 +66,6 @@ static int send_handler(enum sip_transp tp, struct sa *src,
 	prack->tp  = tp;
 
 	tmr_start(&prack->tmr, 64 * SIP_T1, tmr_handler, prack);
-
 	return 0;
 }
 
@@ -93,14 +92,14 @@ out:
  *
  * @param sess      SIP Session
  * @param cseq      CSeq number to be written in RAck header
- * @param rel_seq   RSeq number to be written in RAck header
+ * @param rseq      RSeq number to be written in RAck header
  * @param met       Method to be written in RAck header
  * @param desc      Content description (e.g. SDP)
  *
  * @return 0 if success, otherwise errorcode
  */
-int sipsess_prack(struct sipsess *sess, uint32_t cseq, uint32_t rel_seq,
-		const struct pl *met, struct mbuf *desc)
+int sipsess_prack(struct sipsess *sess, uint32_t cseq, uint32_t rseq,
+		  const struct pl *met, struct mbuf *desc)
 {
 	struct sipsess_prack *prack;
 	char rack_header[256];
@@ -120,8 +119,8 @@ int sipsess_prack(struct sipsess *sess, uint32_t cseq, uint32_t rel_seq,
 	prack->cseq = cseq;
 
 	(void)pl_strcpy(met, method, sizeof(method));
-	re_snprintf(rack_header, sizeof(rack_header), "%d %d %s", rel_seq,
-		    cseq, method);
+	re_snprintf(rack_header, sizeof(rack_header), "%d %d %s", rseq, cseq,
+		    method);
 
 	err = sip_drequestf(&prack->req, sess->sock->sip, true, "PRACK",
 			    sess->dlg, cseq, sess->auth, send_handler,
@@ -174,8 +173,8 @@ int sipsess_prack_again(struct sipsess_sock *sock, const struct sip_msg *msg)
 	struct sipsess_prack *prack;
 
 	prack = list_ledata(hash_lookup(sock->ht_prack,
-				      hash_joaat_pl(&msg->callid),
-				      cmp_handler, (void *)msg));
+					hash_joaat_pl(&msg->callid),
+					cmp_handler, (void *)msg));
 	if (!prack)
 		return ENOENT;
 

--- a/src/sipsess/prack.c
+++ b/src/sipsess/prack.c
@@ -88,6 +88,17 @@ out:
 }
 
 
+/**
+ * Send PRACK message (RFC 3262)
+ *
+ * @param sess      SIP Session
+ * @param cseq      CSeq number to be written in RAck header
+ * @param rel_seq   RSeq number to be written in RAck header
+ * @param met       Method to be written in RAck header
+ * @param desc      Content description (e.g. SDP)
+ *
+ * @return 0 if success, otherwise errorcode
+ */
 int sipsess_prack(struct sipsess *sess, uint32_t cseq, uint32_t rel_seq,
 		const struct pl *met, struct mbuf *desc)
 {
@@ -150,6 +161,14 @@ static bool cmp_handler(struct le *le, void *arg)
 }
 
 
+/**
+ * Re-send a PRACK message (RFC 3262)
+ *
+ * @param sock      SIP Session socket
+ * @param msg       SIP message
+ *
+ * @return 0 if success, otherwise errorcode
+ */
 int sipsess_prack_again(struct sipsess_sock *sock, const struct sip_msg *msg)
 {
 	struct sipsess_prack *prack;

--- a/src/sipsess/prack.c
+++ b/src/sipsess/prack.c
@@ -120,7 +120,7 @@ int sipsess_prack(struct sipsess *sess, uint32_t cseq, uint32_t rel_seq,
 			    "Content-Length: %zu\r\n"
 			    "\r\n"
 			    "%b",
-				rack_header,
+			    rack_header,
 			    desc ? "Content-Type: " : "",
 			    desc ? sess->ctype : "",
 			    desc ? "\r\n" : "",

--- a/src/sipsess/reply.c
+++ b/src/sipsess/reply.c
@@ -155,35 +155,34 @@ int sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 	struct sipsess_reply *reply;
 	struct sip_contact contact;
 	char rseq_header[64];
-	bool rel100_peer_sup;
-	bool rel100_peer_req;
-	bool send_reliably;
+	bool reliably;
+	enum rel100_mode rel100_peer = REL100_DISABLED;
 	struct pl require_header = pl_null;
 	int err = ENOMEM;
 
-	rel100_peer_sup = sip_msg_hdr_has_value(msg,
-						SIP_HDR_SUPPORTED, "100rel");
-	rel100_peer_req = sip_msg_hdr_has_value(msg,
-						SIP_HDR_REQUIRE, "100rel");
+	if (sip_msg_hdr_has_value(msg, SIP_HDR_SUPPORTED, "100rel"))
+		rel100_peer |= REL100_ENABLED;
 
-	if (rel100 == REL100_REQUIRED
-	    && !(rel100_peer_sup || rel100_peer_req)) {
+	if (sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE, "100rel"))
+		rel100_peer |= REL100_REQUIRED;
+
+	if (rel100 == REL100_REQUIRED && !rel100_peer) {
 		(void)sip_treplyf(&sess->st, NULL, sess->sip, msg, false,
 				  421, "Extension required",
 				  "Require: 100rel\r\n"
 				  "Content-Length: 0\r\n\r\n");
 		return -1;
 	}
-	else if (rel100_peer_req && !rel100) {
+	else if (rel100_peer & REL100_REQUIRED && !rel100) {
 		(void)sip_treplyf(&sess->st, NULL, sess->sip, msg, false, 420,
 				  "Bad Extension", "Unsupported: 100rel\r\n"
 				  "Content-Length: 0\r\n\r\n");
 		return -1;
 	}
 
-	send_reliably = rel100 && (rel100_peer_req || rel100_peer_sup);
+	reliably = rel100 && rel100_peer;
 
-	if (rel100 != REL100_REQUIRED && send_reliably) {
+	if (rel100 != REL100_REQUIRED && reliably) {
 		pl_set_str(&require_header, "Require: 100rel\r\n");
 	}
 
@@ -198,7 +197,7 @@ int sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 	reply->sess = sess;
 
 	sip_contact_set(&contact, sess->cuser, &msg->dst, msg->tp);
-	if (send_reliably) {
+	if (reliably) {
 		reply->rel_seq = prev ? prev->rel_seq+1 : rand_u16();
 		re_snprintf(rseq_header, sizeof(rseq_header),
 					"%d", reply->rel_seq);
@@ -215,9 +214,9 @@ int sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 			  sip_contact_print, &contact,
 			  fmt, ap,
 			  require_header.p ? require_header.p : "",
-			  send_reliably ? "RSeq: " : "",
-			  send_reliably ? rseq_header : "",
-			  send_reliably ? "\n" : "",
+			  reliably ? "RSeq: " : "",
+			  reliably ? rseq_header : "",
+			  reliably ? "\n" : "",
 			  desc ? "Content-Type: " : "",
 			  desc ? sess->ctype : "",
 			  desc ? "\r\n" : "",
@@ -228,7 +227,7 @@ int sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 	if (err)
 		goto out;
 
-	if (send_reliably) {
+	if (reliably) {
 		tmr_start(&reply->tmr, 64 * SIP_T1, tmr_handler, reply);
 		tmr_start(&reply->tmrg, SIP_T1, retransmit_handler, reply);
 	}
@@ -261,6 +260,7 @@ static bool cmp_handler(struct le *le, void *arg)
 				msg->rack.rel_seq == reply->rel_seq &&
 				!pl_cmp(&msg->rack.met, &reply->msg->met);
 	}
+
 	return msg->cseq.num == reply->seq;
 }
 
@@ -295,8 +295,7 @@ int sipsess_reply_prack(struct sipsess *sess, const struct sip_msg *msg,
 		return ENOENT;
 
 	*awaiting_answer = reply->awaiting_answer;
-	err = sipsess_reply_2xx(sess, msg, 200, "OK", NULL,
-					NULL, NULL);
+	err = sipsess_reply_2xx(sess, msg, 200, "OK", NULL, NULL, NULL);
 
 	mem_deref(reply);
 

--- a/src/sipsess/reply.c
+++ b/src/sipsess/reply.c
@@ -121,7 +121,8 @@ int sipsess_reply_2xx(struct sipsess *sess, const struct sip_msg *msg,
 	if (pl_strcmp(&msg->met, "PRACK")) {
 		tmr_start(&reply->tmr, 64 * SIP_T1, tmr_handler, reply);
 		tmr_start(&reply->tmrg, SIP_T1, retransmit_handler, reply);
-	} else {
+	}
+	else {
 		mem_deref(reply);
 	}
 
@@ -141,8 +142,9 @@ int sipsess_reply_2xx(struct sipsess *sess, const struct sip_msg *msg,
 
 
 int sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
-		      uint16_t scode, const char *reason, enum rel100_mode rel100,
-			  struct mbuf *desc, const char *fmt, va_list *ap)
+		      uint16_t scode, const char *reason,
+		      enum rel100_mode rel100, struct mbuf *desc,
+		      const char *fmt, va_list *ap)
 {
 	struct sipsess_reply *reply;
 	struct sip_contact contact;
@@ -153,25 +155,29 @@ int sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 	struct pl require_header;
 	int err = ENOMEM;
 
-	rel100_peer_sup = sip_msg_hdr_has_value(msg, SIP_HDR_SUPPORTED, "100rel");
-	rel100_peer_req = sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE, "100rel");
+	rel100_peer_sup = sip_msg_hdr_has_value(msg,
+						SIP_HDR_SUPPORTED, "100rel");
+	rel100_peer_req = sip_msg_hdr_has_value(msg,
+						SIP_HDR_REQUIRE, "100rel");
 
-	if (rel100 == REL100_REQUIRED && !(rel100_peer_sup || rel100_peer_req)) {
+	if (rel100 == REL100_REQUIRED
+	    && !(rel100_peer_sup || rel100_peer_req)) {
 		(void)sip_treplyf(&sess->st, NULL, sess->sip, msg, false,
 				  421, "Extension required",
 				  "Require: 100rel\r\n"
 				  "Content-Length: 0\r\n\r\n");
 		return -1;
-	} else if (rel100_peer_req && !rel100) {
-		(void)sip_treplyf(&sess->st, NULL, sess->sip, msg, false,
-				  420, "Bad Extension",
-				  "Unsupported: 100rel\r\n"
+	}
+	else if (rel100_peer_req && !rel100) {
+		(void)sip_treplyf(&sess->st, NULL, sess->sip, msg, false, 420,
+				  "Bad Extension", "Unsupported: 100rel\r\n"
 				  "Content-Length: 0\r\n\r\n");
 		return -1;
 	}
 	if (rel100 != REL100_REQUIRED && rel100_peer_req) {
 		pl_set_str(&require_header, "Require: 100rel\r\n");
-	} else {
+	}
+	else {
 		require_header.p = NULL;
 	}
 
@@ -190,7 +196,8 @@ int sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 
 	if (send_reliably) {
 		reply->rel_seq = rand_u16();
-		re_snprintf(rseq_header, sizeof(rseq_header), "%d", reply->rel_seq);
+		re_snprintf(rseq_header, sizeof(rseq_header), "%d",
+			    reply->rel_seq);
 	}
 
 	err = sip_treplyf(&sess->st, &reply->mb, sess->sip,
@@ -220,7 +227,8 @@ int sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 	if (send_reliably) {
 		tmr_start(&reply->tmr, 64 * SIP_T1, tmr_handler, reply);
 		tmr_start(&reply->tmrg, SIP_T1, retransmit_handler, reply);
-	} else {
+	}
+	else {
 		mem_deref(reply);
 	}
 

--- a/src/sipsess/reply.c
+++ b/src/sipsess/reply.c
@@ -77,7 +77,7 @@ static void retransmit_handler(void *arg)
 	reply->txc++;
 
 	delay = !reply->rel_seq ?
-		MIN(SIP_T1<<reply->txc, SIP_T2) : SIP_T1<<reply->txc;
+		MIN(SIP_T1 << reply->txc, SIP_T2) : SIP_T1 << reply->txc;
 
 	tmr_start(&reply->tmrg, delay, retransmit_handler, reply);
 }
@@ -151,7 +151,7 @@ int sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 		      enum rel100_mode rel100, struct mbuf *desc,
 		      const char *fmt, va_list *ap)
 {
-	struct sipsess_reply *prev_reply;
+	struct sipsess_reply *prev;
 	struct sipsess_reply *reply;
 	struct sip_contact contact;
 	char rseq_header[64];
@@ -193,17 +193,15 @@ int sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 	if (!reply)
 		goto out;
 
-	prev_reply = list_ledata(list_tail(&sess->replyl));
+	prev = list_ledata(list_tail(&sess->replyl));
 	list_append(&sess->replyl, &reply->le, reply);
 	reply->seq  = msg->cseq.num;
 	reply->msg  = mem_ref((void *)msg);
 	reply->sess = sess;
 
 	sip_contact_set(&contact, sess->cuser, &msg->dst, msg->tp);
-
 	if (send_reliably) {
-		reply->rel_seq = prev_reply ?
-			prev_reply->rel_seq+1 : rand_u16();
+		reply->rel_seq = prev ? prev->rel_seq+1 : rand_u16();
 		re_snprintf(rseq_header, sizeof(rseq_header),
 					"%d", reply->rel_seq);
 	}
@@ -285,6 +283,7 @@ int sipsess_reply_ack(struct sipsess *sess, const struct sip_msg *msg,
 
 	return 0;
 }
+
 
 int sipsess_reply_prack(struct sipsess *sess, const struct sip_msg *msg,
 		      bool *awaiting_answer)

--- a/src/sipsess/reply.c
+++ b/src/sipsess/reply.c
@@ -158,7 +158,7 @@ int sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 	bool rel100_peer_sup;
 	bool rel100_peer_req;
 	bool send_reliably;
-	struct pl require_header;
+	struct pl require_header = pl_null;
 	int err = ENOMEM;
 
 	rel100_peer_sup = sip_msg_hdr_has_value(msg,
@@ -180,14 +180,12 @@ int sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 				  "Content-Length: 0\r\n\r\n");
 		return -1;
 	}
-	if (rel100 != REL100_REQUIRED && rel100_peer_req) {
+
+	send_reliably = rel100 && (rel100_peer_req || rel100_peer_sup);
+
+	if (rel100 != REL100_REQUIRED && send_reliably) {
 		pl_set_str(&require_header, "Require: 100rel\r\n");
 	}
-	else {
-		require_header.p = NULL;
-	}
-
-	send_reliably = rel100 == REL100_REQUIRED || rel100_peer_req;
 
 	reply = mem_zalloc(sizeof(*reply), destructor);
 	if (!reply)

--- a/src/sipsess/reply.c
+++ b/src/sipsess/reply.c
@@ -289,6 +289,7 @@ int sipsess_reply_prack(struct sipsess *sess, const struct sip_msg *msg,
 		      bool *awaiting_answer)
 {
 	struct sipsess_reply *reply;
+	int err;
 
 	reply = list_ledata(list_apply(&sess->replyl, false, cmp_handler,
 				       (void *)msg));
@@ -296,10 +297,10 @@ int sipsess_reply_prack(struct sipsess *sess, const struct sip_msg *msg,
 		return ENOENT;
 
 	*awaiting_answer = reply->awaiting_answer;
-	(void)sipsess_reply_2xx(sess, msg, 200, "OK", NULL,
+	err = sipsess_reply_2xx(sess, msg, 200, "OK", NULL,
 					NULL, NULL);
 
 	mem_deref(reply);
 
-	return 0;
+	return err;
 }

--- a/src/sipsess/reply.c
+++ b/src/sipsess/reply.c
@@ -160,11 +160,10 @@ int sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 	struct pl require_header = pl_null;
 	int err = ENOMEM;
 
-	if (sip_msg_hdr_has_value(msg, SIP_HDR_SUPPORTED, "100rel"))
-		rel100_peer |= REL100_ENABLED;
-
 	if (sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE, "100rel"))
-		rel100_peer |= REL100_REQUIRED;
+		rel100_peer = REL100_REQUIRED;
+	else if (sip_msg_hdr_has_value(msg, SIP_HDR_SUPPORTED, "100rel"))
+		rel100_peer = REL100_ENABLED;
 
 	if (rel100 == REL100_REQUIRED && !rel100_peer) {
 		(void)sip_treplyf(&sess->st, NULL, sess->sip, msg, false,
@@ -173,7 +172,7 @@ int sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 				  "Content-Length: 0\r\n\r\n");
 		return -1;
 	}
-	else if (rel100_peer & REL100_REQUIRED && !rel100) {
+	else if (rel100_peer == REL100_REQUIRED && !rel100) {
 		(void)sip_treplyf(&sess->st, NULL, sess->sip, msg, false, 420,
 				  "Bad Extension", "Unsupported: 100rel\r\n"
 				  "Content-Length: 0\r\n\r\n");
@@ -181,7 +180,6 @@ int sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 	}
 
 	reliably = rel100 && rel100_peer;
-
 	if (rel100 != REL100_REQUIRED && reliably) {
 		pl_set_str(&require_header, "Require: 100rel\r\n");
 	}

--- a/src/sipsess/reply.c
+++ b/src/sipsess/reply.c
@@ -15,6 +15,7 @@
 #include <re_msg.h>
 #include <re_sip.h>
 #include <re_sipsess.h>
+#include <re_sys.h>
 #include "sipsess.h"
 
 
@@ -27,6 +28,7 @@ struct sipsess_reply {
 	struct sipsess *sess;
 	bool awaiting_answer;
 	uint32_t seq;
+	uint32_t rel_seq;
 	uint32_t txc;
 };
 
@@ -116,8 +118,111 @@ int sipsess_reply_2xx(struct sipsess *sess, const struct sip_msg *msg,
 	if (err)
 		goto out;
 
-	tmr_start(&reply->tmr, 64 * SIP_T1, tmr_handler, reply);
-	tmr_start(&reply->tmrg, SIP_T1, retransmit_handler, reply);
+	if (pl_strcmp(&msg->met, "PRACK")) {
+		tmr_start(&reply->tmr, 64 * SIP_T1, tmr_handler, reply);
+		tmr_start(&reply->tmrg, SIP_T1, retransmit_handler, reply);
+	} else {
+		mem_deref(reply);
+	}
+
+	if (!mbuf_get_left(msg->mb) && desc) {
+		reply->awaiting_answer = true;
+		sess->awaiting_answer = true;
+	}
+
+ out:
+	if (err) {
+		sess->st = mem_deref(sess->st);
+		mem_deref(reply);
+	}
+
+	return err;
+}
+
+
+int sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
+		      uint16_t scode, const char *reason, enum rel100_mode rel100,
+			  struct mbuf *desc, const char *fmt, va_list *ap)
+{
+	struct sipsess_reply *reply;
+	struct sip_contact contact;
+	char rseq_header[64];
+	bool rel100_peer_sup;
+	bool rel100_peer_req;
+	bool send_reliably;
+	struct pl require_header;
+	int err = ENOMEM;
+
+	rel100_peer_sup = sip_msg_hdr_has_value(msg, SIP_HDR_SUPPORTED, "100rel");
+	rel100_peer_req = sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE, "100rel");
+
+	if (rel100 == REL100_REQUIRED && !(rel100_peer_sup || rel100_peer_req)) {
+		(void)sip_treplyf(&sess->st, NULL, sess->sip, msg, false,
+				  421, "Extension required",
+				  "Require: 100rel\r\n"
+				  "Content-Length: 0\r\n\r\n");
+		return -1;
+	} else if (rel100_peer_req && !rel100) {
+		(void)sip_treplyf(&sess->st, NULL, sess->sip, msg, false,
+				  420, "Bad Extension",
+				  "Unsupported: 100rel\r\n"
+				  "Content-Length: 0\r\n\r\n");
+		return -1;
+	}
+	if (rel100 != REL100_REQUIRED && rel100_peer_req) {
+		pl_set_str(&require_header, "Require: 100rel\r\n");
+	} else {
+		require_header.p = NULL;
+	}
+
+	send_reliably = rel100 == REL100_REQUIRED || rel100_peer_req;
+
+	reply = mem_zalloc(sizeof(*reply), destructor);
+	if (!reply)
+		goto out;
+
+	list_append(&sess->replyl, &reply->le, reply);
+	reply->seq  = msg->cseq.num;
+	reply->msg  = mem_ref((void *)msg);
+	reply->sess = sess;
+
+	sip_contact_set(&contact, sess->cuser, &msg->dst, msg->tp);
+
+	if (send_reliably) {
+		reply->rel_seq = rand_u16();
+		re_snprintf(rseq_header, sizeof(rseq_header), "%d", reply->rel_seq);
+	}
+
+	err = sip_treplyf(&sess->st, &reply->mb, sess->sip,
+			  msg, true, scode, reason,
+			  "%H"
+			  "%v"
+			  "%s%s%s%s%s%s%s"
+			  "Content-Length: %zu\r\n"
+			  "\r\n"
+			  "%b",
+			  sip_contact_print, &contact,
+			  fmt, ap,
+			  require_header.p ? require_header.p : "",
+			  send_reliably ? "RSeq: " : "",
+			  send_reliably ? rseq_header : "",
+			  send_reliably ? "\n" : "",
+			  desc ? "Content-Type: " : "",
+			  desc ? sess->ctype : "",
+			  desc ? "\r\n" : "",
+			  desc ? mbuf_get_left(desc) : (size_t)0,
+			  desc ? mbuf_buf(desc) : NULL,
+			  desc ? mbuf_get_left(desc) : (size_t)0);
+
+	if (err)
+		goto out;
+
+	if (send_reliably) {
+		tmr_start(&reply->tmr, 64 * SIP_T1, tmr_handler, reply);
+		tmr_start(&reply->tmrg, SIP_T1, retransmit_handler, reply);
+	} else {
+		mem_deref(reply);
+	}
 
 	if (!mbuf_get_left(msg->mb) && desc) {
 		reply->awaiting_answer = true;
@@ -139,6 +244,11 @@ static bool cmp_handler(struct le *le, void *arg)
 	struct sipsess_reply *reply = le->data;
 	const struct sip_msg *msg = arg;
 
+	if (!pl_strcmp(&msg->met, "PRACK")) {
+		return msg->rack.cseq == reply->seq &&
+				msg->rack.rel_seq == reply->rel_seq &&
+				!pl_cmp(&msg->rack.met, &reply->msg->met);
+	}
 	return msg->cseq.num == reply->seq;
 }
 
@@ -154,6 +264,25 @@ int sipsess_reply_ack(struct sipsess *sess, const struct sip_msg *msg,
 		return ENOENT;
 
 	*awaiting_answer = reply->awaiting_answer;
+
+	mem_deref(reply);
+
+	return 0;
+}
+
+int sipsess_reply_prack(struct sipsess *sess, const struct sip_msg *msg,
+		      bool *awaiting_answer)
+{
+	struct sipsess_reply *reply;
+
+	reply = list_ledata(list_apply(&sess->replyl, false, cmp_handler,
+				       (void *)msg));
+	if (!reply)
+		return ENOENT;
+
+	*awaiting_answer = reply->awaiting_answer;
+	(void)sipsess_reply_2xx(sess, msg, 200, "OK", NULL,
+					NULL, NULL);
 
 	mem_deref(reply);
 

--- a/src/sipsess/sipsess.h
+++ b/src/sipsess/sipsess.h
@@ -82,7 +82,7 @@ int  sipsess_ack(struct sipsess_sock *sock, struct sip_dialog *dlg,
 		 uint32_t cseq, struct sip_auth *auth,
 		 const char *ctype, struct mbuf *desc);
 int  sipsess_ack_again(struct sipsess_sock *sock, const struct sip_msg *msg);
-int  sipsess_prack(struct sipsess *sess, uint32_t cseq, uint32_t rel_seq,
+int  sipsess_prack(struct sipsess *sess, uint32_t cseq, uint32_t rseq,
 		   const struct pl *met, struct mbuf *desc);
 int  sipsess_prack_again(struct sipsess_sock *sock, const struct sip_msg *msg);
 int  sipsess_reply_2xx(struct sipsess *sess, const struct sip_msg *msg,

--- a/src/sipsess/sipsess.h
+++ b/src/sipsess/sipsess.h
@@ -39,6 +39,7 @@ struct sipsess {
 	bool modify_pending;
 	bool established;
 	bool peerterm;
+	bool rel100_supported;
 	int terminated;
 };
 
@@ -48,6 +49,7 @@ struct sipsess_sock {
 	struct sip_lsnr *lsnr_req;
 	struct hash *ht_sess;
 	struct hash *ht_ack;
+	struct hash *ht_prack;
 	struct sip *sip;
 	sipsess_conn_h *connh;
 	void *arg;
@@ -80,10 +82,18 @@ int  sipsess_ack(struct sipsess_sock *sock, struct sip_dialog *dlg,
 		uint32_t cseq, struct sip_auth *auth,
 		const char *ctype, struct mbuf *desc);
 int  sipsess_ack_again(struct sipsess_sock *sock, const struct sip_msg *msg);
+int  sipsess_prack(struct sipsess *sess, uint32_t cseq, uint32_t rel_seq,
+		const struct pl *met, struct mbuf *desc);
+int  sipsess_prack_again(struct sipsess_sock *sock, const struct sip_msg *msg);
 int  sipsess_reply_2xx(struct sipsess *sess, const struct sip_msg *msg,
 		       uint16_t scode, const char *reason, struct mbuf *desc,
 		       const char *fmt, va_list *ap);
+int  sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
+		       uint16_t scode, const char *reason, enum rel100_mode rel100,
+			   struct mbuf *desc, const char *fmt, va_list *ap);
 int  sipsess_reply_ack(struct sipsess *sess, const struct sip_msg *msg,
+		       bool *awaiting_answer);
+int  sipsess_reply_prack(struct sipsess *sess, const struct sip_msg *msg,
 		       bool *awaiting_answer);
 int  sipsess_reinvite(struct sipsess *sess, bool reset_ls);
 int  sipsess_bye(struct sipsess *sess, bool reset_ls);

--- a/src/sipsess/sipsess.h
+++ b/src/sipsess/sipsess.h
@@ -89,8 +89,9 @@ int  sipsess_reply_2xx(struct sipsess *sess, const struct sip_msg *msg,
 		       uint16_t scode, const char *reason, struct mbuf *desc,
 		       const char *fmt, va_list *ap);
 int  sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
-		       uint16_t scode, const char *reason, enum rel100_mode rel100,
-			   struct mbuf *desc, const char *fmt, va_list *ap);
+		       uint16_t scode, const char *reason,
+		       enum rel100_mode rel100, struct mbuf *desc,
+		       const char *fmt, va_list *ap);
 int  sipsess_reply_ack(struct sipsess *sess, const struct sip_msg *msg,
 		       bool *awaiting_answer);
 int  sipsess_reply_prack(struct sipsess *sess, const struct sip_msg *msg,

--- a/src/sipsess/sipsess.h
+++ b/src/sipsess/sipsess.h
@@ -79,11 +79,11 @@ int  sipsess_alloc(struct sipsess **sessp, struct sipsess_sock *sock,
 void sipsess_terminate(struct sipsess *sess, int err,
 		       const struct sip_msg *msg);
 int  sipsess_ack(struct sipsess_sock *sock, struct sip_dialog *dlg,
-		uint32_t cseq, struct sip_auth *auth,
-		const char *ctype, struct mbuf *desc);
+		 uint32_t cseq, struct sip_auth *auth,
+		 const char *ctype, struct mbuf *desc);
 int  sipsess_ack_again(struct sipsess_sock *sock, const struct sip_msg *msg);
 int  sipsess_prack(struct sipsess *sess, uint32_t cseq, uint32_t rel_seq,
-		const struct pl *met, struct mbuf *desc);
+		   const struct pl *met, struct mbuf *desc);
 int  sipsess_prack_again(struct sipsess_sock *sock, const struct sip_msg *msg);
 int  sipsess_reply_2xx(struct sipsess *sess, const struct sip_msg *msg,
 		       uint16_t scode, const char *reason, struct mbuf *desc,
@@ -95,7 +95,7 @@ int  sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 int  sipsess_reply_ack(struct sipsess *sess, const struct sip_msg *msg,
 		       bool *awaiting_answer);
 int  sipsess_reply_prack(struct sipsess *sess, const struct sip_msg *msg,
-		       bool *awaiting_answer);
+			 bool *awaiting_answer);
 int  sipsess_reinvite(struct sipsess *sess, bool reset_ls);
 int  sipsess_bye(struct sipsess *sess, bool reset_ls);
 int  sipsess_request_alloc(struct sipsess_request **reqp, struct sipsess *sess,


### PR DESCRIPTION
This PR adds support for [RFC 3262](https://datatracker.ietf.org/doc/html/rfc3262) which enables provisional SIP responses to be sent reliably by acknowledging them through PRACKs.
Related:
- https://github.com/baresip/baresip/pull/1930
- https://github.com/baresip/retest/pull/88