### PR TITLE
debian: fix prefix

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -26,7 +26,7 @@ build-stamp: configure-stamp
 	dh_testdir
 
 	# Add here commands to compile the package.
-	$(MAKE) RELEASE=1 \
+	$(MAKE) RELEASE=1 PREFIX=/usr \
 		EXTRA_CFLAGS=$(EXTRA_CFLAGS) \
 		EXTRA_LFLAGS=$(EXTRA_LFLAGS)
 


### PR DESCRIPTION
Fixed wrong `prefix` value in `/usr/lib/pkgconfig/libre.pc`.