### PR TITLE
rtmp: check upper bound for amf array

### DIFF
--- a/src/rtmp/amf_dec.c
+++ b/src/rtmp/amf_dec.c
@@ -165,7 +165,7 @@ static int amf_decode_value(struct odict *dict, const char *key,
 			return ENODATA;
 
 		array_len = ntohl(mbuf_read_u32(mb));
-		if (!array_len)
+		if (!array_len || array_len > 65536)
 			return EPROTO;
 
 		err = odict_alloc(&object, 32);


### PR DESCRIPTION
reported by Coverity:

```
** CID 354662:  Insecure data handling  (TAINTED_SCALAR)
/src/rtmp/amf_dec.c: 175 in amf_decode_value()

________________________________________________________________________________________________________
*** CID 354662:  Insecure data handling  (TAINTED_SCALAR)
/src/rtmp/amf_dec.c: 175 in amf_decode_value()
169     			return EPROTO;
170
171     		err = odict_alloc(&object, 32);
172     		if (err)
173     			return err;
174
>>>     CID 354662:  Insecure data handling  (TAINTED_SCALAR)
>>>     Using tainted variable "array_len" as a loop boundary.
175     		for (i=0; i<array_len; i++) {
176
177     			char ix[32];
178
179     			re_snprintf(ix, sizeof(ix), "%u", i);
180
```
