### PR TITLE
thread: thrd_error fixes

### DIFF
--- a/include/re_thread.h
+++ b/include/re_thread.h
@@ -256,9 +256,13 @@ void tss_delete(tss_t key);
 
 /******************************************************************************
  * Extra - non C11 helpers
+ * (We avoid tss_ mtx_ cnd_ prefixes since these reserved for functions with
+ * different return values)
  *****************************************************************************/
-/* int thrd_prio(enum thrd_prio prio) */
-/* void thrd_print(struct re_printf *pf, void *unused); */
+
+/* Ideas: */
+/* int thread_prio(enum thrd_prio prio) */
+/* void thread_print(struct re_printf *pf, void *unused); */
 
 /**
  * Allocates and initializes a new mutex
@@ -267,7 +271,7 @@ void tss_delete(tss_t key);
  *
  * @return 0 if success, otherwise errorcode
  */
-int mtx_alloc(mtx_t **mtx);
+int mutex_alloc(mtx_t **mtx);
 
 
 /**
@@ -278,7 +282,7 @@ int mtx_alloc(mtx_t **mtx);
  * @param func  Function to execute
  * @param arg   Argument to pass to the function
  *
- * @return thrd_success on success, otherwise thrd_error or thrd_nomem
+ * @return 0 if success, otherwise errorcode
  */
-int thrd_create_name(thrd_t *thr, const char *name, thrd_start_t func,
+int thread_create_name(thrd_t *thr, const char *name, thrd_start_t func,
 		     void *arg);

--- a/include/re_thread.h
+++ b/include/re_thread.h
@@ -67,7 +67,7 @@ typedef int (*thrd_start_t)(void *);
  * @param func  Function to execute
  * @param arg   Argument to pass to the function
  *
- * @return 0 if success, otherwise errorcode
+ * @return thrd_success on success, otherwise thrd_error
  */
 int thrd_create(thrd_t *thr, thrd_start_t func, void *arg);
 
@@ -96,7 +96,7 @@ thrd_t thrd_current(void);
  *
  * @param thr  Thread
  *
- * @return 0 if success, otherwise errorcode
+ * @return thrd_success on success, otherwise thrd_error
  */
 int thrd_detach(thrd_t thr);
 
@@ -108,7 +108,7 @@ int thrd_detach(thrd_t thr);
  * @param thr  Thread
  * @param res  Result code location
  *
- * @return 0 if success, otherwise errorcode
+ * @return thrd_success on success, otherwise thrd_error
  */
 int thrd_join(thrd_t thr, int *res);
 
@@ -139,7 +139,7 @@ void thrd_exit(int res);
  *
  * @param cnd  Pointer to a variable to store condition variable
  *
- * @return 0 if success, otherwise errorcode
+ * @return thrd_success on success, otherwise thrd_error
  */
 int cnd_init(cnd_t *cnd);
 
@@ -149,7 +149,7 @@ int cnd_init(cnd_t *cnd);
  *
  * @param cnd  Pointer to condition variable
  *
- * @return 0 if success, otherwise errorcode
+ * @return thrd_success on success, otherwise thrd_error
  */
 int cnd_signal(cnd_t *cnd);
 
@@ -159,7 +159,7 @@ int cnd_signal(cnd_t *cnd);
  *
  * @param cnd  Pointer to condition variable
  *
- * @return 0 if success, otherwise errorcode
+ * @return thrd_success on success, otherwise thrd_error
  */
 int cnd_broadcast(cnd_t *cnd);
 
@@ -170,7 +170,7 @@ int cnd_broadcast(cnd_t *cnd);
  * @param cnd   Pointer to condition variable
  * @param mtx   Lock mutex pointer
  *
- * @return 0 if success, otherwise errorcode
+ * @return thrd_success on success, otherwise thrd_error
  */
 int cnd_wait(cnd_t *cnd, mtx_t *mtx);
 
@@ -278,7 +278,7 @@ int mtx_alloc(mtx_t **mtx);
  * @param func  Function to execute
  * @param arg   Argument to pass to the function
  *
- * @return 0 if success, otherwise errorcode
+ * @return thrd_success on success, otherwise thrd_error or thrd_nomem
  */
 int thrd_create_name(thrd_t *thr, const char *name, thrd_start_t func,
 		     void *arg);

--- a/src/jbuf/jbuf.c
+++ b/src/jbuf/jbuf.c
@@ -189,8 +189,10 @@ int jbuf_alloc(struct jbuf **jbp, uint32_t min, uint32_t max)
 
 	jb->pt = -1;
 	err = mtx_init(&jb->lock, mtx_plain);
-	if (err)
+	if (err != thrd_success) {
+		err = ENOMEM;
 		goto out;
+	}
 
 	/* Allocate all frames now */
 	for (i=0; i<jb->max; i++) {

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -179,11 +179,10 @@ static void re_once(void)
 	int err;
 
 	err = tss_create(&key, thread_destructor);
-	if (err == thrd_error) {
-		DEBUG_WARNING("tss_create failed: %d\n", err);
-		exit(err);
+	if (err != thrd_success) {
+		DEBUG_WARNING("tss_create failed\n");
+		exit(ENOMEM);
 	}
-
 }
 
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -145,7 +145,7 @@ int re_alloc(struct re **rep)
 	if (!re)
 		return ENOMEM;
 
-	err = mtx_alloc(&re->mutex);
+	err = mutex_alloc(&re->mutex);
 	if (err) {
 		DEBUG_WARNING("thread_init: mtx_init error\n");
 		goto out;
@@ -212,8 +212,8 @@ static inline void re_lock(struct re *re)
 	int err;
 
 	err = mtx_lock(re->mutexp);
-	if (err)
-		DEBUG_WARNING("re_lock: %m\n", err);
+	if (err != thrd_success)
+		DEBUG_WARNING("re_lock err\n");
 }
 
 
@@ -222,8 +222,8 @@ static inline void re_unlock(struct re *re)
 	int err;
 
 	err = mtx_unlock(re->mutexp);
-	if (err)
-		DEBUG_WARNING("re_unlock: %m\n", err);
+	if (err != thrd_success)
+		DEBUG_WARNING("re_unlock err\n");
 }
 
 
@@ -1258,8 +1258,10 @@ int re_thread_init(void)
 		re_global = re;
 
 	err = tss_set(key, re);
-	if (err == thrd_error)
+	if (err != thrd_success) {
+		err = ENOMEM;
 		DEBUG_WARNING("thread_init: tss_set error\n");
+	}
 
 	return err;
 }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -179,7 +179,7 @@ static void re_once(void)
 	int err;
 
 	err = tss_create(&key, thread_destructor);
