### PR TITLE
Add MbedTLS support as alternative backend to OpenSSL

### DIFF
--- a/.github/workflows/musl.yml
+++ b/.github/workflows/musl.yml
@@ -1,0 +1,25 @@
+name: Alpine (musl)
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: alpine
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install devel tools
+      run: |
+        apk add musl-dev git cmake gcc make binutils openssl-dev linux-headers zlib-dev 
+
+    - name: make
+      run: |
+        cmake -B build -DCMAKE_C_FLAGS="-Werror"
+        cmake --build build -j

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ option(USE_BFCP "Enable BFCP" ON)
 option(USE_PCP "Enable PCP" ON)
 option(USE_RTMP "Enable RTMP" ON)
 option(USE_SIP "Enable SIP" ON)
+option(USE_OPENSSL "Enable OpenSSL" ON)
+option(USE_MBEDTLS "Enable MbedTLS" OFF)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_C_STANDARD 11)
@@ -424,6 +426,12 @@ if(USE_OPENSSL)
     src/tls/openssl/tls.c
     src/hmac/openssl/hmac.c
   )
+  add_compile_definitions(USE_OPENSSL)
+elseif(USE_MBEDTLS)
+  list(APPEND SRCS
+    src/main/mbedtls.c
+  )
+  add_compile_definitions(USE_MBEDTLS)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,6 +432,7 @@ elseif(USE_MBEDTLS)
   list(APPEND SRCS
     src/main/mbedtls.c
     src/aes/mbedtls/aes.c
+    src/hmac/mbedtls/hmac.c
   )
   add_compile_definitions(USE_MBEDTLS)
   set(CRYPTO_LIBS MbedTLS MbedCrypto MbedX509)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,9 +505,7 @@ target_compile_definitions(re-objs PRIVATE ${RE_DEFINITIONS})
 
 target_include_directories(re-objs PRIVATE .)
 target_include_directories(re-objs PRIVATE include)
-if(USE_OPENSSL)
-  target_include_directories(re-objs PUBLIC ${OPENSSL_INCLUDE_DIR})
-endif()
+target_link_libraries(re-objs PRIVATE ${CRYPTO_LIBS})
 
 
 ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,6 +501,9 @@ target_compile_definitions(re-objs PRIVATE ${RE_DEFINITIONS})
 
 target_include_directories(re-objs PRIVATE .)
 target_include_directories(re-objs PRIVATE include)
+if(USE_OPENSSL)
+  target_include_directories(re-objs PUBLIC ${OPENSSL_INCLUDE_DIR})
+endif()
 
 
 ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,8 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang")
   set_source_files_properties(src/mem/mem.c PROPERTIES COMPILE_FLAGS -Wpadded)
 endif()
 
+find_package(MbedTLS)
+
 set(re_DIR ${CMAKE_CURRENT_LIST_DIR}/cmake)
 find_package(re CONFIG REQUIRED)
 ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,7 +505,11 @@ target_compile_definitions(re-objs PRIVATE ${RE_DEFINITIONS})
 
 target_include_directories(re-objs PRIVATE .)
 target_include_directories(re-objs PRIVATE include)
-target_link_libraries(re-objs PRIVATE ${CRYPTO_LIBS})
+if(USE_OPENSSL)
+  target_include_directories(re-objs PUBLIC ${OPENSSL_INCLUDE_DIR})
+elseif(USE_MBEDTLS)
+  target_include_directories(re-objs PUBLIC ${MBEDTLS_INCLUDE_DIRS})
+endif()
 
 
 ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,6 @@ option(USE_BFCP "Enable BFCP" ON)
 option(USE_PCP "Enable PCP" ON)
 option(USE_RTMP "Enable RTMP" ON)
 option(USE_SIP "Enable SIP" ON)
-option(USE_OPENSSL "Enable OpenSSL" ON)
-option(USE_MBEDTLS "Enable MbedTLS" OFF)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_C_STANDARD 11)
@@ -427,11 +425,13 @@ if(USE_OPENSSL)
     src/hmac/openssl/hmac.c
   )
   add_compile_definitions(USE_OPENSSL)
+  set(CRYPTO_LIBS OpenSSL::SSL OpenSSL::Crypto)
 elseif(USE_MBEDTLS)
   list(APPEND SRCS
     src/main/mbedtls.c
   )
   add_compile_definitions(USE_MBEDTLS)
+  set(CRYPTO_LIBS MbedTLS MbedCrypto MbedX509)
 endif()
 
 
