### PR TITLE
Fix error: ‘NI_MAXSERV’ undeclared

### DIFF
--- a/src/tcp/tcp.c
+++ b/src/tcp/tcp.c
@@ -3,6 +3,10 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
+
 #include <stdlib.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>

--- a/src/tcp/tcp.c
+++ b/src/tcp/tcp.c
@@ -3,9 +3,6 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
-#ifndef _GNU_SOURCE
-# define _GNU_SOURCE
-#endif
 
 #include <stdlib.h>
 #ifdef HAVE_UNISTD_H
@@ -18,6 +15,7 @@
 #define __USE_POSIX 1  /**< Use POSIX flag */
 #define __USE_XOPEN2K 1/**< Use POSIX.1:2001 code */
 #define __USE_MISC 1
+#define _GNU_SOURCE 1
 #include <netdb.h>
 #endif
 #ifdef __APPLE__


### PR DESCRIPTION
When I compile libre using `arm-linux-musleabi-gcc` cross-compiler with musl library I encountered a compilation issue:

```
[ 59%] Building C object CMakeFiles/re-objs.dir/src/tcp/tcp.c.o
.../git/re/src/tcp/tcp.c: In function ‘tcp_sock_bind’:
.../git/re/src/tcp/tcp.c:725:12: error: ‘NI_MAXSERV’ undeclared (first use in this function)
  char serv[NI_MAXSERV] = "0";
            ^~~~~~~~~~
.../git/re/src/tcp/tcp.c:725:12: note: each undeclared identifier is reported only once for each function it appears in
.../git/re/src/tcp/tcp.c:725:7: warning: unused variable ‘serv’ [-Wunused-variable]
  char serv[NI_MAXSERV] = "0";
       ^~~~
.../re/src/tcp/tcp.c: In function ‘tcp_conn_alloc’:
.../re/src/tcp/tcp.c:886:12: error: ‘NI_MAXSERV’ undeclared (first use in this function)
  char serv[NI_MAXSERV] = "0";
            ^~~~~~~~~~
.../re/src/tcp/tcp.c:886:7: warning: unused variable ‘serv’ [-Wunused-variable]
  char serv[NI_MAXSERV] = "0";
       ^~~~
.../re/src/tcp/tcp.c: In function ‘tcp_conn_bind’:
.../re/src/tcp/tcp.c:963:12: error: ‘NI_MAXSERV’ undeclared (first use in this function)
  char serv[NI_MAXSERV] = "0";
            ^~~~~~~~~~
.../re/src/tcp/tcp.c:963:7: warning: unused variable ‘serv’ [-Wunused-variable]
  char serv[NI_MAXSERV] = "0";
       ^~~~
.../re/src/tcp/tcp.c: In function ‘tcp_conn_connect’:
.../re/src/tcp/tcp.c:1037:12: error: ‘NI_MAXSERV’ undeclared (first use in this function)
  char serv[NI_MAXSERV];
            ^~~~~~~~~~
.../re/src/tcp/tcp.c:1037:7: warning: unused variable ‘serv’ [-Wunused-variable]
  char serv[NI_MAXSERV];
       ^~~~
```

It turns out [the same issue](https://github.com/openssl/openssl/issues/13049) had OpenSSL project, and it was fixed by [this commit](https://github.com/openssl/openssl/commit/99501e817cbc4f11cc045dbaa7a81854d4349335). It resolved my issue as well.