-	if (err) {
+	if (err == thrd_error) {
 		DEBUG_WARNING("tss_create failed: %d\n", err);
 		exit(err);
 	}
@@ -1258,7 +1258,7 @@ int re_thread_init(void)
 		re_global = re;
 
 	err = tss_set(key, re);
-	if (err)
+	if (err == thrd_error)
 		DEBUG_WARNING("thread_init: tss_set error\n");
 
 	return err;

--- a/src/rtp/sess.c
+++ b/src/rtp/sess.c
@@ -248,7 +248,7 @@ int rtcp_sess_alloc(struct rtcp_sess **sessp, struct rtp_sock *rs)
 	sess->rs = rs;
 	tmr_init(&sess->tmr);
 
-	err = mtx_alloc(&sess->lock);
+	err = mutex_alloc(&sess->lock);
 	if (err)
 		goto out;
 

--- a/src/thread/posix.c
+++ b/src/thread/posix.c
@@ -32,20 +32,22 @@ int thrd_create(thrd_t *thr, thrd_start_t func, void *arg)
 	int err;
 
 	if (!thr || !func)
-		return EINVAL;
+		return thrd_error;
 
 	th = mem_alloc(sizeof(struct thread), NULL);
 	if (!th)
-		return ENOMEM;
+		return thrd_nomem;
 
 	th->func = func;
 	th->arg	 = arg;
 
 	err = pthread_create(thr, NULL, thrd_handler, th);
-	if (err)
+	if (err) {
 		mem_deref(th);
+		return thrd_error;
+	}
 
-	return err;
+	return thrd_success;
 }
 
 
@@ -63,7 +65,7 @@ thrd_t thrd_current(void)
 
 int thrd_detach(thrd_t thr)
 {
-	return pthread_detach(thr);
+	return (pthread_detach(thr) == 0) ? thrd_success : thrd_error;
 }
 
 
@@ -96,27 +98,27 @@ void thrd_exit(int res)
 int cnd_init(cnd_t *cnd)
 {
 	if (!cnd)
-		return EINVAL;
+		return thrd_error;
 
-	return pthread_cond_init(cnd, NULL);
+	return (pthread_cond_init(cnd, NULL) == 0) ? thrd_success : thrd_error;
 }
 
 
 int cnd_signal(cnd_t *cnd)
 {
 	if (!cnd)
-		return EINVAL;
+		return thrd_error;
 
-	return pthread_cond_signal(cnd);
+	return (pthread_cond_signal(cnd) == 0) ? thrd_success : thrd_error;
 }
 
 
 int cnd_wait(cnd_t *cnd, mtx_t *mtx)
 {
 	if (!cnd || !mtx)
-		return EINVAL;
+		return thrd_error;
 
-	return pthread_cond_wait(cnd, mtx);
+	return (pthread_cond_wait(cnd, mtx) == 0) ? thrd_success : thrd_error;
 }
 
 
@@ -140,10 +142,12 @@ int mtx_init(mtx_t *mtx, int type)
 		pthread_mutex_init(mtx, NULL);
 		return thrd_success;
 	}
