### PR TITLE
btrace: fix gcc 4.3.5 warnings

### DIFF
--- a/include/re_btrace.h
+++ b/include/re_btrace.h
@@ -9,25 +9,25 @@ struct btrace {
 	size_t len;
 };
 
-int btrace_print(struct re_printf *pf, struct btrace *btrace);
-int btrace_println(struct re_printf *pf, struct btrace *btrace);
-int btrace_print_json(struct re_printf *pf, struct btrace *btrace);
+int btrace_print(struct re_printf *pf, struct btrace *bt);
+int btrace_println(struct re_printf *pf, struct btrace *bt);
+int btrace_print_json(struct re_printf *pf, struct btrace *bt);
 
 #if defined(HAVE_EXECINFO) && !defined(RELEASE)
 #include <execinfo.h>
-static inline int btrace(struct btrace *btrace)
+static inline int btrace(struct btrace *bt)
 {
-	if (!btrace)
+	if (!bt)
 		return EINVAL;
 
-	btrace->len = backtrace(btrace->stack, BTRACE_SZ);
+	bt->len = backtrace(bt->stack, BTRACE_SZ);
 
 	return 0;
 }
 #else
-static inline int btrace(struct btrace *btrace)
+static inline int btrace(struct btrace *bt)
 {
-	(void)btrace;
+	(void)bt;
 	return 0;
 }
 #endif

--- a/src/btrace/btrace.c
+++ b/src/btrace/btrace.c
@@ -8,28 +8,28 @@
 
 enum print_type { BTRACE_CSV, BTRACE_NEWLINE, BTRACE_JSON };
 
-static int print_debug(struct re_printf *pf, struct btrace *btrace,
+static int print_debug(struct re_printf *pf, struct btrace *bt,
 		       enum print_type type)
 {
 #if !defined(HAVE_EXECINFO) || defined(RELEASE)
 	(void)pf;
-	(void)btrace;
+	(void)bt;
 	(void)type;
 
 	return 0;
 #else
 	char **symbols;
 
-	if (!pf || !btrace)
+	if (!pf || !bt)
 		return EINVAL;
 
-	if (!btrace->len)
+	if (!bt->len)
 		return 0;
 
 #if defined(FREEBSD) || defined(OPENBSD)
-	symbols = backtrace_symbols(btrace->stack, btrace->len);
+	symbols = backtrace_symbols(bt->stack, bt->len);
 #else
-	symbols = backtrace_symbols(btrace->stack, (int)btrace->len);
+	symbols = backtrace_symbols(bt->stack, (int)bt->len);
 #endif
 
 	if (!symbols)
@@ -37,21 +37,21 @@ static int print_debug(struct re_printf *pf, struct btrace *btrace,
 
 	switch (type) {
 	case BTRACE_CSV:
-		for (size_t j = 0; j < btrace->len; j++) {
+		for (size_t j = 0; j < bt->len; j++) {
 			re_hprintf(pf, "%s%s", symbols[j],
-				   ((j + 1) < btrace->len) ? ", " : "");
+				   ((j + 1) < bt->len) ? ", " : "");
 		}
 		break;
 	case BTRACE_NEWLINE:
-		for (size_t j = 0; j < btrace->len; j++) {
+		for (size_t j = 0; j < bt->len; j++) {
 			re_hprintf(pf, "%s \n", symbols[j]);
 		}
 		break;
 	case BTRACE_JSON:
 		re_hprintf(pf, "[");
-		for (size_t j = 0; j < btrace->len; j++) {
+		for (size_t j = 0; j < bt->len; j++) {
 			re_hprintf(pf, "\"%s\"%s", symbols[j],
-				   ((j + 1) < btrace->len) ? ", " : "");
+				   ((j + 1) < bt->len) ? ", " : "");
 		}
 		re_hprintf(pf, "]");
 		break;
@@ -67,40 +67,40 @@ static int print_debug(struct re_printf *pf, struct btrace *btrace,
 /**
  * Print debug backtrace (comma separated)
  *
- * @param pf     Print function for debug output
- * @param btrace Backtrace object
+ * @param pf Print function for debug output
+ * @param bt Backtrace object
  *
  * @return 0 if success, otherwise errorcode
  */
-int btrace_print(struct re_printf *pf, struct btrace *btrace)
+int btrace_print(struct re_printf *pf, struct btrace *bt)
 {
-	return print_debug(pf, btrace, BTRACE_CSV);
+	return print_debug(pf, bt, BTRACE_CSV);
 }
 
 
 /**
  * Print debug backtrace with newlines
  *
- * @param pf     Print function for debug output
- * @param btrace Backtrace object
+ * @param pf Print function for debug output
+ * @param bt Backtrace object
  *
  * @return 0 if success, otherwise errorcode
  */
-int btrace_println(struct re_printf *pf, struct btrace *btrace)
+int btrace_println(struct re_printf *pf, struct btrace *bt)
 {
-	return print_debug(pf, btrace, BTRACE_NEWLINE);
+	return print_debug(pf, bt, BTRACE_NEWLINE);
 }
 
 
 /**
  * Print debug backtrace as json array
  *
- * @param pf     Print function for debug output
- * @param btrace Backtrace object
+ * @param pf Print function for debug output
+ * @param bt Backtrace object
  *
  * @return 0 if success, otherwise errorcode
  */
-int btrace_print_json(struct re_printf *pf, struct btrace *btrace)
+int btrace_print_json(struct re_printf *pf, struct btrace *bt)
 {
-	return print_debug(pf, btrace, BTRACE_JSON);
+	return print_debug(pf, bt, BTRACE_JSON);
 }


### PR DESCRIPTION
Fixes gcc warnings
```
warning: declaration of 'btrace' shadows a global declaration
```
