### PR TITLE
sipsess: fix PRACK offer/answer behavior

### DIFF
--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -101,6 +101,7 @@ static void invite_resp_handler(int err, const struct sip_msg *msg, void *arg)
 							   sess->arg);
 				}
 			}
+
 			err |= sip_dialog_established(sess->dlg) ?
 					sip_dialog_update(sess->dlg, msg) :
 					sip_dialog_create(sess->dlg, msg);

--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -84,19 +84,22 @@ static void invite_resp_handler(int err, const struct sip_msg *msg, void *arg)
 
 	if (msg->scode < 200) {
 		sess->progrh(msg, sess->arg);
-		if (sess->sent_offer) {
-			err = sess->answerh(msg, sess->arg);
-			if (err)
-				goto out;
-		}
 
 		if (sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE, "100rel")
 				&& sess->rel100_supported) {
 
-			if (!sess->sent_offer && msg && mbuf_get_left(msg->mb))
-			{
-				sess->modify_pending = false;
-				err = sess->offerh(&desc, msg, sess->arg);
+			if (msg && mbuf_get_left(msg->mb)) {
+				if (sess->sent_offer) {
+					sess->awaiting_answer = false;
+					err = sess->answerh(msg, sess->arg);
+					if (err)
+						goto out;
+				}
+				else {
+					sess->modify_pending = false;
+					err = sess->offerh(&desc, msg,
+							   sess->arg);
+				}
 			}
 			err |= sip_dialog_established(sess->dlg) ?
 					sip_dialog_update(sess->dlg, msg) :

--- a/src/sipsess/listen.c
+++ b/src/sipsess/listen.c
@@ -194,6 +194,7 @@ static void prack_handler(struct sipsess_sock *sock, const struct sip_msg *msg)
 	bool awaiting_answer = false;
 
 	sess = sipsess_find(sock, msg);
+
 	if (!sess || sipsess_reply_find(sess, msg, &awaiting_answer)) {
 		(void)sip_reply(sock->sip, msg, 481,
 				"Transaction Does Not Exist");

--- a/src/sipsess/listen.c
+++ b/src/sipsess/listen.c
@@ -155,7 +155,7 @@ static void ack_handler(struct sipsess_sock *sock, const struct sip_msg *msg)
 	if (!sess)
 		return;
 
-	if (sipsess_reply_find(sess, msg, &awaiting_answer))
+	if (sipsess_reply_ack(sess, msg, &awaiting_answer))
 		return;
 
 	if (sess->terminated) {
@@ -195,7 +195,7 @@ static void prack_handler(struct sipsess_sock *sock, const struct sip_msg *msg)
 
 	sess = sipsess_find(sock, msg);
 
-	if (!sess || sipsess_reply_find(sess, msg, &awaiting_answer)) {
+	if (!sess || sipsess_reply_ack(sess, msg, &awaiting_answer)) {
 		(void)sip_reply(sock->sip, msg, 481,
 				"Transaction Does Not Exist");
 		return;

--- a/src/sipsess/listen.c
+++ b/src/sipsess/listen.c
@@ -155,7 +155,7 @@ static void ack_handler(struct sipsess_sock *sock, const struct sip_msg *msg)
 	if (!sess)
 		return;
 
-	if (sipsess_reply_ack(sess, msg, &awaiting_answer))
+	if (sipsess_reply_find(sess, msg, &awaiting_answer))
 		return;
 
 	if (sess->terminated) {
@@ -194,8 +194,7 @@ static void prack_handler(struct sipsess_sock *sock, const struct sip_msg *msg)
 	bool awaiting_answer = false;
 
 	sess = sipsess_find(sock, msg);
-
-	if (!sess || sipsess_reply_prack(sess, msg, &awaiting_answer)) {
+	if (!sess || sipsess_reply_find(sess, msg, &awaiting_answer)) {
 		(void)sip_reply(sock->sip, msg, 481,
 				"Transaction Does Not Exist");
 		return;

--- a/src/sipsess/reply.c
+++ b/src/sipsess/reply.c
@@ -267,7 +267,7 @@ static bool cmp_handler(struct le *le, void *arg)
 }
 
 
-int sipsess_reply_find(struct sipsess *sess, const struct sip_msg *msg,
+int sipsess_reply_ack(struct sipsess *sess, const struct sip_msg *msg,
 		      bool *awaiting_answer)
 {
 	struct sipsess_reply *reply;

--- a/src/sipsess/reply.c
+++ b/src/sipsess/reply.c
@@ -286,7 +286,7 @@ int sipsess_reply_ack(struct sipsess *sess, const struct sip_msg *msg,
 
 
 int sipsess_reply_prack(struct sipsess *sess, const struct sip_msg *msg,
-		      bool *awaiting_answer)
+			struct mbuf *desc, bool *awaiting_answer)
 {
 	struct sipsess_reply *reply;
 	int err;
@@ -297,7 +297,7 @@ int sipsess_reply_prack(struct sipsess *sess, const struct sip_msg *msg,
 		return ENOENT;
 
 	*awaiting_answer = reply->awaiting_answer;
-	err = sipsess_reply_2xx(sess, msg, 200, "OK", NULL, NULL, NULL);
+	err = sipsess_reply_2xx(sess, msg, 200, "OK", desc, NULL, NULL);
 
 	mem_deref(reply);
 

--- a/src/sipsess/reply.c
+++ b/src/sipsess/reply.c
@@ -87,25 +87,28 @@ int sipsess_reply_2xx(struct sipsess *sess, const struct sip_msg *msg,
 		      uint16_t scode, const char *reason, struct mbuf *desc,
 		      const char *fmt, va_list *ap)
 {
-	struct sipsess_reply *reply;
+	struct sipsess_reply *reply = NULL;
 	struct sip_contact contact;
 	int err = ENOMEM;
 	bool is_prack = !pl_strcmp(&msg->met, "PRACK");
 
-	reply = mem_zalloc(sizeof(*reply), destructor);
-	if (!reply)
-		goto out;
+	if (!is_prack) {
+		reply = mem_zalloc(sizeof(*reply), destructor);
+		if (!reply)
+			goto out;
 
-	if (!is_prack)
 		list_append(&sess->replyl, &reply->le, reply);
 
-	reply->rel_seq = 0;
-	reply->seq  = msg->cseq.num;
-	reply->msg  = mem_ref((void *)msg);
-	reply->sess = sess;
+		reply->rel_seq = 0;
+		reply->seq  = msg->cseq.num;
+		reply->msg  = mem_ref((void *)msg);
+		reply->sess = sess;
+	}
+
 	sip_contact_set(&contact, sess->cuser, &msg->dst, msg->tp);
 
-	err = sip_treplyf(is_prack ? NULL : &sess->st, &reply->mb, sess->sip,
+	err = sip_treplyf(is_prack ? NULL : &sess->st,
+			  reply ? &reply->mb : NULL, sess->sip,
 			  msg, true, scode, reason,
 			  "%H"
 			  "%v"
@@ -125,17 +128,14 @@ int sipsess_reply_2xx(struct sipsess *sess, const struct sip_msg *msg,
 	if (err)
 		goto out;
 
-	if (!is_prack) {
+	if (reply) {
 		tmr_start(&reply->tmr, 64 * SIP_T1, tmr_handler, reply);
 		tmr_start(&reply->tmrg, SIP_T1, retransmit_handler, reply);
-	}
-	else {
-		mem_deref(reply);
-	}
 
-	if (!mbuf_get_left(msg->mb) && desc) {
-		reply->awaiting_answer = true;
-		sess->awaiting_answer = true;
+		if (!mbuf_get_left(msg->mb) && desc) {
+			reply->awaiting_answer = true;
+			sess->awaiting_answer = true;
+		}
 	}
 
  out:

--- a/src/sipsess/reply.c
+++ b/src/sipsess/reply.c
@@ -267,26 +267,8 @@ static bool cmp_handler(struct le *le, void *arg)
 }
 
 
-int sipsess_reply_ack(struct sipsess *sess, const struct sip_msg *msg,
+int sipsess_reply_find(struct sipsess *sess, const struct sip_msg *msg,
 		      bool *awaiting_answer)
-{
-	struct sipsess_reply *reply;
-
-	reply = list_ledata(list_apply(&sess->replyl, false, cmp_handler,
-				       (void *)msg));
-	if (!reply)
-		return ENOENT;
-
-	*awaiting_answer = reply->awaiting_answer;
-
-	mem_deref(reply);
-
-	return 0;
-}
-
-
-int sipsess_reply_prack(struct sipsess *sess, const struct sip_msg *msg,
-			bool *awaiting_answer)
 {
 	struct sipsess_reply *reply;
 

--- a/src/sipsess/sipsess.h
+++ b/src/sipsess/sipsess.h
@@ -95,7 +95,7 @@ int  sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 int  sipsess_reply_ack(struct sipsess *sess, const struct sip_msg *msg,
 		       bool *awaiting_answer);
 int  sipsess_reply_prack(struct sipsess *sess, const struct sip_msg *msg,
-			 struct mbuf *desc, bool *awaiting_answer);
+			 bool *awaiting_answer);
 int  sipsess_reinvite(struct sipsess *sess, bool reset_ls);
 int  sipsess_bye(struct sipsess *sess, bool reset_ls);
 int  sipsess_request_alloc(struct sipsess_request **reqp, struct sipsess *sess,

--- a/src/sipsess/sipsess.h
+++ b/src/sipsess/sipsess.h
@@ -92,10 +92,8 @@ int  sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 		       uint16_t scode, const char *reason,
 		       enum rel100_mode rel100, struct mbuf *desc,
 		       const char *fmt, va_list *ap);
-int  sipsess_reply_ack(struct sipsess *sess, const struct sip_msg *msg,
+int  sipsess_reply_find(struct sipsess *sess, const struct sip_msg *msg,
 		       bool *awaiting_answer);
-int  sipsess_reply_prack(struct sipsess *sess, const struct sip_msg *msg,
-			 bool *awaiting_answer);
 int  sipsess_reinvite(struct sipsess *sess, bool reset_ls);
 int  sipsess_bye(struct sipsess *sess, bool reset_ls);
 int  sipsess_request_alloc(struct sipsess_request **reqp, struct sipsess *sess,

--- a/src/sipsess/sipsess.h
+++ b/src/sipsess/sipsess.h
@@ -95,7 +95,7 @@ int  sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 int  sipsess_reply_ack(struct sipsess *sess, const struct sip_msg *msg,
 		       bool *awaiting_answer);
 int  sipsess_reply_prack(struct sipsess *sess, const struct sip_msg *msg,
-			 bool *awaiting_answer);
+			 struct mbuf *desc, bool *awaiting_answer);
 int  sipsess_reinvite(struct sipsess *sess, bool reset_ls);
 int  sipsess_bye(struct sipsess *sess, bool reset_ls);
 int  sipsess_request_alloc(struct sipsess_request **reqp, struct sipsess *sess,

--- a/src/sipsess/sipsess.h
+++ b/src/sipsess/sipsess.h
@@ -92,7 +92,7 @@ int  sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 		       uint16_t scode, const char *reason,
 		       enum rel100_mode rel100, struct mbuf *desc,
 		       const char *fmt, va_list *ap);
-int  sipsess_reply_find(struct sipsess *sess, const struct sip_msg *msg,
+int  sipsess_reply_ack(struct sipsess *sess, const struct sip_msg *msg,
 		       bool *awaiting_answer);
 int  sipsess_reinvite(struct sipsess *sess, bool reset_ls);
 int  sipsess_bye(struct sipsess *sess, bool reset_ls);


### PR DESCRIPTION
[According to RFC 3262](https://datatracker.ietf.org/doc/html/rfc3262#section-5), PRACKs and reliable 1xx responses can contain both SDP answers and offers. E.g. if a reliable 1xx response contains an offer, the PRACK **MUST** contain an answer. This behavior is now correctly supported.

This situation can occur when an initial INVITE did not contain SDP, but the 1xx response did (which is rare in most real world scenarios).