### PR TITLE
sipsess: fix coverity warnings

### DIFF
--- a/src/sipsess/accept.c
+++ b/src/sipsess/accept.c
@@ -109,28 +109,6 @@ int sipsess_accept(struct sipsess **sessp, struct sipsess_sock *sock,
 		err = sipsess_reply_2xx(sess, msg, scode, reason, desc,
 					fmt, &ap);
 	}
-	else {
-		struct sip_contact contact;
-
-		sip_contact_set(&contact, sess->cuser, &msg->dst, msg->tp);
-
-		err = sip_treplyf(&sess->st, NULL, sess->sip,
-				  msg, true, scode, reason,
-				  "%H"
-				  "%v"
-				  "%s%s%s"
-				  "Content-Length: %zu\r\n"
-				  "\r\n"
-				  "%b",
-				  sip_contact_print, &contact,
-				  fmt, &ap,
-				  desc ? "Content-Type: " : "",
-				  desc ? sess->ctype : "",
-				  desc ? "\r\n" : "",
-				  desc ? mbuf_get_left(desc) : (size_t)0,
-				  desc ? mbuf_buf(desc) : NULL,
-				  desc ? mbuf_get_left(desc) : (size_t)0);
-	}
 
 	va_end(ap);
 

--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -79,7 +79,10 @@ static void invite_resp_handler(int err, const struct sip_msg *msg, void *arg)
 	struct sipsess *sess = arg;
 	struct mbuf *desc = NULL;
 
-	if (err || sip_request_loops(&sess->ls, msg->scode))
+	if (!sess)
+		return;
+
+	if (!msg || err || sip_request_loops(&sess->ls, msg->scode))
 		goto out;
 
 	if (msg->scode < 200) {
@@ -88,7 +91,7 @@ static void invite_resp_handler(int err, const struct sip_msg *msg, void *arg)
 		if (sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE, "100rel")
 				&& sess->rel100_supported) {
 
-			if (msg && mbuf_get_left(msg->mb)) {
+			if (mbuf_get_left(msg->mb)) {
 				if (sess->sent_offer) {
 					sess->awaiting_answer = false;
 					err = sess->answerh(msg, sess->arg);


### PR DESCRIPTION
remove unneccessary null check and remove dead code part that is covered by sipsess_reply_xx functions.

fixes #432