### PR TITLE
cmake,make: add clang atomic-implicit-seq-cst warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wshorten-64-to-32)
+  add_compile_options(-Wshorten-64-to-32 -Watomic-implicit-seq-cst)
   # Ensure struct mem is aligned (used as fat pointer)
   set_source_files_properties(src/mem/mem.c PROPERTIES COMPILE_FLAGS -Wpadded)
 endif()

--- a/mk/re.mk
+++ b/mk/re.mk
@@ -155,6 +155,7 @@ CFLAGS	+= -Wold-style-definition
 CFLAGS	+= -Wvla # Avoid insecure variable-length arrays
 ifeq ($(CC_NAME), clang)
 CFLAGS	+= -Wshorten-64-to-32
+CFLAGS  += -Watomic-implicit-seq-cst
 endif
 
 CFLAGS  += -g


### PR DESCRIPTION
Atomic operations should always be explicit.

- C11 default is sequentially-consistent memory ordering (performance overhead on some systems like ARM)
- Some expressions like `x = x + 1` (atomic read followed by atomic write), are not atomic (easy to make mistakes)
- C99 and MVSC has to be explicit