### PR TITLE
UPDATE bugfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,6 +416,7 @@ if(USE_SIP)
     src/sipsess/reply.c
     src/sipsess/request.c
     src/sipsess/sess.c
+    src/sipsess/update.c
   )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ legend:
 * [RFC 2915](https://tools.ietf.org/html/rfc2915) - The Naming Authority Pointer (NAPTR) DNS Resource Record
 * [RFC 3261](https://tools.ietf.org/html/rfc3261) - SIP: Session Initiation Protocol
 * [RFC 3262](https://tools.ietf.org/html/rfc3262) - SIP Reliability of Provisional Responses
-* [RFC 3311](https://tools.ietf.org/html/rfc3311) - The SIP UPDATE Method
 * [RFC 3263](https://tools.ietf.org/html/rfc3263) - Locating SIP Servers
 * [RFC 3264](https://tools.ietf.org/html/rfc3264) - An Offer/Answer Model with SDP
 * [RFC 3265](https://tools.ietf.org/html/rfc3265) - SIP-Specific Event Notification
+* [RFC 3311](https://tools.ietf.org/html/rfc3311) - The SIP UPDATE Method
 * [RFC 3327](https://tools.ietf.org/html/rfc3327) - SIP Extension Header Field for Registering Non-Adjacent Contacts
 * [RFC 3428](https://tools.ietf.org/html/rfc3428) - SIP Extension for Instant Messaging
 * [RFC 3489](https://tools.ietf.org/html/rfc3489) - STUN - Simple Traversal of UDP Through NATs

--- a/src/sipsess/mod.mk
+++ b/src/sipsess/mod.mk
@@ -15,3 +15,4 @@ SRCS	+= sipsess/modify.c
 SRCS	+= sipsess/prack.c
 SRCS	+= sipsess/reply.c
 SRCS	+= sipsess/request.c
+SRCS	+= sipsess/update.c

--- a/src/sipsess/modify.c
+++ b/src/sipsess/modify.c
@@ -26,18 +26,15 @@ static void tmr_handler(void *arg)
 }
 
 
-static void target_refresh_resp_handler(int err, const struct sip_msg *msg,
+static void reinvite_resp_handler(int err, const struct sip_msg *msg,
 				  void *arg)
 {
 	struct sipsess *sess = arg;
 	const struct sip_hdr *hdr;
-	bool is_invite = true;
 	struct mbuf *desc = NULL;
 
 	if (!msg || err || sip_request_loops(&sess->ls, msg->scode))
 		goto out;
-
-	is_invite = !pl_strcmp(&msg->cseq.met, "INVITE");
 
 	if (msg->scode < 200) {
 		return;
@@ -46,16 +43,16 @@ static void target_refresh_resp_handler(int err, const struct sip_msg *msg,
 
 		(void)sip_dialog_update(sess->dlg, msg);
 
-		if (sess->sent_offer)
+		if (sess->sent_offer) {
 			(void)sess->answerh(msg, sess->arg);
-		else if (is_invite) {
+		}
+		else {
 			sess->modify_pending = false;
 			(void)sess->offerh(&desc, msg, sess->arg);
 		}
 
-		if (is_invite)
-			(void)sipsess_ack(sess->sock, sess->dlg, msg->cseq.num,
-					  sess->auth, sess->ctype, desc);
+		(void)sipsess_ack(sess->sock, sess->dlg, msg->cseq.num,
+				  sess->auth, sess->ctype, desc);
 
 		mem_deref(desc);
 	}
@@ -73,8 +70,7 @@ static void target_refresh_resp_handler(int err, const struct sip_msg *msg,
 				break;
 			}
 
-			err = is_invite ? sipsess_reinvite(sess, false) :
-					  sipsess_update(sess, false);
+			err = sipsess_reinvite(sess, false);
 			if (err)
 				break;
 
@@ -106,10 +102,7 @@ static void target_refresh_resp_handler(int err, const struct sip_msg *msg,
 	else if (err == ETIMEDOUT)
 		sipsess_terminate(sess, err, NULL);
 	else if (sess->modify_pending)
-		if (is_invite)
-			(void)sipsess_reinvite(sess, true);
-		else
-			(void)sipsess_update(sess, true);
+		(void)sipsess_reinvite(sess, true);
 
 	else
 		sess->desc = mem_deref(sess->desc);
@@ -144,31 +137,7 @@ int sipsess_reinvite(struct sipsess *sess, bool reset_ls)
 
 	return sip_drequestf(&sess->req, sess->sip, true, "INVITE",
 			     sess->dlg, 0, sess->auth,
-			     send_handler, target_refresh_resp_handler, sess,
-			     "%s%s%s"
-			     "Content-Length: %zu\r\n"
-			     "\r\n"
-			     "%b",
-			     sess->desc ? "Content-Type: " : "",
-			     sess->desc ? sess->ctype : "",
-			     sess->desc ? "\r\n" : "",
-			     sess->desc ? mbuf_get_left(sess->desc) :(size_t)0,
-			     sess->desc ? mbuf_buf(sess->desc) : NULL,
-			     sess->desc ? mbuf_get_left(sess->desc):(size_t)0);
-}
-
-
-int sipsess_update(struct sipsess *sess, bool reset_ls)
-{
-	sess->sent_offer = sess->desc ? true : false;
-	sess->modify_pending = false;
-
-	if (reset_ls)
-		sip_loopstate_reset(&sess->ls);
-
-	return sip_drequestf(&sess->req, sess->sip, true, "UPDATE",
-			     sess->dlg, 0, sess->auth,
-			     send_handler, target_refresh_resp_handler, sess,
+			     send_handler, reinvite_resp_handler, sess,
 			     "%s%s%s"
 			     "Content-Length: %zu\r\n"
 			     "\r\n"
@@ -207,5 +176,5 @@ int sipsess_modify(struct sipsess *sess, struct mbuf *desc)
 	if (sess->established)
 		return sipsess_reinvite(sess, true);
 	else
-		return sipsess_update(sess, true);
+		return sipsess_update(sess, NULL, NULL);
 }

--- a/src/sipsess/modify.c
+++ b/src/sipsess/modify.c
@@ -167,14 +167,12 @@ int sipsess_modify(struct sipsess *sess, struct mbuf *desc)
 	mem_deref(sess->desc);
 	sess->desc = mem_ref(desc);
 
-	if (sess->tmr.th || sess->replyl.head ||
-	    (sess->req && sess->established)) {
+	if (!sess->established)
+		return sipsess_update(sess);
+
+	if (sess->req || sess->tmr.th || sess->replyl.head) {
 		sess->modify_pending = true;
 		return 0;
 	}
-
-	if (sess->established)
-		return sipsess_reinvite(sess, true);
-	else
-		return sipsess_update(sess, NULL, NULL);
+	return sipsess_reinvite(sess, true);
 }

--- a/src/sipsess/request.c
+++ b/src/sipsess/request.c
@@ -22,6 +22,7 @@ static void destructor(void *arg)
 {
 	struct sipsess_request *req = arg;
 
+	tmr_cancel(&req->tmr);
 	list_unlink(&req->le);
 	mem_deref(req->ctype);
 	mem_deref(req->body);
@@ -68,6 +69,7 @@ int sipsess_request_alloc(struct sipsess_request **reqp, struct sipsess *sess,
 	req->body  = mem_ref(body);
 	req->resph = resph ? resph : internal_resp_handler;
 	req->arg   = arg;
+	tmr_init(&req->tmr);
 
  out:
 	if (err)

--- a/src/sipsess/sipsess.h
+++ b/src/sipsess/sipsess.h
@@ -65,6 +65,7 @@ struct sipsess_request {
 	char *ctype;
 	struct mbuf *body;
 	sip_resp_h *resph;
+	struct tmr tmr;
 	void *arg;
 };
 
@@ -95,7 +96,7 @@ int  sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 int  sipsess_reply_ack(struct sipsess *sess, const struct sip_msg *msg,
 		       bool *awaiting_answer);
 int  sipsess_reinvite(struct sipsess *sess, bool reset_ls);
-int  sipsess_update(struct sipsess *sess, bool reset_ls);
+int  sipsess_update(struct sipsess *sess, sip_resp_h resph, void *arg);
 int  sipsess_bye(struct sipsess *sess, bool reset_ls);
 int  sipsess_request_alloc(struct sipsess_request **reqp, struct sipsess *sess,
 			   const char *ctype, struct mbuf *body,

--- a/src/sipsess/sipsess.h
+++ b/src/sipsess/sipsess.h
@@ -96,7 +96,7 @@ int  sipsess_reply_1xx(struct sipsess *sess, const struct sip_msg *msg,
 int  sipsess_reply_ack(struct sipsess *sess, const struct sip_msg *msg,
 		       bool *awaiting_answer);
 int  sipsess_reinvite(struct sipsess *sess, bool reset_ls);
-int  sipsess_update(struct sipsess *sess, sip_resp_h resph, void *arg);
+int  sipsess_update(struct sipsess *sess);
 int  sipsess_bye(struct sipsess *sess, bool reset_ls);
 int  sipsess_request_alloc(struct sipsess_request **reqp, struct sipsess *sess,
 			   const char *ctype, struct mbuf *body,

--- a/src/sipsess/update.c
+++ b/src/sipsess/update.c
@@ -1,0 +1,155 @@
+/**
+ * @file update.c  SIP Session UPDATE (RFC 3311)
+ *
+ * Copyright (C) 2022 commend.com - m.fridrich@commend.com
+ */
+#include <re_types.h>
+#include <re_mem.h>
+#include <re_mbuf.h>
+#include <re_sa.h>
+#include <re_list.h>
+#include <re_hash.h>
+#include <re_fmt.h>
+#include <re_uri.h>
+#include <re_tmr.h>
+#include <re_msg.h>
+#include <re_sip.h>
+#include <re_sipsess.h>
+#include "sipsess.h"
+
+
+static int update_request(struct sipsess_request *req);
+
+
+static void tmr_handler(void *arg)
+{
+	struct sipsess_request *req = arg;
+	int err;
+
+	err = update_request(req);
+	if (err)
+		mem_deref(req);
+}
+
+
+static void update_resp_handler(int err, const struct sip_msg *msg, void *arg)
+{
+	struct sipsess_request *req = arg;
+	const struct sip_hdr *hdr;
+
+	if (!msg || err || sip_request_loops(&req->ls, msg->scode))
+		goto out;
+
+	if (msg->scode < 200) {
+		return;
+	}
+	else if (msg->scode < 300) {
+		(void)sip_dialog_update(req->sess->dlg, msg);
+
+		if (req->sess->sent_offer)
+			(void)req->sess->answerh(msg, req->sess->arg);
+	}
+	else {
+		if (req->sess->terminated)
+			goto out;
+
+		switch (msg->scode) {
+
+		case 401:
+		case 407:
+			err = sip_auth_authenticate(req->sess->auth, msg);
+			if (err) {
+				err = (err == EAUTH) ? 0 : err;
+				break;
+			}
+
+			err = update_request(req);
+			if (err)
+				break;
+
+			return;
+
+		case 408:
+		case 481:
+			sipsess_terminate(req->sess, 0, msg);
+			break;
+		case 491:
+			tmr_start(&req->tmr, req->sess->owner ? 3000 : 1000,
+				  tmr_handler, req);
+			return;
+		case 500:
+			hdr = sip_msg_hdr(msg, SIP_HDR_RETRY_AFTER);
+			if (!hdr)
+				break;
+
+			tmr_start(&req->tmr, pl_u32(&hdr->val) * 1000,
+				  tmr_handler, req);
+			return;
+
+		}
+	}
+
+out:
+	if (!req->sess->terminated) {
+		if (err == ETIMEDOUT)
+			sipsess_terminate(req->sess, err, NULL);
+		else
+			req->resph(err, msg, req->arg);
+	}
+
+	mem_deref(req);
+}
+
+
+static int update_request(struct sipsess_request *req)
+{
+	if (!req || req->tmr.th)
+		return -1;
+
+	return sip_drequestf(&req->req, req->sess->sip, true, "UPDATE",
+			    req->sess->dlg, 0, req->sess->auth, NULL,
+			    update_resp_handler, req,
+			    "%s%s%s"
+			    "Content-Length: %zu\r\n"
+			    "\r\n"
+			    "%b",
+			    req->body ? "Content-Type: " : "",
+			    req->body ? req->ctype : "",
+			    req->body ? "\r\n" : "",
+			    req->body ? mbuf_get_left(req->body) :(size_t)0,
+			    req->body ? mbuf_buf(req->body) : NULL,
+			    req->body ? mbuf_get_left(req->body):(size_t)0);
+}
+
+
+/**
+ * Send UPDATE request (RFC 3311)
+ *
+ * @param sess      SIP Session
+ * @param resph     Response handler
+ * @param arg       Handler argument
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int sipsess_update(struct sipsess *sess, sip_resp_h resph, void *arg)
+{
+	struct sipsess_request *req;
+	int err;
+
+	if (!sess || sess->terminated || !sess->ctype || !sess->desc)
+		return EINVAL;
+
+	sess->sent_offer = sess->desc ? true : false;
+	sess->modify_pending = false;
+
+	err = sipsess_request_alloc(&req, sess, sess->ctype, sess->desc, resph,
+				    arg);
+	if (err)
+		return err;
+
+	err = update_request(req);
+	if (err)
+		mem_deref(req);
+
+	return err;
+}

--- a/src/sipsess/update.c
+++ b/src/sipsess/update.c
@@ -126,12 +126,10 @@ static int update_request(struct sipsess_request *req)
  * Send UPDATE request (RFC 3311)
  *
  * @param sess      SIP Session
- * @param resph     Response handler
- * @param arg       Handler argument
  *
  * @return 0 if success, otherwise errorcode
  */
-int sipsess_update(struct sipsess *sess, sip_resp_h resph, void *arg)
+int sipsess_update(struct sipsess *sess)
 {
 	struct sipsess_request *req;
 	int err;
@@ -142,8 +140,8 @@ int sipsess_update(struct sipsess *sess, sip_resp_h resph, void *arg)
 	sess->sent_offer = sess->desc ? true : false;
 	sess->modify_pending = false;
 
-	err = sipsess_request_alloc(&req, sess, sess->ctype, sess->desc, resph,
-				    arg);
+	err = sipsess_request_alloc(&req, sess, sess->ctype, sess->desc, NULL,
+				    NULL);
 	if (err)
 		return err;
 


### PR DESCRIPTION
In `modify.c:sipsess_update()` `sess->req` (containing the original INVITE request) was overwritten with the UPDATE request which could lead to a multitude of problems.

Now, an UPDATE is sent by allocating a `sipsess_request` and sending it is handled separately from re-INVITEs.