### PR TITLE
sipreg fix contact handler `expires` evaluation

### DIFF
--- a/src/sipreg/reg.c
+++ b/src/sipreg/reg.c
@@ -164,7 +164,7 @@ static bool contact_handler(const struct sip_hdr *hdr,
 	if (err)
 		return false;
 
-	if (!sa_cmp(&host, &reg->laddr, SA_ALL))
+	if (!sa_cmp(&host, &reg->laddr, SA_ADDR))
 		return false;
 
 	err = uri_param_get(&c.auri, &transp, &pval);

--- a/src/sipreg/reg.c
+++ b/src/sipreg/reg.c
@@ -148,17 +148,31 @@ static bool contact_handler(const struct sip_hdr *hdr,
 {
 	struct sipreg *reg = arg;
 	struct sip_addr c;
+	struct pl transp = PL("transport");
 	struct pl pval;
-	char uri[256];
+	struct sa host;
+	enum sip_transp tp;
+	int err;
 
 	if (sip_addr_decode(&c, &hdr->val))
 		return false;
 
-	if (re_snprintf(uri, sizeof(uri), "sip:%s@%J%s", reg->cuser,
-			&reg->laddr, sip_transp_param(reg->tp)) < 0)
+	if (pl_strcmp(&c.uri.user, reg->cuser))
+	    return false;
+
+	err = sa_set(&host, &c.uri.host, c.uri.port);
+	if (err)
 		return false;
 
-	if (pl_strcmp(&c.auri, uri))
+	if (!sa_cmp(&host, &reg->laddr, SA_ALL))
+		return false;
+
+	err = uri_param_get(&c.auri, &transp, &pval);
+	if (err)
+		pl_set_str(&pval, "udp");
+
+	tp = sip_transp_decode(&pval);
+	if (tp != reg->tp)
 		return false;
 
 	if (!msg_param_decode(&c.params, "expires", &pval)) {


### PR DESCRIPTION
- sipreg: case-insensitive comparison of ;transport=tls
- sipreg: do not compare port numbers of Contact header

These two commits solve the problem that in some situations the `;expires=` parameter in the Contact header in the response to the REGISTER is not evaluated.

There are two more problems/questions which are related to this:
- Currently there is no error handling for the case where the `contact_handler` returns `false`. Then the expires is not evaluated, without any warning. Should there be any error handling?
- What if the SIP registrar rewrites the port number in the Contact handler. Should `re`, `baresip` update it's Contact handler for following SIP requests?