### PR TITLE
Fix prack handling

### DIFF
--- a/src/sipsess/prack.c
+++ b/src/sipsess/prack.c
@@ -78,8 +78,9 @@ static void resp_handler(int err, const struct sip_msg *msg, void *arg)
 		goto out;
 
 	sess = sipsess_find(prack->sock, msg);
-	if (!sess)
+	if (!sess || sess->terminated)
 		goto out;
+
 	if (sess->prackh)
 		sess->prackh(msg, sess->arg);
 


### PR DESCRIPTION
If a UA receives a response to a PRACK after the session has terminated, don't call the prack handler.

Fixes https://github.com/baresip/baresip/issues/1996.
