### PR TITLE
sip: sip_conncfg_set pass by reference

### DIFF
--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -433,7 +433,7 @@ int sip_keepalive_start(struct sip_keepalive **kap, struct sip *sip,
 
 /* sip_conncfg */
 int sip_conncfg_set(struct sip *sip, const struct sa *paddr,
-		    const struct sip_conncfg conncfg);
+		    const struct sip_conncfg *conncfg);
 
 
 /* sip_uas_auth */

--- a/src/sip/transp.c
+++ b/src/sip/transp.c
@@ -1873,7 +1873,7 @@ void sip_transp_rmladdr(struct sip *sip, const struct sa *laddr)
  * @return 0 if success, otherwise errorcode
  */
 int sip_conncfg_set(struct sip *sip, const struct sa *paddr,
-		    const struct sip_conncfg conncfg)
+		    const struct sip_conncfg *conncfg)
 {
 	struct sip_conncfg *cfg;
 
@@ -1882,7 +1882,7 @@ int sip_conncfg_set(struct sip *sip, const struct sa *paddr,
 
 	cfg = sip_conncfg_find(sip, paddr);
 	if (cfg) {
-		cfg->srcport = conncfg.srcport;
+		cfg->srcport = conncfg->srcport;
 		return 0;
 	}
 	else {
@@ -1892,9 +1892,10 @@ int sip_conncfg_set(struct sip *sip, const struct sa *paddr,
 	if (!cfg)
 		return ENOMEM;
 
-	memcpy(cfg, &conncfg, sizeof(*cfg));
+	memcpy(cfg, conncfg, sizeof(*cfg));
 	memset(&cfg->he, 0, sizeof(cfg->he));
 	sa_cpy(&cfg->paddr, paddr);
 	hash_append(sip->ht_conncfg, sa_hash(paddr, SA_ALL), &cfg->he, cfg);
+
 	return 0;
 }

--- a/src/sipreg/reg.c
+++ b/src/sipreg/reg.c
@@ -300,7 +300,7 @@ static int send_handler(enum sip_transp tp, struct sa *src,
 		struct sip_conncfg cfg;
 		memset(&cfg, 0, sizeof(cfg));
 		cfg.srcport = reg->srcport;
-		err = sip_conncfg_set(reg->sip, dst, cfg);
+		err = sip_conncfg_set(reg->sip, dst, &cfg);
 	}
 
 	return err;


### PR DESCRIPTION
the parameter `struct sip_conncfg` is passed by value, which means the whole struct has to be
copied to the call-stack.

it is more efficient to pass by reference, i.e. use a pointer