+
 	pthread_mutexattr_init(&attr);
 	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
 	pthread_mutex_init(mtx, &attr);
 	pthread_mutexattr_destroy(&attr);
+
 	return thrd_success;
 }
 

--- a/src/thread/posix.c
+++ b/src/thread/posix.c
@@ -16,7 +16,7 @@ struct thread {
 };
 
 
-static void *thrd_handler(void *p)
+static void *handler(void *p)
 {
 	struct thread th = *(struct thread *)p;
 
@@ -41,7 +41,7 @@ int thrd_create(thrd_t *thr, thrd_start_t func, void *arg)
 	th->func = func;
 	th->arg	 = arg;
 
-	err = pthread_create(thr, NULL, thrd_handler, th);
+	err = pthread_create(thr, NULL, handler, th);
 	if (err) {
 		mem_deref(th);
 		return thrd_error;

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -3,7 +3,7 @@
 #include <re_thread.h>
 
 
-static void mtx_destructor(void *data)
+static void mutex_destructor(void *data)
 {
 	mtx_t *mtx = data;
 
@@ -11,7 +11,7 @@ static void mtx_destructor(void *data)
 }
 
 
-int mtx_alloc(mtx_t **mtx)
+int mutex_alloc(mtx_t **mtx)
 {
 	mtx_t *m;
 	int err;
@@ -29,7 +29,7 @@ int mtx_alloc(mtx_t **mtx)
 		goto out;
 	}
 
-	mem_destructor(m, mtx_destructor);
+	mem_destructor(m, mutex_destructor);
 
 	*mtx = m;
 
@@ -41,13 +41,13 @@ out:
 }
 
 
-int thrd_create_name(thrd_t *thr, const char *name, thrd_start_t func,
+int thread_create_name(thrd_t *thr, const char *name, thrd_start_t func,
 		     void *arg)
 {
-	(void)name; /* @TODO implement */
+	(void)name;
 
 	if (!thr || !func)
-		return thrd_error;
+		return EINVAL;
 
-	return thrd_create(thr, func, arg);
+	return (thrd_create(thr, func, arg) == thrd_success) ? 0 : EAGAIN;
 }

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -24,8 +24,8 @@ int mutex_alloc(mtx_t **mtx)
 		return ENOMEM;
 
 	err = mtx_init(m, mtx_plain);
-	if (err == thrd_error) {
-		err = EBUSY;
+	if (err != thrd_success) {
+		err = ENOMEM;
 		goto out;
 	}
 

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -24,8 +24,10 @@ int mtx_alloc(mtx_t **mtx)
 		return ENOMEM;
 
 	err = mtx_init(m, mtx_plain);
-	if (err)
+	if (err == thrd_error) {
+		err = EBUSY;
 		goto out;
+	}
 
 	mem_destructor(m, mtx_destructor);
 
@@ -42,13 +44,10 @@ out:
 int thrd_create_name(thrd_t *thr, const char *name, thrd_start_t func,
 		     void *arg)
 {
-	int err;
 	(void)name; /* @TODO implement */
 
 	if (!thr || !func)
-		return EINVAL;
+		return thrd_error;
 
-	err = thrd_create(thr, func, arg);
-
-	return err;
+	return thrd_create(thr, func, arg);
 }

--- a/src/thread/win32.c
+++ b/src/thread/win32.c
@@ -27,7 +27,7 @@ struct thread {
 	void *arg;
 };
 
-static int tss_dtor_register(tss_t key, tss_dtor_t dtor)
+static int dtor_register(tss_t key, tss_dtor_t dtor)
 {
 	int i;
 
@@ -81,7 +81,7 @@ static unsigned __stdcall thrd_handler(void *p)
 int thrd_create(thrd_t *thr, thrd_start_t func, void *arg)
 {
 	struct thread *th;
-	int err = 0;
+	int err = thrd_success;
 	uintptr_t handle;
 
 	if (!thr || !func)
@@ -291,7 +291,7 @@ int tss_create(tss_t *key, tss_dtor_t destructor)
 	if (!destructor)
 		return thrd_success;
 
-	err = tss_dtor_register(*key, destructor);
+	err = dtor_register(*key, destructor);
 	if (err) {
 		TlsFree(*key);
 		return thrd_error;

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -116,8 +116,10 @@ int re_trace_init(const char *json_file)
 	}
 
 	err = mtx_init(&trace.lock, mtx_plain);
-	if (err)
+	if (err != thrd_success) {
+		err = ENOMEM;
 		goto out;
+	}
 
 	err = fs_fopen(&trace.f, json_file, "w+");
 	if (err)


### PR DESCRIPTION
This PR cleanups return value handling for some C11 thread functions.

It renames `mtx_alloc` -> `mutex_alloc` and `thrd_create_name` -> `thread_create_name` to make clear that these are libre related functions that uses other return values (0 for success etc.).

Fixes #429 