### PR TITLE
Do not change local media format id to match the one in the offer

### DIFF
--- a/src/sdp/media.c
+++ b/src/sdp/media.c
@@ -317,20 +317,6 @@ void sdp_media_align_formats(struct sdp_media *m, bool offer)
 		}
 	}
 
-	if (offer) {
-
-		for (lle=m->lfmtl.tail; lle; ) {
-
-			lfmt = lle->data;
-
-			lle = lle->prev;
-
-			if (lfmt && !lfmt->sup) {
-				list_unlink(&lfmt->le);
-				list_append(&m->lfmtl, &lfmt->le, lfmt);
-			}
-		}
-	}
 }
 
 


### PR DESCRIPTION
Before this patch, when offer was received, local id of common media was changed to match that in the offer.  As result, the id could conflict with some other local media id.

I don't see a need for the id change.  Since this is a very serious bug, my suggestion is to the merge this PR. If someone thinks the id needs to be changed then he/she can make another PR that fixes the conflict.

After this PR, the re-INVITE test of https://github.com/baresip/baresip/issues/2073 worked fine.