### PR TITLE
atomic: rename helpers

### DIFF
--- a/include/re_atomic.h
+++ b/include/re_atomic.h
@@ -719,7 +719,7 @@ static __forceinline unsigned __int64 _re_atomic_fetch_and(
 /* --- Some short alias helpers --- */
 
 /**
- * @def re_atomic_weak(_a)
+ * @def re_atomic_rlx(_a)
  *
  * Load value from an atomic object with relaxed order
  *
@@ -727,23 +727,23 @@ static __forceinline unsigned __int64 _re_atomic_fetch_and(
  *
  * @return value of the atomic variable
  */
-#define re_atomic_weak(_a) re_atomic_load(_a, re_memory_order_relaxed)
+#define re_atomic_rlx(_a) re_atomic_load(_a, re_memory_order_relaxed)
 
 
 /**
- * @def re_atomic_weak_set(_a, _v)
+ * @def re_atomic_rlx_set(_a, _v)
  *
  * Store value in an atomic object with relaxed order
  *
  * @param _a  pointer to the atomic object
  * @param _v  new value
  */
-#define re_atomic_weak_set(_a, _v)                                            \
+#define re_atomic_rlx_set(_a, _v)                                            \
 	re_atomic_store(_a, _v, re_memory_order_relaxed)
 
 
 /**
- * @def re_atomic_weak_add(_a, _v)
+ * @def re_atomic_rlx_add(_a, _v)
  *
  * Replace value from an atomic object with addition and relaxed order
  *
@@ -752,12 +752,12 @@ static __forceinline unsigned __int64 _re_atomic_fetch_and(
  *
  * @return value held previously by the atomic variable
  */
-#define re_atomic_weak_add(_a, _v)                                            \
+#define re_atomic_rlx_add(_a, _v)                                            \
 	re_atomic_fetch_add(_a, _v, re_memory_order_relaxed)
 
 
 /**
- * @def re_atomic_weak_sub(_a, _v)
+ * @def re_atomic_rlx_sub(_a, _v)
  *
  * Replace value from an atomic object with substraction and relaxed order
  *
@@ -766,12 +766,12 @@ static __forceinline unsigned __int64 _re_atomic_fetch_and(
  *
  * @return value held previously by the atomic variable
  */
-#define re_atomic_weak_sub(_a, _v)                                            \
+#define re_atomic_rlx_sub(_a, _v)                                            \
 	re_atomic_fetch_sub(_a, _v, re_memory_order_relaxed)
 
 
 /**
- * @def re_atomic_strong(_a)
+ * @def re_atomic_acq(_a)
  *
  * Load value from an atomic object with acquire order
  *
@@ -779,23 +779,23 @@ static __forceinline unsigned __int64 _re_atomic_fetch_and(
  *
  * @return value of the atomic variable
  */
-#define re_atomic_strong(_a) re_atomic_load(_a, re_memory_order_acquire)
+#define re_atomic_acq(_a) re_atomic_load(_a, re_memory_order_acquire)
 
 
 /**
- * @def re_atomic_strong_set(_a, _v)
+ * @def re_atomic_rls_set(_a, _v)
  *
  * Store value in an atomic object with release order
  *
  * @param _a  pointer to the atomic object
  * @param _v  new value
  */
-#define re_atomic_strong_set(_a, _v)                                          \
+#define re_atomic_rls_set(_a, _v)                                          \
 	re_atomic_store(_a, _v, re_memory_order_release)
 
 
 /**
- * @def re_atomic_strong_add(_a, _v)
+ * @def re_atomic_acq_add(_a, _v)
  *
  * Replace value from an atomic object with addition and acquire-release order
  *
@@ -804,12 +804,12 @@ static __forceinline unsigned __int64 _re_atomic_fetch_and(
  *
  * @return value held previously by the atomic variable
  */
-#define re_atomic_strong_add(_a, _v)                                          \
+#define re_atomic_acq_add(_a, _v)                                          \
 	re_atomic_fetch_add(_a, _v, re_memory_order_acq_rel)
 
 
 /**
- * @def re_atomic_strong_sub(_a, _v)
+ * @def re_atomic_acq_sub(_a, _v)
  *
  * Replace value from an atomic object with substraction and acquire-release
  * order
@@ -819,12 +819,12 @@ static __forceinline unsigned __int64 _re_atomic_fetch_and(
  *
  * @return value held previously by the atomic variable
  */
-#define re_atomic_strong_sub(_a, _v)                                          \
+#define re_atomic_acq_sub(_a, _v)                                          \
 	re_atomic_fetch_sub(_a, _v, re_memory_order_acq_rel)
 
 
 /**
- * @def re_atomic_sync(_a)
+ * @def re_atomic_seq(_a)
  *
  * Load value from an atomic object with sequentially-consistent order
  *
@@ -832,23 +832,23 @@ static __forceinline unsigned __int64 _re_atomic_fetch_and(
  *
  * @return value of the atomic variable
  */
-#define re_atomic_sync(_a) re_atomic_load(_a, re_memory_order_seq_cst)
+#define re_atomic_seq(_a) re_atomic_load(_a, re_memory_order_seq_cst)
 
 
 /**
- * @def re_atomic_sync_set(_a, _v)
+ * @def re_atomic_seq_set(_a, _v)
  *
  * Store value in an atomic object with sequentially-consistent order
  *
  * @param _a  pointer to the atomic object
  * @param _v  new value
  */
-#define re_atomic_sync_set(_a, _v)                                            \
+#define re_atomic_seq_set(_a, _v)                                            \
 	re_atomic_store(_a, _v, re_memory_order_seq_cst)
 
 
 /**
- * @def re_atomic_sync_add(_a, _v)
+ * @def re_atomic_seq_add(_a, _v)
  *
  * Replace value from an atomic object with addition and
  * sequentially-consistent order
@@ -858,12 +858,12 @@ static __forceinline unsigned __int64 _re_atomic_fetch_and(
  *
  * @return value held previously by the atomic variable
  */
-#define re_atomic_sync_add(_a, _v)                                            \
+#define re_atomic_seq_add(_a, _v)                                            \
 	re_atomic_fetch_add(_a, _v, re_memory_order_seq_cst)
 
 
 /**
- * @def re_atomic_sync_sub(_a, _v)
+ * @def re_atomic_seq_sub(_a, _v)
  *
  * Replace value from an atomic object with substraction and
  * sequentially-consistent order
@@ -873,7 +873,8 @@ static __forceinline unsigned __int64 _re_atomic_fetch_and(
  *
  * @return value held previously by the atomic variable
  */
-#define re_atomic_sync_sub(_a, _v)                                            \
+#define re_atomic_seq_sub(_a, _v)                                            \
 	re_atomic_fetch_sub(_a, _v, re_memory_order_seq_cst)
+
 
 #endif /* RE_H_ATOMIC__ */

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1063,7 +1063,7 @@ int re_main(re_signal_h *signalh)
 	}
 #endif
 
