### PR TITLE
pcp: fix cppcheck warning

### DIFF
--- a/src/pcp/request.c
+++ b/src/pcp/request.c
@@ -112,7 +112,7 @@ static void completed(struct pcp_request *req, int err, struct pcp_msg *msg)
 
 	/* if the request failed, we only called the
 	   response handler once and never again */
-	if (err || msg->hdr.result != PCP_SUCCESS ) {
+	if (err || !msg || msg->hdr.result != PCP_SUCCESS ) {
 		req->resph = NULL;
 	}
 


### PR DESCRIPTION
cppcheck --version
Cppcheck 2.3


```
src/pcp/request.c:115:13: warning: Possible null pointer dereference: msg [nullPointer]
 if (err || msg->hdr.result != PCP_SUCCESS ) {
            ^
src/pcp/request.c:141:29: note: Calling function 'completed', 3rd argument 'NULL' value is 0
  completed(req, ETIMEDOUT, NULL);
                            ^
src/pcp/request.c:115:13: note: Null pointer dereference
 if (err || msg->hdr.result != PCP_SUCCESS ) {
            ^
```
