### PR TITLE
http/client: fix possible null pointer dereference

### DIFF
--- a/src/http/client.c
+++ b/src/http/client.c
@@ -391,9 +391,14 @@ out:
 static int send_req_buf(struct conn *conn)
 {
 	int err;
-	struct http_req *req = conn->req;
+	struct http_req *req;
 
-	if (!conn || !req || !req->cli)
+	if (!conn)
+		return EINVAL;
+
+	req = conn->req;
+
+	if (!req || !req->cli)
 		return EINVAL;
 
 	if (!mbuf_get_left(req->mbreq))


### PR DESCRIPTION
Reported-by: Coverity Scan

New defect(s) Reported-by: Coverity Scan
Showing 1 of 1 defect(s)

```c
** CID 277673:  Null pointer dereferences  (REVERSE_INULL)
/src/http/client.c: 396 in send_req_buf()
________________________________________________________________________________________________________
*** CID 277673:  Null pointer dereferences  (REVERSE_INULL)
/src/http/client.c: 396 in send_req_buf()
390     
391     static int send_req_buf(struct conn *conn)
392     {
393     	int err;
394     	struct http_req *req = conn->req;
395     
>>>     CID 277673:  Null pointer dereferences  (REVERSE_INULL)
>>>     Null-checking "conn" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
396     	if (!conn || !req || !req->cli)
397     		return EINVAL;
398     
399     	if (!mbuf_get_left(req->mbreq))
400     		return 0;
401     
```