### PR TITLE
fmt/print: fix cppcheck overflow

### DIFF
--- a/src/fmt/print.c
+++ b/src/fmt/print.c
@@ -74,11 +74,11 @@ static int write_padded(const char *p, size_t sz, size_t pad, char pch,
 
 static uint32_t local_itoa(char *buf, uint64_t n, uint8_t base, bool uc)
 {
-	char c, *p = buf + NUM_SIZE;
+	char c, *p = buf + (NUM_SIZE - 1);
 	uint32_t len = 1;
 	const char a = uc ? 'A' : 'a';
 
-	*--p = '\0';
+	*p-- = '\0';
 	do {
 		const uint64_t dv  = n / base;
 		const uint64_t mul = dv * base;


### PR DESCRIPTION
```
src/fmt/print.c:77:15: error: Pointer arithmetic overflow; 'buf' buffer size is 64 [ctuPointerArith]
 char c, *p = buf + NUM_SIZE - 1;
              ^
src/fmt/print.c:272:20: note: Calling function local_itoa, 1st argument is uninitialized
   len = local_itoa(num, (sn < 0) ? -sn : sn, base,
                   ^
src/fmt/print.c:77:15: note: Using argument buf
 char c, *p = buf + NUM_SIZE - 1;
```