### PR TITLE
cmake: move definitions to re-config.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,8 +125,6 @@ set(SRCS
 
   src/conf/conf.c
 
-  src/crc32/crc32.c
-
   src/dbg/dbg.c
 
   src/dns/client.c
@@ -416,6 +414,11 @@ elseif(UNIX)
   endif()
 endif()
 
+if(NOT ZLIB_FOUND)
+  list(APPEND SRCS
+    src/crc32/crc32.c
+  )
+endif()
 
 if(HAVE_THREADS)
   #Do nothing
@@ -486,6 +489,7 @@ else()
     ${OPENSSL_LIBRARIES}
     ${Backtrace_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
+    ${ZLIB_LIBRARIES}
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ project(re VERSION 2.6.1 LANGUAGES C)
 
 set(PROJECT_SOVERSION 8) # bump if ABI breaks
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
+
 ##############################################################################
 #
 # Module/Package Includes
@@ -23,155 +25,23 @@ set(PROJECT_SOVERSION 8) # bump if ABI breaks
 include(GNUInstallDirs)
 include(CheckIncludeFile)
 include(CheckFunctionExists)
-find_package(Backtrace)
-find_package(Threads REQUIRED)
-find_package(OpenSSL)
-
-check_symbol_exists("arc4random" "stdlib.h" HAVE_ARC4RANDOM)
-if(HAVE_ARC4RANDOM)
-  add_definitions(-DHAVE_ARC4RANDOM)
-endif()
 
 ##############################################################################
 #
-# Compile options
+# Options
 #
 
-option(USE_OPENSSL "Enable OpenSSL" ${OPENSSL_FOUND})
 option(USE_BFCP "Enable BFCP" ON)
 option(USE_PCP "Enable PCP" ON)
 option(USE_RTMP "Enable RTMP" ON)
 option(USE_SIP "Enable SIP" ON)
 
-
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_EXTENSIONS OFF)
-
-if(MSVC)
-  add_compile_options("/W3")
-else()
-  add_compile_options(
-    -Wall
-    -Wbad-function-cast
-    -Wcast-align
-    -Wextra
-    -Wmissing-declarations
-    -Wmissing-prototypes
-    -Wnested-externs
-    -Wold-style-definition
-    -Wshadow -Waggregate-return
-    -Wstrict-prototypes
-    -Wvla
-  )
-endif()
-
-
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wshorten-64-to-32 -Watomic-implicit-seq-cst)
   # Ensure struct mem is aligned (used as fat pointer)
   set_source_files_properties(src/mem/mem.c PROPERTIES COMPILE_FLAGS -Wpadded)
 endif()
 
