### PR TITLE
dns, http: add dnsc_getaddrinfo_enabled. prevent reset of getaddrinfo enabled

### DIFF
--- a/include/re_dns.h
+++ b/include/re_dns.h
@@ -222,6 +222,7 @@ int  dnsc_notify(struct dns_query **qp, struct dnsc *dnsc, const char *name,
 void dnsc_cache_flush(struct dnsc *dnsc);
 void dnsc_cache_max(struct dnsc *dnsc, uint32_t max);
 void dnsc_getaddrinfo(struct dnsc *dnsc, bool active);
+bool dnsc_getaddrinfo_enabled(struct dnsc *dnsc);
 
 
 /* DNS System functions */

--- a/src/dns/client.c
+++ b/src/dns/client.c
@@ -1319,3 +1319,19 @@ void dnsc_getaddrinfo(struct dnsc *dnsc, bool active)
 
 	dnsc->conf.getaddrinfo = active;
 }
+
+
+/**
+ * Return if getaddrinfo usage is enabled
+ *
+ * @param dnsc  DNS Client
+ *
+ * @return true if getaddrinfo is used, false otherwise
+ */
+bool dnsc_getaddrinfo_enabled(struct dnsc *dnsc)
+{
+	if (!dnsc)
+		return false;
+
+	return dnsc->conf.getaddrinfo;
+}

--- a/src/http/client.c
+++ b/src/http/client.c
@@ -981,7 +981,7 @@ int http_client_set_config(struct http_cli *cli, struct http_conf *conf)
 		.conn_timeout	 = conf->conn_timeout,
 		.idle_timeout	 = conf->idle_timeout,
 		.cache_ttl_max	 = 1800,
-		.getaddrinfo	 = false,
+		.getaddrinfo	 = dnsc_getaddrinfo_enabled(cli->dnsc)
 	};
 
 	return dnsc_conf_set(cli->dnsc, &dconf);


### PR DESCRIPTION
add api dnsc_getaddrinfo_enabled.
Use dnsc_getaddrinfo_enabled to prevent reset of getaddrinfo enabled during http_client_set_config