### PR TITLE
sipreg: avoid sending un-REGISTER periodically

### DIFF
--- a/src/sipreg/reg.c
+++ b/src/sipreg/reg.c
@@ -254,6 +254,8 @@ static void response_handler(int err, const struct sip_msg *msg, void *arg)
 		if (reg->fbregint)
 			tmr_start(&reg->tmr, reg->fbregint * 1000,
 					  tmr_handler, reg);
+		else
+			tmr_cancel(&reg->tmr);
 
 		reg->resph(err, msg, reg->arg);
 


### PR DESCRIPTION
A periodic un-REGISTER should be done only if `fbregint` (fallback SIP server
registration interval) was set.