-
-check_include_file(unistd.h HAVE_UNISTD_H)
-if(HAVE_UNISTD_H)
-  add_definitions(-DHAVE_UNISTD_H)
-endif()
-
-if(Backtrace_FOUND)
-  add_definitions(-DHAVE_EXECINFO)
-else()
-  set(Backtrace_LIBRARIES)
-endif()
-
-check_function_exists(thrd_create HAVE_THREADS)
-if(HAVE_THREADS)
-  add_definitions(-DHAVE_THREADS)
-endif()
-
-if(CMAKE_USE_PTHREADS_INIT)
-  add_definitions(-DHAVE_PTHREAD)
-  set(HAVE_PTHREAD ON)
-endif()
-
-add_definitions(
-  -DHAVE_ATOMIC
-  -DHAVE_INET6
-  -DHAVE_SELECT
-  )
-
-
-if(UNIX)
-  add_definitions(
-    -DHAVE_POLL
-    -DHAVE_PWD_H
-    -DHAVE_ROUTE_LIST
-    -DHAVE_SETRLIMIT
-    -DHAVE_STRERROR_R
-    -DHAVE_STRINGS_H
-    -DHAVE_SYS_TIME_H
-    -DHAVE_UNAME
-    -DHAVE_SELECT_H
-    -DHAVE_SIGNAL
-    )
-  if(NOT ANDROID)
-    add_definitions(-DHAVE_GETIFADDRS)
-  endif()
-endif()
-
-
-if(MSVC)
-  add_definitions(
-    -DHAVE_IO_H
-    -D_CRT_SECURE_NO_WARNINGS
-  )
-endif()
-
-if(WIN32)
-  add_definitions(
-    -DWIN32 -D_WIN32_WINNT=0x0600
-  )
-endif()
-
-if(USE_OPENSSL)
-  add_definitions(
-    -DUSE_DTLS
-    -DUSE_OPENSSL
-    -DUSE_OPENSSL_AES
-    -DUSE_OPENSSL_DTLS
-    -DUSE_OPENSSL_HMAC
-    -DUSE_OPENSSL_SRTP
-    -DUSE_TLS
-  )
-endif()
-
-
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  add_definitions(-DHAVE_KQUEUE -DDARWIN)
-  include_directories(/opt/local/include)
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-  add_definitions(-DHAVE_KQUEUE -DFREEBSD)
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
-  add_definitions(-DHAVE_KQUEUE -DOPENBSD)
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  add_definitions(-DHAVE_EPOLL -DLINUX)
-endif()
-
-
-add_definitions(
-  -DARCH="${CMAKE_SYSTEM_PROCESSOR}"
-  -DOS="${CMAKE_SYSTEM_NAME}"
-  -DVERSION="${PROJECT_VERSION}"
-  -DVER_MAJOR=${PROJECT_VERSION_MAJOR}
-  -DVER_MINOR=${PROJECT_VERSION_MINOR}
-  -DVER_PATCH=${PROJECT_VERSION_PATCH}
-)
-
-if(${CMAKE_BUILD_TYPE} MATCHES "[Rr]el")
-  add_definitions(-DRELEASE)
-endif()
-
+include(re)
 
 ##############################################################################
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,6 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 # Module/Package Includes
 #
 include(GNUInstallDirs)
-include(CheckIncludeFile)
-include(CheckFunctionExists)
 
 ##############################################################################
 #
@@ -36,13 +34,42 @@ option(USE_PCP "Enable PCP" ON)
 option(USE_RTMP "Enable RTMP" ON)
 option(USE_SIP "Enable SIP" ON)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_EXTENSIONS OFF)
+
+if(MSVC)
+  add_compile_options("/W3")
+else()
+  add_compile_options(
+    -pedantic
+    -Wall
+    -Wbad-function-cast
+    -Wcast-align
+    -Wextra
+    -Wmissing-declarations
+    -Wmissing-prototypes
+    -Wnested-externs
+    -Wno-strict-aliasing
+    -Wold-style-definition
+    -Wshadow -Waggregate-return
+    -Wstrict-prototypes
+    -Wuninitialized
+    -Wvla
+  )
+endif()
+
+if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wshorten-64-to-32 -Watomic-implicit-seq-cst)
+endif()
+
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
   # Ensure struct mem is aligned (used as fat pointer)
   set_source_files_properties(src/mem/mem.c PROPERTIES COMPILE_FLAGS -Wpadded)
 endif()
 
-include(re)
-
+set(re_DIR ${CMAKE_CURRENT_LIST_DIR}/cmake)
+find_package(re CONFIG REQUIRED)
 ##############################################################################
 #
 # Source/Header section
