### PR TITLE
types,fmt: use re_restrict

### DIFF
--- a/include/re_fmt.h
+++ b/include/re_fmt.h
@@ -87,15 +87,15 @@ typedef int(re_printf_h)(struct re_printf *pf, void *arg);
 int re_vhprintf(const char *fmt, va_list ap, re_vprintf_h *vph, void *arg);
 int re_vfprintf(FILE *stream, const char *fmt, va_list ap);
 int re_vprintf(const char *fmt, va_list ap);
-int re_vsnprintf(char *restrict str, size_t size, const char *restrict fmt,
-		 va_list ap);
+int re_vsnprintf(char *re_restrict str, size_t size,
+		 const char *re_restrict fmt, va_list ap);
 int re_vsdprintf(char **strp, const char *fmt, va_list ap);
 
 int re_hprintf(struct re_printf *pf, const char *fmt, ...);
 int re_fprintf(FILE *stream, const char *fmt, ...);
 int re_printf(const char *fmt, ...);
-int re_snprintf(char *restrict str, size_t size, const char *restrict fmt,
-		...);
+int re_snprintf(char *re_restrict str, size_t size,
+		const char *re_restrict fmt, ...);
 int re_sdprintf(char **strp, const char *fmt, ...);
 
 

--- a/include/re_types.h
+++ b/include/re_types.h
@@ -252,3 +252,9 @@ typedef SSIZE_T ssize_t;
 #define likely(x) x
 #define unlikely(x) x
 #endif
+
+#ifdef WIN32
+#define re_restrict __restrict
+#else
+#define re_restrict restrict
+#endif

--- a/src/fmt/print.c
+++ b/src/fmt/print.c
@@ -622,8 +622,8 @@ int re_vprintf(const char *fmt, va_list ap)
  *
  * @return The number of characters printed, or -1 if error
  */
-int re_vsnprintf(char *restrict str, size_t size, const char *restrict fmt,
-		 va_list ap)
+int re_vsnprintf(char *re_restrict str, size_t size,
+		 const char *re_restrict fmt, va_list ap)
 {
 	struct pl pl;
 	int err;
@@ -757,7 +757,8 @@ int re_printf(const char *fmt, ...)
  *
  * @return The number of characters printed, or -1 if error
  */
-int re_snprintf(char *restrict str, size_t size, const char *restrict fmt, ...)
+int re_snprintf(char *re_restrict str, size_t size,
+		const char *re_restrict fmt, ...)
 {
 	va_list ap;
 	int n;


### PR DESCRIPTION
Adds `__restrict` macro for WIN32

Fixes #512 