### PR TITLE
strans/accept: fix cancel/rejection

### DIFF
--- a/src/sip/strans.c
+++ b/src/sip/strans.c
@@ -368,13 +368,11 @@ int sip_strans_reply(struct sip_strans **stp, struct sip *sip,
 		}
 		else if (scode < 300) {
 			tmr_start(&st->tmr, 64 * SIP_T1, tmr_handler, st);
-			if (pl_strcmp(&msg->met, "PRACK"))
-				st->state = ACCEPTED;
+			st->state = ACCEPTED;
 		}
 		else {
 			tmr_start(&st->tmr, 64 * SIP_T1, tmr_handler, st);
-			if (pl_strcmp(&msg->met, "PRACK"))
-				st->state = COMPLETED;
+			st->state = COMPLETED;
 
 			if (!sip_transp_reliable(st->msg->tp))
 				tmr_start(&st->tmrg, SIP_T1,

--- a/src/sip/strans.c
+++ b/src/sip/strans.c
@@ -368,11 +368,13 @@ int sip_strans_reply(struct sip_strans **stp, struct sip *sip,
 		}
 		else if (scode < 300) {
 			tmr_start(&st->tmr, 64 * SIP_T1, tmr_handler, st);
-			st->state = ACCEPTED;
+			if (!pl_strcmp(&msg->met, "INVITE"))
+				st->state = ACCEPTED;
 		}
 		else {
 			tmr_start(&st->tmr, 64 * SIP_T1, tmr_handler, st);
-			st->state = COMPLETED;
+			if (!pl_strcmp(&msg->met, "INVITE"))
+				st->state = COMPLETED;
 
 			if (!sip_transp_reliable(st->msg->tp))
 				tmr_start(&st->tmrg, SIP_T1,

--- a/src/sip/strans.c
+++ b/src/sip/strans.c
@@ -368,12 +368,12 @@ int sip_strans_reply(struct sip_strans **stp, struct sip *sip,
 		}
 		else if (scode < 300) {
 			tmr_start(&st->tmr, 64 * SIP_T1, tmr_handler, st);
-			if (!pl_strcmp(&msg->met, "INVITE"))
+			if (pl_strcmp(&msg->met, "PRACK"))
 				st->state = ACCEPTED;
 		}
 		else {
 			tmr_start(&st->tmr, 64 * SIP_T1, tmr_handler, st);
-			if (!pl_strcmp(&msg->met, "INVITE"))
+			if (pl_strcmp(&msg->met, "PRACK"))
 				st->state = COMPLETED;
 
 			if (!sip_transp_reliable(st->msg->tp))

--- a/src/sipsess/accept.c
+++ b/src/sipsess/accept.c
@@ -22,12 +22,8 @@ static void cancel_handler(void *arg)
 {
 	struct sipsess *sess = arg;
 
-	if (!sess->st && !sess->awaiting_answer && !sess->established)
-		(void)sip_reply(sess->sip, sess->msg, 487,
-				"Request Terminated");
-	else
-		(void)sip_treply(&sess->st, sess->sip, sess->msg, 487,
-				 "Request Terminated");
+	(void)sip_treply(&sess->st, sess->sip, sess->msg, 487,
+			 "Request Terminated");
 
 	sess->peerterm = true;
 
@@ -201,8 +197,7 @@ int sipsess_answer(struct sipsess *sess, uint16_t scode, const char *reason,
 	va_list ap;
 	int err;
 
-	if (!sess || !sess->msg || scode < 200 || scode > 299
-	    || (!sess->st && (sess->established || sess->awaiting_answer)))
+	if (!sess || !sess->st || !sess->msg || scode < 200 || scode > 299)
 		return EINVAL;
 
 	va_start(ap, fmt);
@@ -230,8 +225,7 @@ int sipsess_reject(struct sipsess *sess, uint16_t scode, const char *reason,
 	va_list ap;
 	int err;
 
-	if (!sess || !sess->msg || scode < 300
-	    || (!sess->st && (sess->established || sess->awaiting_answer)))
+	if (!sess || !sess->st || !sess->msg || scode < 300)
 		return EINVAL;
 
 	va_start(ap, fmt);

--- a/src/sipsess/accept.c
+++ b/src/sipsess/accept.c
@@ -22,8 +22,8 @@ static void cancel_handler(void *arg)
 {
 	struct sipsess *sess = arg;
 
-	(void)sip_treply(&sess->st, sess->sip, sess->msg, 487,
-			 "Request Terminated");
+	(void)sip_treply(&sess->st, sess->sip, sess->msg,
+			 487, "Request Terminated");
 
 	sess->peerterm = true;
 
@@ -229,14 +229,8 @@ int sipsess_reject(struct sipsess *sess, uint16_t scode, const char *reason,
 		return EINVAL;
 
 	va_start(ap, fmt);
-
-	if (!sess->st && !sess->awaiting_answer && !sess->established)
-		err = sip_replyf(sess->sip, sess->msg, scode, reason,
-				 fmt ? "%v" : NULL, fmt, &ap);
-	else
-		err = sip_treplyf(&sess->st, NULL, sess->sip, sess->msg, false,
-				  scode, reason, fmt ? "%v" : NULL, fmt, &ap);
-
+	err = sip_treplyf(&sess->st, NULL, sess->sip, sess->msg, false,
+			  scode, reason, fmt ? "%v" : NULL, fmt, &ap);
 	va_end(ap);
 
 	return err;

--- a/src/sipsess/accept.c
+++ b/src/sipsess/accept.c
@@ -201,9 +201,8 @@ int sipsess_answer(struct sipsess *sess, uint16_t scode, const char *reason,
 	va_list ap;
 	int err;
 
-	if (!sess || (!sess->st
-	    && (sess->established || sess->awaiting_answer))
-	    || !sess->msg || scode < 200 || scode > 299)
+	if (!sess || !sess->msg || scode < 200 || scode > 299
+	    || (!sess->st && (sess->established || sess->awaiting_answer)))
 		return EINVAL;
 
 	va_start(ap, fmt);
@@ -231,9 +230,8 @@ int sipsess_reject(struct sipsess *sess, uint16_t scode, const char *reason,
 	va_list ap;
 	int err;
 
-	if (!sess || (!sess->st
-	    && (sess->established || sess->awaiting_answer))
-	    || !sess->msg || scode < 300)
+	if (!sess || !sess->msg || scode < 300
+	    || (!sess->st && (sess->established || sess->awaiting_answer)))
 		return EINVAL;
 
 	va_start(ap, fmt);

--- a/src/sipsess/reply.c
+++ b/src/sipsess/reply.c
@@ -102,9 +102,8 @@ int sipsess_reply_2xx(struct sipsess *sess, const struct sip_msg *msg,
 	reply->msg  = mem_ref((void *)msg);
 	reply->sess = sess;
 
-	sip_contact_set(&contact, sess->cuser, &msg->dst, msg->tp);
-
 	is_prack = !pl_strcmp(&msg->met, "PRACK");
+	sip_contact_set(&contact, sess->cuser, &msg->dst, msg->tp);
 
 	err = sip_treplyf(is_prack ? NULL : &sess->st, &reply->mb, sess->sip,
 			  msg, true, scode, reason,
@@ -143,6 +142,7 @@ int sipsess_reply_2xx(struct sipsess *sess, const struct sip_msg *msg,
 	if (err) {
 		if (!is_prack)
 			sess->st = mem_deref(sess->st);
+
 		mem_deref(reply);
 	}
 


### PR DESCRIPTION
This PR fixes an issue introduced with PR #419. It prevented a call from being canceled during early media/ringing if a 100rel/PRACK exchange happened in the transaction.

~~Without the changes in `src/sipsess/accept.c`, the SIP 4xx responses were being retransmitted until T2 fired even though the 4xx responses were being ACKed. I haven't been able to figure out why that happened, maybe there is a better solution than the one I propose in this PR.~~

Update: The server transactions are now being correctly used. The changes in this PR provide a clean solution.