### PR TITLE
udp: remove udp_send_anon()

### DIFF
--- a/include/re_udp.h
+++ b/include/re_udp.h
@@ -25,7 +25,6 @@ int  udp_listen(struct udp_sock **usp, const struct sa *local,
 int  udp_connect(struct udp_sock *us, const struct sa *peer);
 int  udp_open(struct udp_sock **usp, int af);
 int  udp_send(struct udp_sock *us, const struct sa *dst, struct mbuf *mb);
-int  udp_send_anon(const struct sa *dst, struct mbuf *mb);
 int  udp_local_get(const struct udp_sock *us, struct sa *local);
 int  udp_setsockopt(struct udp_sock *us, int level, int optname,
 		    const void *optval, uint32_t optlen);

--- a/src/udp/udp.c
+++ b/src/udp/udp.c
@@ -514,33 +514,6 @@ int udp_send(struct udp_sock *us, const struct sa *dst, struct mbuf *mb)
 
 
 /**
- * Send an anonymous UDP Datagram to a peer
- *
- * @param dst Destination network address
- * @param mb  Buffer to send
- *
- * @return 0 if success, otherwise errorcode
- */
-int udp_send_anon(const struct sa *dst, struct mbuf *mb)
-{
-	struct udp_sock *us;
-	int err;
-
-	if (!dst || !mb)
-		return EINVAL;
-
-	err = udp_listen(&us, NULL, NULL, NULL);
-	if (err)
-		return err;
-
-	err = udp_send_internal(us, dst, mb, NULL);
-	mem_deref(us);
-
-	return err;
-}
-
-
-/**
  * Get the local network address on the UDP Socket
  *
  * @param us    UDP Socket


### PR DESCRIPTION
Proposal to remove this function in order to keep the API small and simple.

The function is not used by baresip or retest.

