### PR TITLE
atomic: add some short atomic alias helpers

### DIFF
--- a/include/re_atomic.h
+++ b/include/re_atomic.h
@@ -715,4 +715,165 @@ static __forceinline unsigned __int64 _re_atomic_fetch_and(
 #define RE_ATOMIC
 #endif
 
+
+/* --- Some short alias helpers --- */
+
+/**
+ * @def re_atomic_weak(_a)
+ *
+ * Load value from an atomic object with relaxed order
+ *
+ * @param _a  pointer to the atomic object
+ *
+ * @return value of the atomic variable
+ */
+#define re_atomic_weak(_a) re_atomic_load(_a, re_memory_order_relaxed)
+
+
+/**
+ * @def re_atomic_weak_set(_a, _v)
+ *
+ * Store value in an atomic object with relaxed order
+ *
+ * @param _a  pointer to the atomic object
+ * @param _v  new value
+ */
+#define re_atomic_weak_set(_a, _v)                                            \
+	re_atomic_store(_a, _v, re_memory_order_relaxed)
+
+
+/**
+ * @def re_atomic_weak_add(_a, _v)
+ *
+ * Replace value from an atomic object with addition and relaxed order
+ *
+ * @param _a  pointer to the atomic object
+ * @param _v  value to add
+ *
+ * @return value held previously by the atomic variable
+ */
+#define re_atomic_weak_add(_a, _v)                                            \
+	re_atomic_fetch_add(_a, _v, re_memory_order_relaxed)
+
+
+/**
+ * @def re_atomic_weak_sub(_a, _v)
+ *
+ * Replace value from an atomic object with substraction and relaxed order
+ *
+ * @param _a  pointer to the atomic object
+ * @param _v  value to subtract
+ *
+ * @return value held previously by the atomic variable
+ */
+#define re_atomic_weak_sub(_a, _v)                                            \
+	re_atomic_fetch_sub(_a, _v, re_memory_order_relaxed)
+
+
+/**
+ * @def re_atomic_strong(_a)
+ *
+ * Load value from an atomic object with acquire order
+ *
+ * @param _a  pointer to the atomic object
+ *
+ * @return value of the atomic variable
+ */
+#define re_atomic_strong(_a) re_atomic_load(_a, re_memory_order_acquire)
+
+
+/**
+ * @def re_atomic_strong_set(_a, _v)
+ *
+ * Store value in an atomic object with release order
+ *
+ * @param _a  pointer to the atomic object
+ * @param _v  new value
+ */
+#define re_atomic_strong_set(_a, _v)                                          \
+	re_atomic_store(_a, _v, re_memory_order_release)
+
+
+/**
+ * @def re_atomic_strong_add(_a, _v)
+ *
+ * Replace value from an atomic object with addition and acquire-release order
+ *
+ * @param _a  pointer to the atomic object
+ * @param _v  value to add
+ *
+ * @return value held previously by the atomic variable
+ */
+#define re_atomic_strong_add(_a, _v)                                          \
+	re_atomic_fetch_add(_a, _v, re_memory_order_acq_rel)
+
+
+/**
+ * @def re_atomic_strong_sub(_a, _v)
+ *
+ * Replace value from an atomic object with substraction and acquire-release
+ * order
+ *
+ * @param _a  pointer to the atomic object
+ * @param _v  value to subtract
+ *
+ * @return value held previously by the atomic variable
+ */
+#define re_atomic_strong_sub(_a, _v)                                          \
+	re_atomic_fetch_sub(_a, _v, re_memory_order_acq_rel)
+
+
+/**
+ * @def re_atomic_sync(_a)
+ *
+ * Load value from an atomic object with sequentially-consistent order
+ *
+ * @param _a  pointer to the atomic object
+ *
+ * @return value of the atomic variable
+ */
+#define re_atomic_sync(_a) re_atomic_load(_a, re_memory_order_seq_cst)
+
+
+/**
+ * @def re_atomic_sync_set(_a, _v)
+ *
+ * Store value in an atomic object with sequentially-consistent order
+ *
+ * @param _a  pointer to the atomic object
+ * @param _v  new value
+ */
+#define re_atomic_sync_set(_a, _v)                                            \
+	re_atomic_store(_a, _v, re_memory_order_seq_cst)
+
+
+/**
+ * @def re_atomic_sync_add(_a, _v)
+ *
+ * Replace value from an atomic object with addition and
+ * sequentially-consistent order
+ *
+ * @param _a  pointer to the atomic object
+ * @param _v  value to add
+ *
+ * @return value held previously by the atomic variable
+ */
+#define re_atomic_sync_add(_a, _v)                                            \
+	re_atomic_fetch_add(_a, _v, re_memory_order_seq_cst)
+
+
+/**
+ * @def re_atomic_sync_sub(_a, _v)
+ *
+ * Replace value from an atomic object with substraction and
+ * sequentially-consistent order
+ *
+ * @param _a  pointer to the atomic object
+ * @param _v  value to substract
+ *
+ * @return value held previously by the atomic variable
+ */
+#define re_atomic_sync_sub(_a, _v)                                            \
+	re_atomic_fetch_sub(_a, _v, re_memory_order_seq_cst)
+
 #endif /* RE_H_ATOMIC__ */

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1063,7 +1063,7 @@ int re_main(re_signal_h *signalh)
 	}
 #endif
 
