### PR TITLE
dns/client: add async getaddrinfo usage

### DIFF
--- a/include/re_dns.h
+++ b/include/re_dns.h
@@ -201,7 +201,7 @@ struct dnsc_conf {
 	uint32_t conn_timeout;  /* in [ms] */
 	uint32_t idle_timeout;  /* in [ms] */
 	uint32_t cache_ttl_max; /* in [s] 0 for disabled */
-	bool     system;        /* use getaddrinfo (by default disabled) */
+	bool     getaddrinfo;   /* use getaddrinfo (by default disabled) */
 };
 
 int  dnsc_alloc(struct dnsc **dcpp, const struct dnsc_conf *conf,
@@ -221,7 +221,7 @@ int  dnsc_notify(struct dns_query **qp, struct dnsc *dnsc, const char *name,
 		 dns_query_h *qh, void *arg);
 void dnsc_cache_flush(struct dnsc *dnsc);
 void dnsc_cache_max(struct dnsc *dnsc, uint32_t max);
-void dnsc_system(struct dnsc *dnsc, bool active);
+void dnsc_getaddrinfo(struct dnsc *dnsc, bool active);
 
 
 /* DNS System functions */

--- a/include/re_dns.h
+++ b/include/re_dns.h
@@ -201,6 +201,7 @@ struct dnsc_conf {
 	uint32_t conn_timeout;  /* in [ms] */
 	uint32_t idle_timeout;  /* in [ms] */
 	uint32_t cache_ttl_max; /* in [s] 0 for disabled */
+	bool     system;        /* use getaddrinfo (by default disabled) */
 };
 
 int  dnsc_alloc(struct dnsc **dcpp, const struct dnsc_conf *conf,
@@ -220,6 +221,7 @@ int  dnsc_notify(struct dns_query **qp, struct dnsc *dnsc, const char *name,
 		 dns_query_h *qh, void *arg);
 void dnsc_cache_flush(struct dnsc *dnsc);
 void dnsc_cache_max(struct dnsc *dnsc, uint32_t max);
+void dnsc_system(struct dnsc *dnsc, bool active);
 
 
 /* DNS System functions */

--- a/src/dns/client.c
+++ b/src/dns/client.c
@@ -833,10 +833,11 @@ static void getaddrinfo_h(int err, void *arg)
 	bool cache = q->dnsc->conf.cache_ttl_max > 0;
 
 	DEBUG_INFO("--- ANSWER SECTION (system) id: %d ---\n", q->id);
-	if (!err)
+	if (!err) {
 		DEBUG_INFO("%H %s\n", dns_rr_print,
 			   list_ledata(list_head(&q->rrlv[0])),
 			   cache ? "(caching)" : "");
+	}
 
 	query_handler(q, err, &q->rrlv[0], &q->rrlv[1], &q->rrlv[2]);
 


### PR DESCRIPTION
Benefits:
- considers `/etc/hosts` entries
- maybe works better on restricted systems