@@ -500,7 +500,7 @@ set_target_properties(re-objs PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_compile_definitions(re-objs PRIVATE ${RE_DEFINITIONS})
 
 target_include_directories(re-objs PRIVATE .)
-target_include_directories(re-objs PRIVATE include ${OPENSSL_INCLUDE_DIR})
+target_include_directories(re-objs PRIVATE include)
 
 
 ##############################################################################
@@ -518,7 +518,7 @@ endif()
 
 if(WIN32)
   target_link_libraries(re-shared PRIVATE
-    ${OPENSSL_LIBRARIES}
+    ${CRYPTO_LIBS}
     qwave
     iphlpapi
     wsock32
@@ -528,7 +528,7 @@ if(WIN32)
 else()
   target_link_libraries(re-shared PRIVATE
     -L/opt/local/lib
-    ${OPENSSL_LIBRARIES}
+    ${CRYPTO_LIBS}
     ${Backtrace_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
     ${ZLIB_LIBRARIES}
@@ -554,7 +554,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 target_link_libraries(re
-  PUBLIC ${OPENSSL_LIBRARIES} ${Backtrace_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
+  PUBLIC ${CRYPTO_LIBS} ${Backtrace_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
   PRIVATE -L/opt/local/lib
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,6 +431,7 @@ if(USE_OPENSSL)
 elseif(USE_MBEDTLS)
   list(APPEND SRCS
     src/main/mbedtls.c
+    src/aes/mbedtls/aes.c
   )
   add_compile_definitions(USE_MBEDTLS)
   set(CRYPTO_LIBS MbedTLS MbedCrypto MbedX509)

--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -1,0 +1,38 @@
+find_path(MBEDTLS_INCLUDE_DIRS mbedtls/ssl.h HINTS ${MBEDTLS_DIR}/include)
+
+find_library(MBEDTLS_LIBRARY mbedtls HINTS ${MBEDTLS_DIR}/lib)
+find_library(MBEDX509_LIBRARY mbedx509 HINTS ${MBEDTLS_DIR}/lib)
+find_library(MBEDCRYPTO_LIBRARY mbedcrypto HINTS ${MBEDTLS_DIR}/lib)
+
+set(MBEDTLS_LIBRARIES "${MBEDTLS_LIBRARY}" "${MBEDX509_LIBRARY}" "${MBEDCRYPTO_LIBRARY}")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(MbedTLS DEFAULT_MSG
+    MBEDTLS_LIBRARY MBEDTLS_INCLUDE_DIRS MBEDX509_LIBRARY MBEDCRYPTO_LIBRARY)
+
+mark_as_advanced(MBEDTLS_INCLUDE_DIRS MBEDTLS_LIBRARY MBEDX509_LIBRARY MBEDCRYPTO_LIBRARY)
+
+if(NOT TARGET MbedTLS)
+	message("in mbedtls ${MBEDTLS_LIBRARY}")
+    add_library(MbedTLS UNKNOWN IMPORTED)
+    set_target_properties(MbedTLS PROPERTIES
+                          INTERFACE_INCLUDE_DIRECTORIES "${MBEDTLS_INCLUDE_DIRS}"
+                          IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                          IMPORTED_LOCATION "${MBEDTLS_LIBRARY}")
+endif()
+
+if(NOT TARGET MbedCrypto)
+    add_library(MbedCrypto UNKNOWN IMPORTED)
+    set_target_properties(MbedCrypto PROPERTIES
+                          INTERFACE_INCLUDE_DIRECTORIES "${MBEDTLS_INCLUDE_DIRS}"
+                          IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                          IMPORTED_LOCATION "${MBEDCRYPTO_LIBRARY}")
+endif()
+
+if(NOT TARGET MbedX509)
+    add_library(MbedX509 UNKNOWN IMPORTED)
+    set_target_properties(MbedX509 PROPERTIES
+                          INTERFACE_INCLUDE_DIRECTORIES "${MBEDTLS_INCLUDE_DIRS}"
+                          IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                          IMPORTED_LOCATION "${MBEDX509_LIBRARY}")
+endif()

--- a/cmake/re-config.cmake
+++ b/cmake/re-config.cmake
@@ -5,7 +5,6 @@ find_package(Backtrace)
 find_package(Threads REQUIRED)
 find_package(ZLIB)
 find_package(OpenSSL)
-find_package(MbedTLS)
 
 option(USE_OPENSSL "Enable OpenSSL" ${OPENSSL_FOUND})
 option(USE_MBEDTLS "Enable MbedTLS" ${MbedTLS_FOUND})

--- a/cmake/re-config.cmake
+++ b/cmake/re-config.cmake
@@ -8,7 +8,7 @@ find_package(OpenSSL)
 find_package(MbedTLS)
 
 option(USE_OPENSSL "Enable OpenSSL" ${OPENSSL_FOUND})
-option(USE_MBEDTLS "Enable MbedTLS" ${MBEDTLS_LIBRARY_FOUND})
+option(USE_MBEDTLS "Enable MbedTLS" ${MbedTLS_FOUND})
 
 check_symbol_exists("arc4random" "stdlib.h" HAVE_ARC4RANDOM)
 if(HAVE_ARC4RANDOM)

--- a/cmake/re-config.cmake
+++ b/cmake/re-config.cmake
@@ -5,8 +5,10 @@ find_package(Backtrace)
 find_package(Threads REQUIRED)
 find_package(ZLIB)
 find_package(OpenSSL)
+find_package(MbedTLS)
 
 option(USE_OPENSSL "Enable OpenSSL" ${OPENSSL_FOUND})
+option(USE_MBEDTLS "Enable MbedTLS" ${MBEDTLS_LIBRARY_FOUND})
 
 check_symbol_exists("arc4random" "stdlib.h" HAVE_ARC4RANDOM)
 if(HAVE_ARC4RANDOM)

--- a/debian/rules
+++ b/debian/rules
@@ -26,7 +26,7 @@ build-stamp: configure-stamp
 	dh_testdir
 
 	# Add here commands to compile the package.
-	$(MAKE) RELEASE=1 \
+	$(MAKE) RELEASE=1 PREFIX=/usr \
 		EXTRA_CFLAGS=$(EXTRA_CFLAGS) \
 		EXTRA_LFLAGS=$(EXTRA_LFLAGS)
 

--- a/src/aes/mbedtls/aes.c
+++ b/src/aes/mbedtls/aes.c
@@ -37,8 +37,9 @@ static inline bool set_crypt_dir(struct aes *aes, bool encr)
 
 		/* update the encrypt/decrypt direction */
 		int mode = encr ? MBEDTLS_GCM_ENCRYPT : MBEDTLS_GCM_DECRYPT;
-		if (mbedtls_gcm_starts(&aes->gcm.ctx, mode, (const unsigned char*)&aes->gcm.iv,
-					sizeof(aes->gcm.iv), NULL, 0)) {
+		if (mbedtls_gcm_starts(&aes->gcm.ctx, mode,
+				(const unsigned char*)&aes->gcm.iv,
+				sizeof(aes->gcm.iv), NULL, 0)) {
 			return false;
 		}
 
@@ -82,18 +83,22 @@ int aes_alloc(struct aes **aesp, enum aes_mode mode,
 	switch (mode) {
 		case AES_MODE_CTR:
 			mbedtls_aes_init(&st->ctr.ctx);
-			err = mbedtls_aes_setkey_enc(&st->ctr.ctx, key, key_bits);
+			err = mbedtls_aes_setkey_enc(&st->ctr.ctx, key,
+				key_bits);
 			if (err)
 				goto out;
 			break;
 		case AES_MODE_GCM:
 			st->gcm.encr = true;
 			mbedtls_gcm_init(&st->gcm.ctx);
-			err = mbedtls_gcm_setkey(&st->gcm.ctx, MBEDTLS_CIPHER_ID_AES, key, key_bits);
+			err = mbedtls_gcm_setkey(&st->gcm.ctx,
+				MBEDTLS_CIPHER_ID_AES, key, key_bits);
 			if (err)
 				goto out;
 			memcpy(&st->gcm.iv, iv, sizeof(st->gcm.iv));
-			if (mbedtls_gcm_starts(&st->gcm.ctx, MBEDTLS_GCM_ENCRYPT, (const unsigned char*)&st->gcm.iv,
+			if (mbedtls_gcm_starts(&st->gcm.ctx,
+					MBEDTLS_GCM_ENCRYPT,
+					(const unsigned char*)&st->gcm.iv,
 					sizeof(st->gcm.iv), NULL, 0))
 				goto out;
 			break;
@@ -118,9 +123,11 @@ void aes_set_iv(struct aes *aes, const uint8_t *iv)
 
 	switch (aes->mode) {
 		case AES_MODE_GCM:
-		mbedtls_gcm_starts(&aes->gcm.ctx, mode, (const unsigned char*)&aes->gcm.iv,
-					sizeof(aes->gcm.iv), NULL, 0);
-		default: ;
+		mbedtls_gcm_starts(&aes->gcm.ctx, mode,
+				(const unsigned char*)&aes->gcm.iv,
+				sizeof(aes->gcm.iv), NULL, 0);
+		default:
+			;
 	}
 }
 
@@ -133,8 +140,9 @@ int aes_encr(struct aes *aes, uint8_t *out, const uint8_t *in, size_t len)
 
 	switch (aes->mode) {
 		case AES_MODE_CTR:
-			mbedtls_aes_crypt_ctr(&aes->ctr.ctx, len, &aes->ctr.nc_off,
-				aes->ctr.nonce_counter, aes->ctr.stream_block, in, out);
+			mbedtls_aes_crypt_ctr(&aes->ctr.ctx, len,
+				&aes->ctr.nc_off, aes->ctr.nonce_counter,
+				aes->ctr.stream_block, in, out);
 			break;
 		case AES_MODE_GCM:
 			if (!set_crypt_dir(aes, true))
@@ -155,8 +163,9 @@ int aes_decr(struct aes *aes, uint8_t *out, const uint8_t *in, size_t len)
 
 	switch (aes->mode) {
 		case AES_MODE_CTR:
-			mbedtls_aes_crypt_ctr(&aes->ctr.ctx, len, &aes->ctr.nc_off,
-				aes->ctr.nonce_counter, aes->ctr.stream_block, in, out);
+			mbedtls_aes_crypt_ctr(&aes->ctr.ctx, len,
+				&aes->ctr.nc_off, aes->ctr.nonce_counter,
+				aes->ctr.stream_block, in, out);
 			break;
 		case AES_MODE_GCM:
 			if (!set_crypt_dir(aes, false))

--- a/src/aes/mbedtls/aes.c
+++ b/src/aes/mbedtls/aes.c
@@ -164,7 +164,7 @@ static int check_started(struct aes *aes, int direction) {
 			aes->gcm.aad_len))
 		return EPROTO;
 #else
-	if (mbedtls_gcm_starts(&aes->gcm.ctx, mode, aes->gcm.iv,
+	if (mbedtls_gcm_starts(&aes->gcm.ctx, direction, aes->gcm.iv,
 				GCM_IV_LEN, aes->gcm.aad, aes->gcm.aad_len))
 		return EPROTO;
 #endif

--- a/src/aes/mbedtls/aes.c
+++ b/src/aes/mbedtls/aes.c
@@ -86,9 +86,8 @@ int aes_alloc(struct aes **aesp, enum aes_mode mode,
 				MBEDTLS_CIPHER_ID_AES, key, key_bits);
 			if (err)
 				goto out;
-			if (iv != NULL) {
+			if (iv)
 				memcpy(st->gcm.iv, iv, GCM_IV_LEN);
-			}
 			break;
 	}
 
@@ -108,12 +107,13 @@ void aes_set_iv(struct aes *aes, const uint8_t *iv)
 		return;
 
 	switch (aes->mode) {
+		case AES_MODE_CTR:
+			memcpy(aes->ctr.nonce_counter, iv,
+				sizeof(aes->ctr.nonce_counter));
+			break;
 		case AES_MODE_GCM:
-			if (iv != NULL) {
-				memcpy(aes->gcm.iv, iv, GCM_IV_LEN);
-			}
-		default:
-			;
+			memcpy(aes->gcm.iv, iv, GCM_IV_LEN);
+			break;
 	}
 }
 

--- a/src/aes/mbedtls/aes.c
+++ b/src/aes/mbedtls/aes.c
@@ -1,0 +1,227 @@
+/**
+ * @file mbedtls/aes.c  AES (Advanced Encryption Standard) using MbedTLS
+ *
+ * Copyright (C) 2022 Dmitry Ilyin
+ */
+#include <string.h>
+#include <mbedtls/aes.h>
+#include <mbedtls/gcm.h>
+#include <re_types.h>
+#include <re_fmt.h>
+#include <re_mem.h>
+#include <re_aes.h>
+
+struct aes {
+	enum aes_mode mode;
+
+	union {
+		struct {
+			mbedtls_aes_context ctx;
+			size_t nc_off;
+			unsigned char nonce_counter[16];
+			unsigned char stream_block[16];
+		} ctr;
+
+		struct {
+			mbedtls_gcm_context ctx;
+			bool encr;
+			uint8_t iv[16];
+		} gcm;
+	};
+};
+
+
+static inline bool set_crypt_dir(struct aes *aes, bool encr)
+{
+	if (aes->gcm.encr != encr) {
+
+		/* update the encrypt/decrypt direction */
+		int mode = encr ? MBEDTLS_GCM_ENCRYPT : MBEDTLS_GCM_DECRYPT;
+		if (mbedtls_gcm_starts(&aes->gcm.ctx, mode, (const unsigned char*)&aes->gcm.iv,
+					sizeof(aes->gcm.iv), NULL, 0)) {
+			return false;
+		}
+
+		aes->gcm.encr = encr;
+	}
+
+	return true;
+}
+
+static void destructor(void *arg)
+{
+	struct aes *st = arg;
+
+	switch (st->mode) {
+		case AES_MODE_CTR:
+			mbedtls_aes_free(&st->ctr.ctx);
+			break;
+		case AES_MODE_GCM:
+			mbedtls_gcm_free(&st->gcm.ctx);
+			break;
+	}
+}
+
+
+int aes_alloc(struct aes **aesp, enum aes_mode mode,
+	      const uint8_t *key, size_t key_bits,
+	      const uint8_t *iv)
+{
+	struct aes *st;
+	int err = 0;
+
+	if (!aesp || !key)
+		return EINVAL;
+
+	st = mem_zalloc(sizeof(*st), destructor);
+	if (!st)
+		return ENOMEM;
+
+	st->mode = mode;
+
+	switch (mode) {
+		case AES_MODE_CTR:
+			mbedtls_aes_init(&st->ctr.ctx);
+			err = mbedtls_aes_setkey_enc(&st->ctr.ctx, key, key_bits);
+			if (err)
+				goto out;
+			break;
+		case AES_MODE_GCM:
+			st->gcm.encr = true;
+			mbedtls_gcm_init(&st->gcm.ctx);
+			err = mbedtls_gcm_setkey(&st->gcm.ctx, MBEDTLS_CIPHER_ID_AES, key, key_bits);
+			if (err)
+				goto out;
+			memcpy(&st->gcm.iv, iv, sizeof(st->gcm.iv));
+			if (mbedtls_gcm_starts(&st->gcm.ctx, MBEDTLS_GCM_ENCRYPT, (const unsigned char*)&st->gcm.iv,
+					sizeof(st->gcm.iv), NULL, 0))
+				goto out;
+			break;
+	}
+
+ out:
+	if (err)
+		mem_deref(st);
+	else
+		*aesp = st;
+
+	return err;
+}
+
+
+void aes_set_iv(struct aes *aes, const uint8_t *iv)
+{
+	int mode = aes->gcm.encr ? MBEDTLS_GCM_ENCRYPT : MBEDTLS_GCM_DECRYPT;
+
+	if (!aes || !iv)
+		return;
+
+	switch (aes->mode) {
+		case AES_MODE_GCM:
+		mbedtls_gcm_starts(&aes->gcm.ctx, mode, (const unsigned char*)&aes->gcm.iv,
+					sizeof(aes->gcm.iv), NULL, 0);
+		default: ;
+	}
+}
+
+
+int aes_encr(struct aes *aes, uint8_t *out, const uint8_t *in, size_t len)
+{
+	if (!aes || !in)
+		return EINVAL;
+
+
+	switch (aes->mode) {
+		case AES_MODE_CTR:
+			mbedtls_aes_crypt_ctr(&aes->ctr.ctx, len, &aes->ctr.nc_off,
+				aes->ctr.nonce_counter, aes->ctr.stream_block, in, out);
+			break;
+		case AES_MODE_GCM:
+			if (!set_crypt_dir(aes, true))
+				return EPROTO;
+
+			mbedtls_gcm_update(&aes->gcm.ctx, len, in, out);
+			break;
+	}
+
+	return 0;
+}
+
+
+int aes_decr(struct aes *aes, uint8_t *out, const uint8_t *in, size_t len)
+{
+	if (!aes || !in)
+		return EINVAL;
+
+	switch (aes->mode) {
+		case AES_MODE_CTR:
+			mbedtls_aes_crypt_ctr(&aes->ctr.ctx, len, &aes->ctr.nc_off,
+				aes->ctr.nonce_counter, aes->ctr.stream_block, in, out);
+			break;
+		case AES_MODE_GCM:
+			if (!set_crypt_dir(aes, false))
+				return EPROTO;
+
+			mbedtls_gcm_update(&aes->gcm.ctx, len, in, out);
+			break;
+	}
+
+	return 0;
+}
+
+
+/**
+ * Get the authentication tag for an AEAD cipher (e.g. GCM)
+ *
+ * @param aes    AES Context
+ * @param tag    Authentication tag
+ * @param taglen Length of Authentication tag
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int aes_get_authtag(struct aes *aes, uint8_t *tag, size_t taglen)
+{
+	if (!aes || !tag || !taglen)
+		return EINVAL;
+
+	switch (aes->mode) {
+
+	case AES_MODE_GCM:
+		mbedtls_gcm_finish(&aes->gcm.ctx, tag, taglen);
+		return 0;
+
+	default:
+		return ENOTSUP;
+	}
+}
+
+/**
+ * Authenticate a decryption tag for an AEAD cipher (e.g. GCM)
+ *
+ * @param aes    AES Context
+ * @param tag    Authentication tag
+ * @param taglen Length of Authentication tag
+ *
+ * @return 0 if success, otherwise errorcode
+ *
+ * @retval EAUTH if authentication failed
+ */
+int aes_authenticate(struct aes *aes, const uint8_t *tag, size_t taglen)
+{
+	unsigned char check_tag[16];
+
+	if (!aes || !tag || !taglen)
+		return EINVAL;
+
+	switch (aes->mode) {
+
+	case AES_MODE_GCM:
+		mbedtls_gcm_finish(&aes->gcm.ctx, check_tag, taglen);
+		if (memcpy(check_tag, tag, taglen) != 0)
+			return EAUTH;
+		return 0;
+
+	default:
+		return ENOTSUP;
+	}
+}

--- a/src/aes/mbedtls/aes.c
+++ b/src/aes/mbedtls/aes.c
@@ -123,6 +123,7 @@ void aes_set_iv(struct aes *aes, const uint8_t *iv)
 
 	switch (aes->mode) {
 		case AES_MODE_GCM:
+		memcpy(&aes->gcm.iv, iv, sizeof(aes->gcm.iv));
 		mbedtls_gcm_starts(&aes->gcm.ctx, mode,
 				(const unsigned char*)&aes->gcm.iv,
 				sizeof(aes->gcm.iv), NULL, 0);

--- a/src/hmac/hmac_sha1.c
+++ b/src/hmac/hmac_sha1.c
@@ -9,10 +9,10 @@
 #include <openssl/sha.h>
 #include <openssl/hmac.h>
 #include <openssl/err.h>
-#elif defined (__APPLE__)
-#include <CommonCrypto/CommonHMAC.h>
 #elif defined (USE_MBEDTLS)
 #include <mbedtls/md.h>
+#elif defined (__APPLE__)
+#include <CommonCrypto/CommonHMAC.h>
 #endif
 #include <re_hmac.h>
 
@@ -45,11 +45,11 @@ void hmac_sha1(const uint8_t *k,  /* secret key */
 #if defined (USE_OPENSSL)
 	if (!HMAC(EVP_sha1(), k, (int)lk, d, ld, out, NULL))
 		ERR_clear_error();
-#elif defined (__APPLE__)
-	CCHmac(kCCHmacAlgSHA1, k, lk, d, ld, out);
 #elif defined (USE_MBEDTLS)
 	mbedtls_md_hmac(mbedtls_md_info_from_type(MBEDTLS_MD_SHA1),
 			k, lk, d, ld, out);
+#elif defined (__APPLE__)
+	CCHmac(kCCHmacAlgSHA1, k, lk, d, ld, out);
 #else
 	(void)k;
 	(void)lk;

--- a/src/hmac/hmac_sha1.c
+++ b/src/hmac/hmac_sha1.c
@@ -50,6 +50,12 @@ void hmac_sha1(const uint8_t *k,  /* secret key */
 #elif defined (USE_MBEDTLS)
 	mbedtls_md_hmac(mbedtls_md_info_from_type(MBEDTLS_MD_SHA1), k, lk, d, ld, out);
 #else
-	sha1_hmac(k, lk, d, ld, out);
+	(void)k;
+	(void)lk;
+	(void)d;
+	(void)ld;
+	(void)out;
+
+#error missing HMAC-SHA1 backend
 #endif
 }

--- a/src/hmac/hmac_sha1.c
+++ b/src/hmac/hmac_sha1.c
@@ -5,12 +5,13 @@
  */
 #include <string.h>
 #include <re_types.h>
-#ifdef USE_OPENSSL
+#if defined(USE_OPENSSL)
 #include <openssl/sha.h>
 #include <openssl/hmac.h>
 #include <openssl/err.h>
 #elif defined (__APPLE__)
 #include <CommonCrypto/CommonHMAC.h>
+#elif defined (USE_MBEDTLS)
 #endif
 #include <re_hmac.h>
 
@@ -38,7 +39,7 @@ void hmac_sha1(const uint8_t *k,  /* secret key */
 	       uint8_t *out,      /* output buffer, at least "t" bytes */
 	       size_t   t)
 {
-#ifdef USE_OPENSSL
+#if defined (USE_OPENSSL)
 	(void)t;
 
 	if (!HMAC(EVP_sha1(), k, (int)lk, d, ld, out, NULL))
@@ -47,6 +48,7 @@ void hmac_sha1(const uint8_t *k,  /* secret key */
 	(void)t;
 
 	CCHmac(kCCHmacAlgSHA1, k, lk, d, ld, out);
+#elif defined (USE_MBEDTLS)
 #else
 	(void)k;
 	(void)lk;

--- a/src/hmac/hmac_sha1.c
+++ b/src/hmac/hmac_sha1.c
@@ -12,6 +12,7 @@
 #elif defined (__APPLE__)
 #include <CommonCrypto/CommonHMAC.h>
 #elif defined (USE_MBEDTLS)
+#include <mbedtls/md.h>
 #endif
 #include <re_hmac.h>
 
@@ -39,26 +40,16 @@ void hmac_sha1(const uint8_t *k,  /* secret key */
 	       uint8_t *out,      /* output buffer, at least "t" bytes */
 	       size_t   t)
 {
-#if defined (USE_OPENSSL)
 	(void)t;
 
+#if defined (USE_OPENSSL)
 	if (!HMAC(EVP_sha1(), k, (int)lk, d, ld, out, NULL))
 		ERR_clear_error();
 #elif defined (__APPLE__)
-	(void)t;
-
 	CCHmac(kCCHmacAlgSHA1, k, lk, d, ld, out);
 #elif defined (USE_MBEDTLS)
+	mbedtls_md_hmac(mbedtls_md_info_from_type(MBEDTLS_MD_SHA1), k, lk, d, ld, out);
 #else
-	(void)k;
-	(void)lk;
-	(void)d;
-	(void)ld;
-	(void)out;
-	(void)t;
-
-#error missing HMAC-SHA1 backend
-
-
+	sha1_hmac(k, lk, d, ld, out);
 #endif
 }

--- a/src/hmac/hmac_sha1.c
+++ b/src/hmac/hmac_sha1.c
@@ -48,7 +48,8 @@ void hmac_sha1(const uint8_t *k,  /* secret key */
 #elif defined (__APPLE__)
 	CCHmac(kCCHmacAlgSHA1, k, lk, d, ld, out);
 #elif defined (USE_MBEDTLS)
-	mbedtls_md_hmac(mbedtls_md_info_from_type(MBEDTLS_MD_SHA1), k, lk, d, ld, out);
+	mbedtls_md_hmac(mbedtls_md_info_from_type(MBEDTLS_MD_SHA1),
+			k, lk, d, ld, out);
 #else
 	(void)k;
 	(void)lk;

--- a/src/hmac/mbedtls/hmac.c
+++ b/src/hmac/mbedtls/hmac.c
@@ -1,0 +1,91 @@
+/**
+ * @file openssl/hmac.c  HMAC using MbedTLS
+ *
+ * Copyright (C) 2022 Dmitry Ilyin
+ */
+
+#include <mbedtls/md.h>
+#include <string.h>
+#include <re_types.h>
+#include <re_mem.h>
+#include <re_hmac.h>
+
+
+struct hmac {
+	const mbedtls_md_info_t *type;
+	uint8_t *key;
+	int key_len;
+};
+
+
+static void destructor(void *arg)
+{
+	struct hmac *hmac = arg;
+
+	mem_deref(hmac->key);
+}
+
+
+int hmac_create(struct hmac **hmacp, enum hmac_hash hash, const uint8_t *key,
+		size_t key_len)
+{
+	struct hmac *hmac;
+	int err = 0;
+
+	if (!hmacp || !key || !key_len)
+		return EINVAL;
+
+	hmac = mem_zalloc(sizeof(*hmac), destructor);
+	if (!hmac)
+		return ENOMEM;
+
+	hmac->key = mem_zalloc(key_len, NULL);
+	if (!hmac->key) {
+		err = ENOMEM;
+		goto error;
+	}
+
+	memcpy(hmac->key, key, key_len);
+	hmac->key_len = (int)key_len;
+
+	switch (hash) {
+
+	case HMAC_HASH_SHA1:
+		hmac->type = mbedtls_md_info_from_type(MBEDTLS_MD_SHA1);
+		break;
+
+	case HMAC_HASH_SHA256:
+		hmac->type = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+		break;
+
+	default:
+		err = ENOTSUP;
+		goto error;
+	}
+
+	*hmacp = hmac;
+
+	return 0;
+
+error:
+	mem_deref(hmac);
+	return err;
+}
+
+
+int hmac_digest(struct hmac *hmac, uint8_t *md, size_t md_len,
+		const uint8_t *data, size_t data_len)
+{
+	int ret;
+
+	if (!hmac || !md || !md_len || !data || !data_len)
+		return EINVAL;
+
+	ret = mbedtls_md_hmac(hmac->type, hmac->key, hmac->key_len,
+			data, data_len, md);
+	if (!ret) {
+		return EPROTO;
+	}
+
+	return 0;
+}

--- a/src/hmac/mbedtls/hmac.c
+++ b/src/hmac/mbedtls/hmac.c
@@ -83,7 +83,7 @@ int hmac_digest(struct hmac *hmac, uint8_t *md, size_t md_len,
 
 	ret = mbedtls_md_hmac(hmac->type, hmac->key, hmac->key_len,
 			data, data_len, md);
-	if (!ret) {
+	if (ret != 0) {
 		return EPROTO;
 	}
 

--- a/src/main/init.c
+++ b/src/main/init.c
@@ -21,8 +21,12 @@ int libre_init(void)
 {
 	int err;
 
-#ifdef USE_OPENSSL
+#if defined(USE_OPENSSL)
 	err = openssl_init();
+	if (err)
+		return err;
+#elif defined (USE_MBEDTLS)
+	err = mbedtls_init();
 	if (err)
 		return err;
 #endif

--- a/src/main/main.h
+++ b/src/main/main.h
@@ -9,8 +9,10 @@
 extern "C" {
 #endif
 
-#ifdef USE_OPENSSL
+#if defined(USE_OPENSSL)
 int  openssl_init(void);
+#elif defined(USE_MBEDTLS)
+int  mbedtls_init(void);
 #endif
 
 #ifdef __cplusplus

--- a/src/main/mbedtls.c
+++ b/src/main/mbedtls.c
@@ -19,8 +19,6 @@ static void sigpipe_handler(int x)
 
 int mbedtls_init(void)
 {
-	int err;
-
 #ifdef SIGPIPE
 	(void)signal(SIGPIPE, sigpipe_handler);
 #endif

--- a/src/main/mbedtls.c
+++ b/src/main/mbedtls.c
@@ -1,0 +1,29 @@
+/**
+ * @file mbedtls.c  MbedTLS initialisation and multi-threading routines
+ *
+ */
+#ifdef HAVE_SIGNAL
+#include <signal.h>
+#endif
+#include "main.h"
+
+
+#ifdef SIGPIPE
+static void sigpipe_handler(int x)
+{
+	(void)x;
+	(void)signal(SIGPIPE, sigpipe_handler);
+}
+#endif
+
+
+int mbedtls_init(void)
+{
+	int err;
+
+#ifdef SIGPIPE
+	(void)signal(SIGPIPE, sigpipe_handler);
+#endif
+
+	return 0;
+}

--- a/src/md5/wrap.c
+++ b/src/md5/wrap.c
@@ -3,10 +3,11 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
-#ifdef USE_OPENSSL
+#if defined(USE_OPENSSL)
 #include <stddef.h>
 #include <openssl/evp.h>
 #include <openssl/md5.h>
+#elif defined(USE_MBEDTLS)
 #endif
 #include <re_types.h>
 #include <re_fmt.h>
@@ -24,7 +25,7 @@
  */
 void md5(const uint8_t *d, size_t n, uint8_t *md)
 {
-#ifdef USE_OPENSSL
+#if defined(USE_OPENSSL)
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 	EVP_MD_CTX *ctx = EVP_MD_CTX_new();
 
@@ -35,6 +36,7 @@ void md5(const uint8_t *d, size_t n, uint8_t *md)
 #else
 	(void)MD5(d, n, md);
 #endif
+#elif defined(USE_MBEDTLS)
 #else
 #error missing MD5 backend
 #endif

--- a/src/md5/wrap.c
+++ b/src/md5/wrap.c
@@ -8,6 +8,10 @@
 #include <openssl/evp.h>
 #include <openssl/md5.h>
 #elif defined(USE_MBEDTLS)
+#include <mbedtls/md5.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/version.h>
 #endif
 #include <re_types.h>
 #include <re_fmt.h>
@@ -37,6 +41,7 @@ void md5(const uint8_t *d, size_t n, uint8_t *md)
 	(void)MD5(d, n, md);
 #endif
 #elif defined(USE_MBEDTLS)
+	mbedtls_md5(d, n, md);
 #else
 #error missing MD5 backend
 #endif

--- a/src/net/ifaddrs.c
+++ b/src/net/ifaddrs.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <sys/socket.h>
 #define __USE_MISC 1   /**< Use MISC code */
+#define _BSD_SOURCE 1
 #include <net/if.h>
 #include <ifaddrs.h>
 #include <re_types.h>

--- a/src/net/posix/pif.c
+++ b/src/net/posix/pif.c
@@ -11,6 +11,7 @@
 #define __USE_XOPEN2K 1/**< Use POSIX.1:2001 code */
 #include <netdb.h>
 #define __USE_MISC 1   /**< Use MISC code */
+#define _BSD_SOURCE 1
 #include <net/if.h>
 #include <arpa/inet.h>
 /*#include <net/if_arp.h>*/

--- a/src/sha/wrap.c
+++ b/src/sha/wrap.c
@@ -8,10 +8,10 @@
 #include <re_types.h>
 #if defined(USE_OPENSSL)
 #include <openssl/sha.h>
-#elif defined (__APPLE__)
-#include <CommonCrypto/CommonDigest.h>
 #elif defined (USE_MBEDTLS)
 #include <mbedtls/md.h>
+#elif defined (__APPLE__)
+#include <CommonCrypto/CommonDigest.h>
 #endif
 #include <re_sha.h>
 
@@ -27,10 +27,10 @@ void sha1(const uint8_t *d, size_t n, uint8_t *md)
 {
 #if defined(USE_OPENSSL)
 	(void)SHA1(d, n, md);
-#elif defined (__APPLE__)
-	CC_SHA1(d, (uint32_t)n, md);
 #elif defined (USE_MBEDTLS)
 	mbedtls_md(mbedtls_md_info_from_type(MBEDTLS_MD_SHA1), d, n, md);
+#elif defined (__APPLE__)
+	CC_SHA1(d, (uint32_t)n, md);
 #else
 	(void)d;
 	(void)n;

--- a/src/sha/wrap.c
+++ b/src/sha/wrap.c
@@ -6,10 +6,11 @@
  */
 
 #include <re_types.h>
-#ifdef USE_OPENSSL
+#if defined(USE_OPENSSL)
 #include <openssl/sha.h>
 #elif defined (__APPLE__)
 #include <CommonCrypto/CommonDigest.h>
+#elif defined (USE_MBEDTLS)
 #endif
 #include <re_sha.h>
 
@@ -23,10 +24,11 @@
  */
 void sha1(const uint8_t *d, size_t n, uint8_t *md)
 {
-#ifdef USE_OPENSSL
+#if defined(USE_OPENSSL)
 	(void)SHA1(d, n, md);
 #elif defined (__APPLE__)
 	CC_SHA1(d, (uint32_t)n, md);
+#elif defined (USE_MBEDTLS)
 #else
 	(void)d;
 	(void)n;
@@ -45,10 +47,11 @@ void sha1(const uint8_t *d, size_t n, uint8_t *md)
  */
 void sha256(const uint8_t *d, size_t n, uint8_t *md)
 {
-#ifdef USE_OPENSSL
+#if defined(USE_OPENSSL)
 	(void)SHA256(d, n, md);
 #elif defined (__APPLE__)
 	CC_SHA256(d, (uint32_t)n, md);
+#elif defined (USE_MBEDTLS)
 #else
 	(void)d;
 	(void)n;

--- a/src/sha/wrap.c
+++ b/src/sha/wrap.c
@@ -11,6 +11,7 @@
 #elif defined (__APPLE__)
 #include <CommonCrypto/CommonDigest.h>
 #elif defined (USE_MBEDTLS)
+#include <mbedtls/md.h>
 #endif
 #include <re_sha.h>
 
@@ -29,6 +30,7 @@ void sha1(const uint8_t *d, size_t n, uint8_t *md)
 #elif defined (__APPLE__)
 	CC_SHA1(d, (uint32_t)n, md);
 #elif defined (USE_MBEDTLS)
+	mbedtls_md(mbedtls_md_info_from_type(MBEDTLS_MD_SHA1), d, n, md);
 #else
 	(void)d;
 	(void)n;
@@ -52,6 +54,7 @@ void sha256(const uint8_t *d, size_t n, uint8_t *md)
 #elif defined (__APPLE__)
 	CC_SHA256(d, (uint32_t)n, md);
 #elif defined (USE_MBEDTLS)
+	mbedtls_md(mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), d, n, md);
 #else
 	(void)d;
 	(void)n;

--- a/src/tcp/tcp.c
+++ b/src/tcp/tcp.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
+
 #include <stdlib.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -14,6 +15,7 @@
 #define __USE_POSIX 1  /**< Use POSIX flag */
 #define __USE_XOPEN2K 1/**< Use POSIX.1:2001 code */
 #define __USE_MISC 1
+#define _GNU_SOURCE 1
 #include <netdb.h>
 #endif
 #ifdef __APPLE__


### PR DESCRIPTION
Some embedded system use MbedTLS rather than heavy OpenSSL and this PR will help to use libre on that systems