### PR TITLE
release v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [v2.5.0] - 2022-07-01
+
+* av1: add doxygen comments by @alfredh in https://github.com/baresip/re/pull/384
+* rtp: add function to calc sequence number diff by @alfredh in https://github.com/baresip/re/pull/385
+* CI fixes by @sreimers in https://github.com/baresip/re/pull/387
+* trace: C11 mutex by @alfredh in https://github.com/baresip/re/pull/390
+* trace: init refactor by @sreimers in https://github.com/baresip/re/pull/391
+* jbuf: use C11 mutex by @alfredh in https://github.com/baresip/re/pull/392
+* av1: define and make AV1_AGGR_HDR_SIZE public by @alfredh in https://github.com/baresip/re/pull/393
+* main: add re_thread_check() for NON-RE thread calls by @sreimers in https://github.com/baresip/re/pull/389
+* cmake: add HAVE_SIGNAL on UNIX by @sreimers in https://github.com/baresip/re/pull/394
+* av1: add av1_obu_count() by @alfredh in https://github.com/baresip/re/pull/395
+* thread: add mtx_alloc by @sreimers in https://github.com/baresip/re/pull/396
+* rtp: C11 mutex by @alfredh in https://github.com/baresip/re/pull/397
+* lock: remove deprecated module by @alfredh in https://github.com/baresip/re/pull/398
+* Added sippreg_unregister API function by @juha-h in https://github.com/baresip/re/pull/400
+* av1 work by @alfredh in https://github.com/baresip/re/pull/402
+* rtp: add rtp_is_rtcp_packet() by @alfredh in https://github.com/baresip/re/pull/405
+* Fix mutex alloc destroy by @sreimers in https://github.com/baresip/re/pull/406
+* av1: minor fixes and doxygen comments by @alfredh in https://github.com/baresip/re/pull/407
+* rtp: Add support for RFC5104 PSFB FIR by @Lastique in https://github.com/baresip/re/pull/408
+* jbuf: Add drain method by @Lastique in https://github.com/baresip/re/pull/409
+* uag: add timestamps to SIP trace by @cspiel1 in https://github.com/baresip/re/pull/412
+* fmt/fmt_timestamp: some cleanup by @sreimers in https://github.com/baresip/re/pull/413
+* main: refactor libre_init and re_global handling by @sreimers in https://github.com/baresip/re/pull/404
+* main: Add support for external threads attaching/detaching re context by @Lastique in https://github.com/baresip/re/pull/414
+* mem: Fix formatting for nrefs and size. by @Lastique in https://github.com/baresip/re/pull/415
+
+---
+
 ## [v2.4.0] - 2022-06-01
 
 ## What's Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,13 @@
 
 cmake_minimum_required(VERSION 3.7)
 
-project(re VERSION 2.4.0 LANGUAGES C)
+project(re VERSION 2.5.0 LANGUAGES C)
 
 # Pre-release identifier, comment out on a release
 # Increment for breaking changes (dev2, dev3...)
 # set(PROJECT_VERSION_PRE dev)
 
-set(PROJECT_SOVERSION 6) # bump if ABI breaks
+set(PROJECT_SOVERSION 7) # bump if ABI breaks
 
 if(PROJECT_VERSION_PRE)
   set(PROJECT_VERSION_FULL ${PROJECT_VERSION}-${PROJECT_VERSION_PRE})

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 # Main version number
 VER_MAJOR := 2
-VER_MINOR := 4
+VER_MINOR := 5
 VER_PATCH := 0
 
 # Development version, comment out on a release
@@ -14,7 +14,7 @@ VER_PATCH := 0
 # VER_PRE   := dev
 
 # bump Major if ABI breaks
-ABI_MAJOR := 6
+ABI_MAJOR := 7
 ABI_AGE   := $(VER_MINOR)
 ABI_REV   := $(VER_PATCH)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+libre (2.5.0) unstable; urgency=medium
+
+  * version 2.5.0
+
+ -- Christian Spielberger <c.spielberger@commend.com>  Fri, 1 Jul 2022 08:00:00 +0200
 libre (2.4.0) unstable; urgency=medium
 
   * version 2.4.0


### PR DESCRIPTION
### Create/Prepare PRs for new Release (re/rem/baresip)
- [x] Bump version
  - `CMakefile`
  - `Makefile`
  - `debian/changelog`
- [x] Update `CHANGELOG.md`
  - Click `Draft a new release` on Release page
  - Fill a new release tag version and title (like v2.4.0)
  - Press `Auto-generate Release notes` 
  - **Save as draft** (don't publish yet)
- [x] Check ABI compatibility (only `re` and `rem` for now)
  - `CMakefile` (Bump PROJECT_SOVERSION)
  - `Makefile` (Bump ABI_MAJOR)
- [x] All tests green? [re/rem/retest/baresip]

### Release
- [ ] Merge PRs in this order
  - libre
  - librem
  - retest (needs only a version tag - no PR)
  - baresip
- [ ] Publish draft Releases (follow the same order)
  - Maybe `Auto-generate Release notes` is needed to update (delete last notes first)
