### PR TITLE
Fix error: storage size of ‘ifrr’ isn’t known

### DIFF
--- a/src/net/ifaddrs.c
+++ b/src/net/ifaddrs.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <sys/socket.h>
 #define __USE_MISC 1   /**< Use MISC code */
+#define _BSD_SOURCE
 #include <net/if.h>
 #include <ifaddrs.h>
 #include <re_types.h>

--- a/src/net/ifaddrs.c
+++ b/src/net/ifaddrs.c
@@ -6,7 +6,7 @@
 #include <unistd.h>
 #include <sys/socket.h>
 #define __USE_MISC 1   /**< Use MISC code */
-#define _BSD_SOURCE
+#define _BSD_SOURCE 1
 #include <net/if.h>
 #include <ifaddrs.h>
 #include <re_types.h>

--- a/src/net/posix/pif.c
+++ b/src/net/posix/pif.c
@@ -11,6 +11,7 @@
 #define __USE_XOPEN2K 1/**< Use POSIX.1:2001 code */
 #include <netdb.h>
 #define __USE_MISC 1   /**< Use MISC code */
+#define _BSD_SOURCE
 #include <net/if.h>
 #include <arpa/inet.h>
 /*#include <net/if_arp.h>*/

--- a/src/net/posix/pif.c
+++ b/src/net/posix/pif.c
@@ -11,7 +11,7 @@
 #define __USE_XOPEN2K 1/**< Use POSIX.1:2001 code */
 #include <netdb.h>
 #define __USE_MISC 1   /**< Use MISC code */
-#define _BSD_SOURCE
+#define _BSD_SOURCE 1
 #include <net/if.h>
 #include <arpa/inet.h>
 /*#include <net/if_arp.h>*/


### PR DESCRIPTION
When I compile libre using arm-linux-musleabi-gcc cross-compiler with musl library I encountered a compilation issue:

```
/tmp/re/src/net/posix/pif.c: In function ‘net_if_getaddr4’:
/tmp/re/src/net/posix/pif.c:65:16: error: storage size of ‘ifrr’ isn’t known
   struct ifreq ifrr;
                ^~~~
/tmp/re/src/net/posix/pif.c:65:16: warning: unused variable ‘ifrr’ [-Wunused-variable]
/tmp/re/src/net/posix/pif.c: In function ‘net_if_list’:
/tmp/re/src/net/posix/pif.c:104:15: error: array type has incomplete element type ‘struct ifreq’
  struct ifreq ifrv[32], *ifr;
               ^~~~
/tmp/re/src/net/posix/pif.c:105:16: error: storage size of ‘ifc’ isn’t known
  struct ifconf ifc;
                ^~~
/tmp/re/src/net/posix/pif.c:126:7: error: increment of pointer to an incomplete type ‘struct ifreq’
       ++ifr) {
       ^~
/tmp/re/src/net/posix/pif.c:127:16: error: storage size of ‘ifrr’ isn’t known
   struct ifreq ifrr;
                ^~~~
/tmp/re/src/net/posix/pif.c:130:10: error: dereferencing pointer to incomplete type ‘struct ifreq’
   if (ifr->ifr_addr.sa_data == (ifr+1)->ifr_addr.sa_data)
          ^~
/tmp/re/src/net/posix/pif.c:130:36: error: invalid use of undefined type ‘struct ifreq’
   if (ifr->ifr_addr.sa_data == (ifr+1)->ifr_addr.sa_data)
                                    ^
/tmp/re/src/net/posix/pif.c:141:26: error: ‘IFF_UP’ undeclared (first use in this function)
   if (!(ifr->ifr_flags & IFF_UP))
                          ^~~~~~
/tmp/re/src/net/posix/pif.c:141:26: note: each undeclared identifier is reported only once for each function it appears in
/tmp/re/src/net/posix/pif.c:127:16: warning: unused variable ‘ifrr’ [-Wunused-variable]
   struct ifreq ifrr;
                ^~~~
/tmp/re/src/net/posix/pif.c:105:16: warning: unused variable ‘ifc’ [-Wunused-variable]
  struct ifconf ifc;
                ^~~
/tmp/re/src/net/posix/pif.c:104:15: warning: unused variable ‘ifrv’ [-Wunused-variable]
  struct ifreq ifrv[32], *ifr;
               ^~~~
```

It turns out to fix the compilation issue `#define _BSD_SOURCE` before each `#include <net/if.h>` if required