### PR TITLE
conf: check if returned size is larger than buffer

### DIFF
--- a/src/conf/conf.c
+++ b/src/conf/conf.c
@@ -53,6 +53,11 @@ static int load_file(struct mbuf *mb, const char *filename)
 		else if (n == 0)
 			break;
 
+		if ((size_t)n > sizeof(buf)) {
+			err = EBADMSG;
+			break;
+		}
+
 		err |= mbuf_write_mem(mb, buf, n);
 	}
 


### PR DESCRIPTION
it looks like Coverity scan is complaining that we are not checking the number of bytes returned.


```
   	6. tainted_data_transitive: Call to function mbuf_write_mem with tainted argument buf transitively taints *mb->buf. [[show details](https://scan8.scan.coverity.com/eventId=12365060-8&modelId=12365060-0&fileInstanceId=62023522&filePath=%2Fsrc%2Fmbuf%2Fmbuf.c&fileStart=207&fileEnd=232)]
   	
CID 93696 (#1 of 1): Untrusted value as argument (TAINTED_SCALAR)
11. tainted_data: Passing tainted expression *mb->buf to mbuf_write_mem, which uses it as an offset. [[show details](https://scan8.scan.coverity.com/eventId=12365060-26&modelId=12365060-1&fileInstanceId=62023522&filePath=%2Fsrc%2Fmbuf%2Fmbuf.c&fileStart=207&fileEnd=232)]
   	Ensure that tainted values are properly sanitized, by checking that their values are within a permissible range.
 56                err |= mbuf_write_mem(mb, buf, n);
   	7. Jumping back to the beginning of the loop.
 57        }
 58
```