-	if (re_atomic_weak(&re->polling)) {
+	if (re_atomic_rlx(&re->polling)) {
 		DEBUG_WARNING("main loop already polling\n");
 		return EALREADY;
 	}
@@ -1075,7 +1075,7 @@ int re_main(re_signal_h *signalh)
 	DEBUG_INFO("Using async I/O polling method: `%s'\n",
 		   poll_method_name(re->method));
 
-	re_atomic_weak_set(&re->polling, true);
+	re_atomic_rlx_set(&re->polling, true);
 
 	re_lock(re);
 	for (;;) {
@@ -1087,7 +1087,7 @@ int re_main(re_signal_h *signalh)
 			re->sig = 0;
 		}
 
-		if (!re_atomic_weak(&re->polling)) {
+		if (!re_atomic_rlx(&re->polling)) {
 			err = 0;
 			break;
 		}
@@ -1118,7 +1118,7 @@ int re_main(re_signal_h *signalh)
 	re_unlock(re);
 
  out:
-	re_atomic_weak_set(&re->polling, false);
+	re_atomic_rlx_set(&re->polling, false);
 
 	return err;
 }
@@ -1136,7 +1136,7 @@ void re_cancel(void)
 		return;
 	}
 
-	re_atomic_weak_set(&re->polling, false);
+	re_atomic_rlx_set(&re->polling, false);
 }
 
 
@@ -1332,7 +1332,7 @@ void re_thread_enter(void)
 
 	/* set only for non-re threads */
 	if (!thrd_equal(re->tid, thrd_current())) {
-		re_atomic_weak_set(&re->thread_enter, true);
+		re_atomic_rlx_set(&re->thread_enter, true);
 	}
 }
 
@@ -1349,7 +1349,7 @@ void re_thread_leave(void)
 		return;
 	}
 
-	re_atomic_weak_set(&re->thread_enter, false);
+	re_atomic_rlx_set(&re->thread_enter, false);
 	re_unlock(re);
 }
 
@@ -1420,7 +1420,7 @@ int re_thread_check(void)
 	if (!re)
 		return EINVAL;
 
-	if (re_atomic_weak(&re->thread_enter))
+	if (re_atomic_rlx(&re->thread_enter))
 		return 0;
 
 	if (thrd_equal(re->tid, thrd_current()))


### PR DESCRIPTION
The `_weak` and `_strong` suffixes are misleading/confusing compared to `atomic_compare_exchange_strong`...

- re_atomic_rlx (relaxed)
- re_atomic_acq (acquire)
- re_atomic_rls_set (release)
- re_atomic_seq (sequentially-consistent)

Are more meaningful, less confusing and explicit.