-	if (re_atomic_load(&re->polling, re_memory_order_relaxed)) {
+	if (re_atomic_weak(&re->polling)) {
 		DEBUG_WARNING("main loop already polling\n");
 		return EALREADY;
 	}
@@ -1075,7 +1075,7 @@ int re_main(re_signal_h *signalh)
 	DEBUG_INFO("Using async I/O polling method: `%s'\n",
 		   poll_method_name(re->method));
 
-	re_atomic_store(&re->polling, true, re_memory_order_relaxed);
+	re_atomic_weak_set(&re->polling, true);
 
 	re_lock(re);
 	for (;;) {
@@ -1087,7 +1087,7 @@ int re_main(re_signal_h *signalh)
 			re->sig = 0;
 		}
 
-		if (!re_atomic_load(&re->polling, re_memory_order_relaxed)) {
+		if (!re_atomic_weak(&re->polling)) {
 			err = 0;
 			break;
 		}
@@ -1118,7 +1118,7 @@ int re_main(re_signal_h *signalh)
 	re_unlock(re);
 
  out:
-	re_atomic_store(&re->polling, false, re_memory_order_relaxed);
+	re_atomic_weak_set(&re->polling, false);
 
 	return err;
 }
@@ -1136,7 +1136,7 @@ void re_cancel(void)
 		return;
 	}
 
-	re_atomic_store(&re->polling, false, re_memory_order_relaxed);
+	re_atomic_weak_set(&re->polling, false);
 }
 
 
@@ -1332,8 +1332,7 @@ void re_thread_enter(void)
 
 	/* set only for non-re threads */
 	if (!thrd_equal(re->tid, thrd_current())) {
-		re_atomic_store(&re->thread_enter, true,
-				re_memory_order_relaxed);
+		re_atomic_weak_set(&re->thread_enter, true);
 	}
 }
 
@@ -1350,7 +1349,7 @@ void re_thread_leave(void)
 		return;
 	}
 
-	re_atomic_store(&re->thread_enter, false, re_memory_order_relaxed);
+	re_atomic_weak_set(&re->thread_enter, false);
 	re_unlock(re);
 }
 
@@ -1421,7 +1420,7 @@ int re_thread_check(void)
 	if (!re)
 		return EINVAL;
 
-	if (re_atomic_load(&re->thread_enter, re_memory_order_relaxed))
+	if (re_atomic_weak(&re->thread_enter))
 		return 0;
 
 	if (thrd_equal(re->tid, thrd_current()))

--- a/src/mem/mem.c
+++ b/src/mem/mem.c
@@ -174,8 +174,7 @@ void *mem_alloc(size_t size, mem_destroy_h *dh)
 	list_append(&meml, &m->le, m);
 	mem_unlock();
 #endif
-
-	re_atomic_store(&m->nrefs, 1u, re_memory_order_relaxed);
+	re_atomic_weak_set(&m->nrefs, 1u);
 	m->dh    = dh;
 
 	STAT_ALLOC(m, size);
@@ -230,7 +229,7 @@ void *mem_realloc(void *data, size_t size)
 
 	MAGIC_CHECK(m);
 
-	if (re_atomic_load(&m->nrefs, re_memory_order_acquire) > 1u) {
+	if (re_atomic_strong(&m->nrefs) > 1u) {
 		void* p = mem_alloc(size, m->dh);
 		if (p) {
 			memcpy(p, data, m->size);
@@ -342,7 +341,7 @@ void *mem_ref(void *data)
 
 	MAGIC_CHECK(m);
 
-	re_atomic_fetch_add(&m->nrefs, 1u, re_memory_order_relaxed);
+	re_atomic_weak_add(&m->nrefs, 1u);
 
 	return data;
 }
@@ -369,8 +368,7 @@ void *mem_deref(void *data)
 
 	MAGIC_CHECK(m);
 
-	if (re_atomic_fetch_sub(
-		&m->nrefs, 1u, re_memory_order_acq_rel) > 1u) {
+	if (re_atomic_strong_sub(&m->nrefs, 1u) > 1u) {
 		return NULL;
 	}
 
@@ -378,7 +376,7 @@ void *mem_deref(void *data)
 		m->dh(data);
 
 	/* NOTE: check if the destructor called mem_ref() */
-	if (re_atomic_load(&m->nrefs, re_memory_order_relaxed) > 0u)
+	if (re_atomic_weak(&m->nrefs) > 0u)
 		return NULL;
 
 #if MEM_DEBUG
@@ -413,7 +411,7 @@ uint32_t mem_nrefs(const void *data)
 
 	MAGIC_CHECK(m);
 
-	return (uint32_t)re_atomic_load(&m->nrefs, re_memory_order_acquire);
+	return (uint32_t)re_atomic_strong(&m->nrefs);
 }
 
 
@@ -427,7 +425,7 @@ static bool debug_handler(struct le *le, void *arg)
 	(void)arg;
 
 	(void)re_fprintf(stderr, "  %p: nrefs=%-2u", p,
-		(uint32_t)re_atomic_load(&m->nrefs, re_memory_order_relaxed));
+		(uint32_t)re_atomic_weak(&m->nrefs));
 
 	(void)re_fprintf(stderr, " size=%-7u", m->size);
 


### PR DESCRIPTION
Adding some shortcuts like `re_atomic_weak` makes code more readable.

Full version:
```c
while (re_atomic_load(&run, re_memory_order_relaxed)) {
```

Shortcut:
```c
while (re_atomic_weak(&run)) {
```