### PR TITLE
SDP support for <proto> udp

### DIFF
--- a/include/re_fmt.h
+++ b/include/re_fmt.h
@@ -114,6 +114,8 @@ void str_ncpy(char *dst, const char *src, size_t n);
 int  str_dup(char **dst, const char *src);
 int  str_x64dup(char **dst, uint64_t val);
 int  str_cmp(const char *s1, const char *s2);
+int  str_ncmp(const char *s1, const char *s2, size_t n);
+const char *str_str(const char *s1, const char *s2);
 int  str_casecmp(const char *s1, const char *s2);
 size_t str_len(const char *s);
 const char *str_error(int errnum, char *buf, size_t sz);

--- a/src/fmt/str.c
+++ b/src/fmt/str.c
@@ -130,6 +130,43 @@ int str_cmp(const char *s1, const char *s2)
 
 
 /**
+ * Compare two 0-terminated strings up to n positions
+ *
+ * @param s1 First string
+ * @param s2 Second string
+ *
+ * @return an integer less than, equal to, or greater than zero if s1 is found
+ *         respectively, to be less than, to match, or be greater than s2 in
+ *         the first n positions
+ */
+int str_ncmp(const char *s1, const char *s2, size_t n)
+{
+	if (!s1 || !s2)
+		return 1;
+
+	return strncmp(s1, s2, n);
+}
+
+
+/**
+ * Check if one 0-terminated string contains another
+ *
+ * @param s1 First string
+ * @param s2 Second string
+ *
+ * @return a position in s1 where it contains s2 as a substring, or NULL
+ *         if s2 does not occur inside s1
+ */
+const char *str_str(const char *s1, const char *s2)
+{
+	if (!s1 || !s2)
+		return NULL;
+
+	return strstr(s1, s2);
+}
+
+
+/**
  * Compare two 0-terminated strings, ignoring case
  *
  * @param s1 First string

--- a/src/sdp/msg.c
+++ b/src/sdp/msg.c
@@ -430,13 +430,18 @@ static int media_encode(const struct sdp_media *m, struct mbuf *mb, bool offer)
 		if (!fmt->sup && !offer)
 			continue;
 
-		err |= mbuf_printf(mb, "a=rtpmap:%s %s/%u",
-				   fmt->id, fmt->name, fmt->srate);
+		if ((str_ncmp(m->proto, "RTP/", 4) == 0) ||
+				(str_str(m->proto, "/RTP/") != NULL)) {
 
-		if (fmt->ch > 1)
-			err |= mbuf_printf(mb, "/%u", fmt->ch);
+			err |= mbuf_printf(mb, "a=rtpmap:%s %s/%u",
+					   fmt->id, fmt->name, fmt->srate);
 
-		err |= mbuf_printf(mb, "\r\n");
+			if (fmt->ch > 1)
+				err |= mbuf_printf(mb, "/%u", fmt->ch);
+
+			err |= mbuf_printf(mb, "\r\n");
+
+		}
 
 		if (str_isset(fmt->params))
 			err |= mbuf_printf(mb, "a=fmtp:%s %s\r\n",


### PR DESCRIPTION
- As per RFC 8866, without rtpmap and possibly with fmtp
- This example shows [unregistered] media type application/vnd.wireguard
- Wireshark does not like the fmtp: line -- that would be a bug there
```
v=0
o=- 3280287138 1947228850 IN IP6 2001:db8:12::34
s=-
c=IN IP6 2001:db8:12::34
t=0 0
m=application 9638 udp vnd.wireguard
a=fmtp:vnd.wireguard pubkey=z7otO6+NKCOM/I7gq6mvcVqYyX3u27Z0WVKMY/juel8=
a=sendrecv
```