### PR TITLE
sip: add RFC 3311 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ legend:
 * [RFC 2915](https://tools.ietf.org/html/rfc2915) - The Naming Authority Pointer (NAPTR) DNS Resource Record
 * [RFC 3261](https://tools.ietf.org/html/rfc3261) - SIP: Session Initiation Protocol
 * [RFC 3262](https://tools.ietf.org/html/rfc3262) - SIP Reliability of Provisional Responses
+* [RFC 3311](https://tools.ietf.org/html/rfc3311) - The SIP UPDATE Method
 * [RFC 3263](https://tools.ietf.org/html/rfc3263) - Locating SIP Servers
 * [RFC 3264](https://tools.ietf.org/html/rfc3264) - An Offer/Answer Model with SDP
 * [RFC 3265](https://tools.ietf.org/html/rfc3265) - SIP-Specific Event Notification

--- a/src/sipsess/listen.c
+++ b/src/sipsess/listen.c
@@ -224,10 +224,11 @@ static void prack_handler(struct sipsess_sock *sock, const struct sip_msg *msg)
 }
 
 
-static void reinvite_handler(struct sipsess_sock *sock,
+static void target_refresh_handler(struct sipsess_sock *sock,
 			     const struct sip_msg *msg)
 {
 	struct sip *sip = sock->sip;
+	bool is_invite = true;
 	struct sipsess *sess;
 	struct mbuf *desc;
 	char m[256];
@@ -239,12 +240,13 @@ static void reinvite_handler(struct sipsess_sock *sock,
 		return;
 	}
 
+	is_invite = !pl_strcmp(&msg->met, "INVITE");
 	if (!sip_dialog_rseq_valid(sess->dlg, msg)) {
 		(void)sip_treply(NULL, sip, msg, 500, "Server Internal Error");
 		return;
 	}
 
-	if (sess->st || sess->awaiting_answer) {
+	if ((is_invite && sess->st) || sess->awaiting_answer) {
 		(void)sip_treplyf(NULL, NULL, sip, msg, false,
 				  500, "Server Internal Error",
 				  "Retry-After: 5\r\n"
@@ -253,7 +255,7 @@ static void reinvite_handler(struct sipsess_sock *sock,
 		return;
 	}
 
-	if (sess->req) {
+	if (is_invite && sess->req) {
 		(void)sip_treply(NULL, sip, msg, 491, "Request Pending");
 		return;
 	}
@@ -277,53 +279,6 @@ static void reinvite_handler(struct sipsess_sock *sock,
 }
 
 
-static void update_handler(struct sipsess_sock *sock,
-			   const struct sip_msg *msg)
-{
-	struct sip *sip = sock->sip;
-	struct sipsess *sess;
-	struct mbuf *desc;
-	char m[256];
-	int err;
-
-	sess = sipsess_find(sock, msg);
-	if (!sess || sess->terminated) {
-		(void)sip_treply(NULL, sip, msg, 481, "Call Does Not Exist");
-		return;
-	}
-
-	if (!sip_dialog_rseq_valid(sess->dlg, msg)) {
-		(void)sip_treply(NULL, sip, msg, 500, "Server Internal Error");
-		return;
-	}
-
-	if (sess->awaiting_answer) {
-		(void)sip_treplyf(NULL, NULL, sip, msg, false,
-				  500, "Server Internal Error",
-				  "Retry-After: 5\r\n"
-				  "Content-Length: 0\r\n"
-				  "\r\n");
-		return;
-	}
-
-	err = sess->offerh(&desc, msg, sess->arg);
-	if (err) {
-		(void)sip_reply(sip, msg, 488, str_error(err, m, sizeof(m)));
-		return;
-	}
-
-	(void)sip_dialog_update(sess->dlg, msg);
-	(void)sipsess_reply_2xx(sess, msg, 200, "OK", desc, NULL, NULL);
-
-	/* pending modifications considered outdated;
-	 * sdp may have changed in above exchange */
-	sess->desc = mem_deref(sess->desc);
-	sess->modify_pending = false;
-	tmr_cancel(&sess->tmr);
-	mem_deref(desc);
-}
-
-
 static void invite_handler(struct sipsess_sock *sock,
 			   const struct sip_msg *msg)
 {
@@ -338,14 +293,14 @@ static bool request_handler(const struct sip_msg *msg, void *arg)
 	if (!pl_strcmp(&msg->met, "INVITE")) {
 
 		if (pl_isset(&msg->to.tag))
-			reinvite_handler(sock, msg);
+			target_refresh_handler(sock, msg);
 		else
 			invite_handler(sock, msg);
 
 		return true;
 	}
 	else if (!pl_strcmp(&msg->met, "UPDATE")) {
-		update_handler(sock, msg);
+		target_refresh_handler(sock, msg);
 		return true;
 	}
 	else if (!pl_strcmp(&msg->met, "ACK")) {

--- a/src/sipsess/sipsess.h
+++ b/src/sipsess/sipsess.h
@@ -95,6 +95,7 @@ int  sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 int  sipsess_reply_ack(struct sipsess *sess, const struct sip_msg *msg,
 		       bool *awaiting_answer);
 int  sipsess_reinvite(struct sipsess *sess, bool reset_ls);
+int  sipsess_update(struct sipsess *sess, bool reset_ls);
 int  sipsess_bye(struct sipsess *sess, bool reset_ls);
 int  sipsess_request_alloc(struct sipsess_request **reqp, struct sipsess *sess,
 			   const char *ctype, struct mbuf *body,


### PR DESCRIPTION
This PR adds support for [RFC 3311](https://datatracker.ietf.org/doc/html/rfc3311) - the SIP UPDATE method.

Related:
- https://github.com/baresip/baresip/pull/1941