### PR TITLE
tls: Add a method to set OpenSSL certificate

### DIFF
--- a/include/re_tls.h
+++ b/include/re_tls.h
@@ -12,9 +12,12 @@ struct tls;
 struct tls_conn;
 struct tcp_conn;
 struct udp_sock;
+
+#ifndef USE_OPENSSL
 struct ssl_ctx_st;
 
 typedef struct ssl_ctx_st SSL_CTX;
+#endif
 
 
 /** Defines the TLS method */
@@ -126,7 +129,7 @@ void dtls_recv_packet(struct dtls_sock *sock, const struct sa *src,
 
 
 #ifdef USE_OPENSSL
-struct ssl_ctx_st *tls_openssl_context(const struct tls *tls);
+SSL_CTX *tls_openssl_context(const struct tls *tls);
 int tls_set_certificate_openssl(struct tls *tls, X509* cert, EVP_PKEY* pkey,
 				bool up_ref);
 #endif

--- a/include/re_tls.h
+++ b/include/re_tls.h
@@ -4,6 +4,10 @@
  * Copyright (C) 2010 Creytiv.com
  */
 
+#ifdef USE_OPENSSL
+#include <openssl/ossl_typ.h>
+#endif
+
 struct tls;
 struct tls_conn;
 struct tcp_conn;
@@ -123,4 +127,6 @@ void dtls_recv_packet(struct dtls_sock *sock, const struct sa *src,
 
 #ifdef USE_OPENSSL
 struct ssl_ctx_st *tls_openssl_context(const struct tls *tls);
+int tls_set_certificate_openssl(struct tls *tls, X509* cert, EVP_PKEY* pkey,
+				bool up_ref);
 #endif

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -1343,7 +1343,7 @@ void tls_flush_error(void)
  *
  * @return OpenSSL context
  */
-struct ssl_ctx_st *tls_openssl_context(const struct tls *tls)
+SSL_CTX *tls_openssl_context(const struct tls *tls)
 {
 	return tls ? tls->ctx : NULL;
 }
@@ -1641,7 +1641,7 @@ static bool remove_handler(struct le *le, void *arg)
 }
 
 
-static void session_remove_cb(struct ssl_ctx_st *ctx, SSL_SESSION *sess)
+static void session_remove_cb(SSL_CTX *ctx, SSL_SESSION *sess)
 {
 	struct tls *tls = SSL_SESSION_get_ex_data(sess, 0);
 	(void) ctx;

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -708,6 +708,55 @@ int tls_set_selfsigned_rsa(struct tls *tls, const char *cn, size_t bits)
 	return err;
 }
 
+/**
+ * Set the certificate and private key on a TLS context
+ *
+ * @param tls      TLS Context
+ * @param cert     Certificate
+ * @param pkey     Private key
+ * @param up_ref   If true, increment reference count of the certificate if
+ *                 successfully set.
+ *                 If false, the reference count is not incremented and
+ *                 the ownership of the certificate is passed to the TLS
+ *                 context.
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int tls_set_certificate_openssl(struct tls *tls, X509* cert, EVP_PKEY* pkey,
+				bool up_ref)
+{
+	int r, err = ENOMEM;
+
+	if (!tls || !cert || !pkey)
+		return EINVAL;
+
+	r = SSL_CTX_use_certificate(tls->ctx, cert);
+	if (r != 1)
+		goto out;
+
+	r = SSL_CTX_use_PrivateKey(tls->ctx, pkey);
+	if (r != 1) {
+		DEBUG_WARNING("set_certificate_openssl: use_PrivateKey"
+			      " failed\n");
+		goto out;
+	}
+
+	if (tls->cert)
+		X509_free(tls->cert);
+
+	tls->cert = cert;
+
+	if (up_ref)
+		X509_up_ref(tls->cert);
+
+	err = 0;
+
+out:
+	if (err)
+		ERR_clear_error();
+
+	return err;
+}
 
 /**
  * Set the certificate and private key on a TLS context


### PR DESCRIPTION
- Add a method to set OpenSSL TLS certificate. This allows an application to provide its own TLS certificate in the form of OpenSSL structures to use in a TLS context.
- Avoid using OpenSSL internal type names. OpenSSL documentation only mentions `SSL_CTX` as the TLS context type, so use that consistently in libre function definitions.
