### PR TITLE
list: fix list_flush head and tail

### DIFF
--- a/src/list/list.c
+++ b/src/list/list.c
@@ -44,8 +44,8 @@ void list_flush(struct list *list)
 	while (le) {
 		struct le *next = le->next;
 		void *data = le->data;
-		le->list = NULL;
-		le->prev = le->next = NULL;
+
+		list_unlink(le);
 		le->data = NULL;
 		le = next;
 		mem_deref(data);


### PR DESCRIPTION
Fixes a segfault when iterating the list within data destructor, since head and tail are not updated.

See: https://github.com/baresip/retest/pull/151