### PR TITLE
send DTMF via hidden call

### DIFF
--- a/include/re_telev.h
+++ b/include/re_telev.h
@@ -18,6 +18,7 @@ int telev_set_srate(struct telev *tel, uint32_t srate);
 int telev_send(struct telev *tel, int event, bool end);
 int telev_recv(struct telev *tel, struct mbuf *mb, int *event, bool *end);
 int telev_poll(struct telev *tel, bool *marker, struct mbuf *mb);
+bool telev_is_empty(struct telev *tel);
 
 int telev_digit2code(int digit);
 int telev_code2digit(int code);

--- a/include/re_telev.h
+++ b/include/re_telev.h
@@ -18,7 +18,7 @@ int telev_set_srate(struct telev *tel, uint32_t srate);
 int telev_send(struct telev *tel, int event, bool end);
 int telev_recv(struct telev *tel, struct mbuf *mb, int *event, bool *end);
 int telev_poll(struct telev *tel, bool *marker, struct mbuf *mb);
-bool telev_is_empty(struct telev *tel);
+bool telev_is_empty(const struct telev *tel);
 
 int telev_digit2code(int digit);
 int telev_code2digit(int code);

--- a/src/telev/telev.c
+++ b/src/telev/telev.c
@@ -341,6 +341,12 @@ int telev_poll(struct telev *tel, bool *marker, struct mbuf *mb)
 }
 
 
+bool telev_is_empty(struct telev *tel)
+{
+	return tel->state == IDLE && !mbuf_get_left(tel->mb);
+}
+
+
 /**
  * Convert DTMF digit to Event code
  *

--- a/src/telev/telev.c
+++ b/src/telev/telev.c
@@ -341,8 +341,11 @@ int telev_poll(struct telev *tel, bool *marker, struct mbuf *mb)
 }
 
 
-bool telev_is_empty(struct telev *tel)
+bool telev_is_empty(const struct telev *tel)
 {
+	if (!tel)
+		return true;
+
 	return tel->state == IDLE && !mbuf_get_left(tel->mb);
 }
 


### PR DESCRIPTION
Adds a function `telev_is_empty()` to query if DTMF characters have been sent out completely.