@@ -457,6 +484,8 @@ add_library(re-objs OBJECT ${SRCS} ${HEADERS})
 
 set_target_properties(re-objs PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
+target_compile_definitions(re-objs PRIVATE ${RE_DEFINITIONS})
+
 target_include_directories(re-objs PRIVATE .)
 target_include_directories(re-objs PRIVATE include ${OPENSSL_INCLUDE_DIR})
 
@@ -549,6 +578,9 @@ install(TARGETS re-shared
     COMPONENT re_dev
 )
 
+install(FILES cmake/re-config.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/re
+)
 
 ##############################################################################
 #

--- a/cmake/re-config.cmake
+++ b/cmake/re-config.cmake
@@ -1,87 +1,61 @@
+include(CheckIncludeFile)
+include(CheckFunctionExists)
+
 find_package(Backtrace)
 find_package(Threads REQUIRED)
-find_package(OpenSSL)
 find_package(ZLIB)
+find_package(OpenSSL)
 
 option(USE_OPENSSL "Enable OpenSSL" ${OPENSSL_FOUND})
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_EXTENSIONS OFF)
-
-if(MSVC)
-  add_compile_options("/W3")
-else()
-  add_compile_options(
-    -pedantic
-    -Wall
-    -Wbad-function-cast
-    -Wcast-align
-    -Wextra
-    -Wmissing-declarations
-    -Wmissing-prototypes
-    -Wnested-externs
-    -Wno-strict-aliasing
-    -Wold-style-definition
-    -Wshadow -Waggregate-return
-    -Wstrict-prototypes
-    -Wuninitialized
-    -Wvla
-  )
-endif()
-
-if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wshorten-64-to-32 -Watomic-implicit-seq-cst)
-endif()
-
 check_symbol_exists("arc4random" "stdlib.h" HAVE_ARC4RANDOM)
 if(HAVE_ARC4RANDOM)
-  add_definitions(-DHAVE_ARC4RANDOM)
+  list(APPEND RE_DEFINITIONS -DHAVE_ARC4RANDOM)
 endif()
 
 if(ZLIB_FOUND)
-  add_definitions(-DUSE_ZLIB)
+  list(APPEND RE_DEFINITIONS -DUSE_ZLIB)
 endif()
 
 check_include_file(syslog.h HAVE_SYSLOG_H)
 if(HAVE_SYSLOG_H)
-  add_definitions(-DHAVE_SYSLOG)
+  list(APPEND RE_DEFINITIONS -DHAVE_SYSLOG)
 endif()
 
 check_include_file(getopt.h HAVE_GETOPT_H)
 if(HAVE_GETOPT_H)
-  add_definitions(-DHAVE_GETOPT)
+  list(APPEND RE_DEFINITIONS -DHAVE_GETOPT)
 endif()
 
 check_include_file(unistd.h HAVE_UNISTD_H)
 if(HAVE_UNISTD_H)
-  add_definitions(-DHAVE_UNISTD_H)
+  list(APPEND RE_DEFINITIONS -DHAVE_UNISTD_H)
 endif()
 
 if(Backtrace_FOUND)
-  add_definitions(-DHAVE_EXECINFO)
+  list(APPEND RE_DEFINITIONS -DHAVE_EXECINFO)
 else()
   set(Backtrace_LIBRARIES)
 endif()
 
 check_function_exists(thrd_create HAVE_THREADS)
 if(HAVE_THREADS)
-  add_definitions(-DHAVE_THREADS)
+  list(APPEND RE_DEFINITIONS -DHAVE_THREADS)
 endif()
 
 if(CMAKE_USE_PTHREADS_INIT)
-  add_definitions(-DHAVE_PTHREAD)
+  list(APPEND RE_DEFINITIONS -DHAVE_PTHREAD)
   set(HAVE_PTHREAD ON)
 endif()
 
