### PR TITLE
dnsc get conf and skip hash alloc without hash size changes

### DIFF
--- a/include/re_dns.h
+++ b/include/re_dns.h
@@ -207,6 +207,7 @@ struct dnsc_conf {
 int  dnsc_alloc(struct dnsc **dcpp, const struct dnsc_conf *conf,
 		const struct sa *srvv, uint32_t srvc);
 int  dnsc_conf_set(struct dnsc *dnsc, const struct dnsc_conf *conf);
+void dnsc_conf_set_timeout(struct dnsc *dnsc, uint32_t connect, uint32_t idle);
 int  dnsc_srv_set(struct dnsc *dnsc, const struct sa *srvv, uint32_t srvc);
 int  dnsc_query(struct dns_query **qp, struct dnsc *dnsc, const char *name,
 		uint16_t type, uint16_t dnsclass,

--- a/src/dns/client.c
+++ b/src/dns/client.c
@@ -1215,6 +1215,16 @@ int dnsc_alloc(struct dnsc **dcpp, const struct dnsc_conf *conf,
 }
 
 
+void  dnsc_conf_set_timeout(struct dnsc *dnsc, uint32_t connect, uint32_t idle)
+{
+	if (!dnsc)
+		return;
+
+	dnsc->conf.conn_timeout = connect;
+	dnsc->conf.idle_timeout = idle;
+}
+
+
 int dnsc_conf_set(struct dnsc *dnsc, const struct dnsc_conf *conf)
 {
 	int err;

--- a/src/http/client.c
+++ b/src/http/client.c
@@ -974,17 +974,9 @@ int http_client_set_config(struct http_cli *cli, struct http_conf *conf)
 		return EINVAL;
 
 	cli->conf = *conf;
-
-	struct dnsc_conf dconf = {
-		.query_hash_size = QUERY_HASH_SIZE,
-		.tcp_hash_size	 = TCP_HASH_SIZE,
-		.conn_timeout	 = conf->conn_timeout,
-		.idle_timeout	 = conf->idle_timeout,
-		.cache_ttl_max	 = 1800,
-		.getaddrinfo	 = dnsc_getaddrinfo_enabled(cli->dnsc)
-	};
-
-	return dnsc_conf_set(cli->dnsc, &dconf);
+	dnsc_conf_set_timeout(cli->dnsc, conf->conn_timeout,
+						  conf->idle_timeout);
+	return 0;
 }
 
 


### PR DESCRIPTION
Set dns timeout separately to skip hash table realloc.
http client set config should changes only idle connect timeouts also in dnsc