### PR TITLE
Fix compilation error on musl: __GNUC_PREREQ macro defined only for libc library

### DIFF
--- a/include/re_atomic.h
+++ b/include/re_atomic.h
@@ -25,7 +25,7 @@ extern "C" {
 #define __CLANG_ATOMICS
 
 #elif defined(__GNUC__)
-#if __GNUC_PREREQ(4, 9)
+#if (__GNUC__ << 16) + __GNUC_MINOR__ >= 0x40009
 #define __SYNC_ATOMICS
 #else
 #error "Atomic requires gcc >= 4.9"


### PR DESCRIPTION
I replaced __GNUC_PREREQ macro to its definition but everything else is the same