-add_definitions(
+list(APPEND RE_DEFINITIONS 
   -DHAVE_ATOMIC
   -DHAVE_INET6
   -DHAVE_SELECT
   )
 
 if(UNIX)
-  add_definitions(
+  list(APPEND RE_DEFINITIONS
     -DHAVE_POLL
     -DHAVE_PWD_H
     -DHAVE_ROUTE_LIST
@@ -95,26 +69,26 @@ if(UNIX)
     -DHAVE_FORK
     )
   if(NOT ANDROID)
-    add_definitions(-DHAVE_GETIFADDRS)
+    list(APPEND RE_DEFINITIONS -DHAVE_GETIFADDRS)
   endif()
 endif()
 
 
 if(MSVC)
-  add_definitions(
+  list(APPEND RE_DEFINITIONS
     -DHAVE_IO_H
     -D_CRT_SECURE_NO_WARNINGS
   )
 endif()
 
 if(WIN32)
-  add_definitions(
+  list(APPEND RE_DEFINITIONS
     -DWIN32 -D_WIN32_WINNT=0x0600
   )
 endif()
 
 if(USE_OPENSSL)
-  add_definitions(
+  list(APPEND RE_DEFINITIONS
     -DUSE_DTLS
     -DUSE_OPENSSL
     -DUSE_OPENSSL_AES
@@ -127,18 +101,18 @@ endif()
 
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  add_definitions(-DHAVE_KQUEUE -DDARWIN)
+  list(APPEND RE_DEFINITIONS -DHAVE_KQUEUE -DDARWIN)
   include_directories(/opt/local/include)
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-  add_definitions(-DHAVE_KQUEUE -DFREEBSD)
+  list(APPEND RE_DEFINITIONS -DHAVE_KQUEUE -DFREEBSD)
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
-  add_definitions(-DHAVE_KQUEUE -DOPENBSD)
+  list(APPEND RE_DEFINITIONS -DHAVE_KQUEUE -DOPENBSD)
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  add_definitions(-DHAVE_EPOLL -DLINUX)
+  list(APPEND RE_DEFINITIONS -DHAVE_EPOLL -DLINUX)
 endif()
 
 
-add_definitions(
+list(APPEND RE_DEFINITIONS 
   -DARCH="${CMAKE_SYSTEM_PROCESSOR}"
   -DOS="${CMAKE_SYSTEM_NAME}"
   -DVERSION="${PROJECT_VERSION}"
@@ -148,5 +122,5 @@ add_definitions(
 )
 
 if(${CMAKE_BUILD_TYPE} MATCHES "[Rr]el")
-  add_definitions(-DRELEASE)
+  list(APPEND RE_DEFINITIONS -DRELEASE)
 endif()

--- a/cmake/re.cmake
+++ b/cmake/re.cmake
@@ -1,0 +1,133 @@
+find_package(Backtrace)
+find_package(Threads REQUIRED)
+find_package(OpenSSL)
+
+option(USE_OPENSSL "Enable OpenSSL" ${OPENSSL_FOUND})
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_EXTENSIONS OFF)
+
+if(MSVC)
+  add_compile_options("/W3")
+else()
+  add_compile_options(
+    -Wall
+    -Wbad-function-cast
+    -Wcast-align
+    -Wextra
+    -Wmissing-declarations
+    -Wmissing-prototypes
+    -Wnested-externs
+    -Wold-style-definition
+    -Wshadow -Waggregate-return
+    -Wstrict-prototypes
+    -Wvla
+  )
+endif()
+
+if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wshorten-64-to-32 -Watomic-implicit-seq-cst)
+endif()
+
+check_symbol_exists("arc4random" "stdlib.h" HAVE_ARC4RANDOM)
+if(HAVE_ARC4RANDOM)
+  add_definitions(-DHAVE_ARC4RANDOM)
+endif()
+
+check_include_file(unistd.h HAVE_UNISTD_H)
+if(HAVE_UNISTD_H)
+  add_definitions(-DHAVE_UNISTD_H)
+endif()
+
+if(Backtrace_FOUND)
+  add_definitions(-DHAVE_EXECINFO)
+else()
+  set(Backtrace_LIBRARIES)
+endif()
+
+check_function_exists(thrd_create HAVE_THREADS)
+if(HAVE_THREADS)
+  add_definitions(-DHAVE_THREADS)
+endif()
+
+if(CMAKE_USE_PTHREADS_INIT)
+  add_definitions(-DHAVE_PTHREAD)
+  set(HAVE_PTHREAD ON)
+endif()
+
+add_definitions(
+  -DHAVE_ATOMIC
+  -DHAVE_INET6
+  -DHAVE_SELECT
+  )
+
+if(UNIX)
+  add_definitions(
+    -DHAVE_POLL
+    -DHAVE_PWD_H
+    -DHAVE_ROUTE_LIST
+    -DHAVE_SETRLIMIT
+    -DHAVE_STRERROR_R
+    -DHAVE_STRINGS_H
+    -DHAVE_SYS_TIME_H
+    -DHAVE_UNAME
+    -DHAVE_SELECT_H
+    -DHAVE_SIGNAL
+    )
+  if(NOT ANDROID)
+    add_definitions(-DHAVE_GETIFADDRS)
+  endif()
+endif()
+
+
+if(MSVC)
+  add_definitions(
+    -DHAVE_IO_H
+    -D_CRT_SECURE_NO_WARNINGS
+  )
+endif()
+
+if(WIN32)
+  add_definitions(
+    -DWIN32 -D_WIN32_WINNT=0x0600
+  )
+endif()
+
+if(USE_OPENSSL)
+  add_definitions(
+    -DUSE_DTLS
+    -DUSE_OPENSSL
+    -DUSE_OPENSSL_AES
+    -DUSE_OPENSSL_DTLS
+    -DUSE_OPENSSL_HMAC
+    -DUSE_OPENSSL_SRTP
+    -DUSE_TLS
+  )
+endif()
+
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  add_definitions(-DHAVE_KQUEUE -DDARWIN)
+  include_directories(/opt/local/include)
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+  add_definitions(-DHAVE_KQUEUE -DFREEBSD)
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
+  add_definitions(-DHAVE_KQUEUE -DOPENBSD)
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  add_definitions(-DHAVE_EPOLL -DLINUX)
+endif()
+
+
+add_definitions(
+  -DARCH="${CMAKE_SYSTEM_PROCESSOR}"
+  -DOS="${CMAKE_SYSTEM_NAME}"
+  -DVERSION="${PROJECT_VERSION}"
+  -DVER_MAJOR=${PROJECT_VERSION_MAJOR}
+  -DVER_MINOR=${PROJECT_VERSION_MINOR}
+  -DVER_PATCH=${PROJECT_VERSION_PATCH}
+)
+
+if(${CMAKE_BUILD_TYPE} MATCHES "[Rr]el")
+  add_definitions(-DRELEASE)
+endif()

--- a/cmake/re.cmake
+++ b/cmake/re.cmake
@@ -1,6 +1,7 @@
 find_package(Backtrace)
 find_package(Threads REQUIRED)
 find_package(OpenSSL)
+find_package(ZLIB)
 
 option(USE_OPENSSL "Enable OpenSSL" ${OPENSSL_FOUND})
 
@@ -12,6 +13,7 @@ if(MSVC)
   add_compile_options("/W3")
 else()
   add_compile_options(
+    -pedantic
     -Wall
     -Wbad-function-cast
     -Wcast-align
@@ -19,9 +21,11 @@ else()
     -Wmissing-declarations
     -Wmissing-prototypes
     -Wnested-externs
+    -Wno-strict-aliasing
     -Wold-style-definition
     -Wshadow -Waggregate-return
     -Wstrict-prototypes
+    -Wuninitialized
     -Wvla
   )
 endif()
@@ -33,6 +37,20 @@ endif()
 check_symbol_exists("arc4random" "stdlib.h" HAVE_ARC4RANDOM)
 if(HAVE_ARC4RANDOM)
   add_definitions(-DHAVE_ARC4RANDOM)
+endif()
+
+if(ZLIB_FOUND)
+  add_definitions(-DUSE_ZLIB)
+endif()
+
+check_include_file(syslog.h HAVE_SYSLOG_H)
+if(HAVE_SYSLOG_H)
+  add_definitions(-DHAVE_SYSLOG)
+endif()
+
+check_include_file(getopt.h HAVE_GETOPT_H)
+if(HAVE_GETOPT_H)
+  add_definitions(-DHAVE_GETOPT)
 endif()
 
 check_include_file(unistd.h HAVE_UNISTD_H)
@@ -74,6 +92,7 @@ if(UNIX)
     -DHAVE_UNAME
     -DHAVE_SELECT_H
     -DHAVE_SIGNAL
+    -DHAVE_FORK
     )
   if(NOT ANDROID)
     add_definitions(-DHAVE_GETIFADDRS)


### PR DESCRIPTION
This way we can share/maintain options with other projects (like we did with re.mk).