### PR TITLE
Correctly update local media format ids to match those in the offer

### DIFF
--- a/src/sdp/media.c
+++ b/src/sdp/media.c
@@ -306,15 +306,6 @@ void sdp_media_align_formats(struct sdp_media *m, bool offer)
 			rfmt->data = lfmt->data;
 
 		rfmt->ref = lfmt->ref;
-
-		if (offer) {
-			mem_deref(lfmt->id);
-			lfmt->id = mem_ref(rfmt->id);
-			lfmt->pt = atoi(lfmt->id ? lfmt->id : "");
-
-			list_unlink(&lfmt->le);
-			list_append(&m->lfmtl, &lfmt->le, lfmt);
-		}
 	}
 
 	if (offer) {

--- a/src/sdp/media.c
+++ b/src/sdp/media.c
@@ -260,6 +260,7 @@ void sdp_media_align_formats(struct sdp_media *m, bool offer)
 {
 	struct sdp_format *rfmt, *lfmt = NULL;
 	struct le *rle, *lle;
+	int pt_offer = RTP_DYNPT_START;
 
 	if (!m || m->disabled || !sa_port(&m->raddr) || m->fmt_ignore)
 		return;
@@ -306,20 +307,30 @@ void sdp_media_align_formats(struct sdp_media *m, bool offer)
 			rfmt->data = lfmt->data;
 
 		rfmt->ref = lfmt->ref;
+
+		/* Use payload type from offer - RFC3264 - 6.1 */
+		if (offer) {
+			mem_deref(lfmt->id);
+			lfmt->id = mem_ref(rfmt->id);
+			lfmt->pt = atoi(lfmt->id ? lfmt->id : "");
+			if (lfmt->pt > pt_offer)
+				pt_offer = lfmt->pt;
+		}
 	}
 
+	/* Recalculate pt of unsupported codecs */
 	if (offer) {
 
-		for (lle=m->lfmtl.tail; lle; ) {
+		for (lle=m->lfmtl.head; lle; lle=lle->next) {
 
 			lfmt = lle->data;
 
-			lle = lle->prev;
-
-			if (lfmt && !lfmt->sup) {
-				list_unlink(&lfmt->le);
-				list_append(&m->lfmtl, &lfmt->le, lfmt);
-			}
+			if (lfmt && !lfmt->sup)
+				if (lfmt->pt >= RTP_DYNPT_START) {
+					mem_deref(lfmt->id);
+					lfmt->pt = ++pt_offer;
+					re_sdprintf(&lfmt->id, "%i", lfmt->pt);
+				}
 		}
 	}
 }


### PR DESCRIPTION
Before this patch, when offer was received, local id of common media was changed to match that in the offer. As result, the id could conflict with some other local media id.

I don't see a need for the id change. Since this is a very serious bug, my suggestion is to the merge this PR. If someone thinks the id needs to be changed then he/she can make another PR that fixes the conflict.

After this PR, the re-INVITE test of https://github.com/baresip/baresip/issues/2073 worked fine.