### PR TITLE
ice: local candidate policy config

### DIFF
--- a/include/re_ice.h
+++ b/include/re_ice.h
@@ -48,6 +48,12 @@ enum ice_candpair_state {
 	ICE_CANDPAIR_FAILED      /**< Failed state; check failed             */
 };
 
+/** ICE local candidate policy */
+enum ice_policy {
+	ICE_POLICY_ALL,	  /**< Allow all local candidates */
+	ICE_POLICY_RELAY, /**< Use only RELAY candidates  */
+};
+
 struct ice;
 struct ice_cand;
 struct icem;
@@ -57,6 +63,7 @@ struct turnc;
 struct ice_conf {
 	uint32_t rto;             /**< STUN Retransmission TimeOut */
 	uint32_t rc;              /**< STUN Retransmission Count   */
+	enum ice_policy policy;   /**< ICE Local Candidate Policy  */
 	bool debug;               /**< Enable ICE debugging        */
 };
 

--- a/include/re_ice.h
+++ b/include/re_ice.h
@@ -12,6 +12,12 @@ enum ice_role {
 	ICE_ROLE_CONTROLLED
 };
 
+/** ICE Transport **/
+enum ice_transp {
+	ICE_TRANSP_NONE = -1,
+	ICE_TRANSP_UDP  = IPPROTO_UDP
+};
+
 /** ICE Component ID */
 enum ice_compid {
 	ICE_COMPID_RTP  = 1,

--- a/include/re_ice.h
+++ b/include/re_ice.h
@@ -67,8 +67,6 @@ void icem_set_conf(struct icem *icem, const struct ice_conf *conf);
 void icem_set_role(struct icem *icem, enum ice_role role);
 void icem_set_name(struct icem *icem, const char *name);
 int  icem_comp_add(struct icem *icem, unsigned compid, void *sock);
-int  icem_cand_add(struct icem *icem, unsigned compid, uint16_t lprio,
-		   const char *ifname, const struct sa *addr);
 
 bool icem_verify_support(struct icem *icem, unsigned compid,
 			 const struct sa *raddr);
@@ -103,6 +101,9 @@ int  ice_cand_encode(struct re_printf *pf, const struct ice_cand *cand);
 int  ice_remotecands_encode(struct re_printf *pf, const struct icem *icem);
 struct ice_cand *icem_cand_find(const struct list *lst, unsigned compid,
 				const struct sa *addr);
+int icem_lcand_add_base(struct icem *icem, enum ice_cand_type type,
+			unsigned compid, uint16_t lprio, const char *ifname,
+			enum ice_transp transp, const struct sa *addr);
 int icem_lcand_add(struct icem *icem, struct ice_cand *base,
 		   enum ice_cand_type type,
 		   const struct sa *addr);

--- a/src/ice/cand.c
+++ b/src/ice/cand.c
@@ -126,6 +126,9 @@ int icem_lcand_add(struct icem *icem, struct ice_cand *base,
 	if (!base)
 		return EINVAL;
 
+	if (type == ICE_CAND_TYPE_HOST || type == ICE_CAND_TYPE_RELAY)
+		return EINVAL;
+
 	err = cand_alloc(&cand, icem, type, base->compid,
 			 ice_cand_calc_prio(type, 0, base->compid),
 			 base->ifname, base->transp, addr);

--- a/src/ice/cand.c
+++ b/src/ice/cand.c
@@ -86,20 +86,23 @@ static int cand_alloc(struct ice_cand **candp, struct icem *icem,
 }
 
 
-int icem_lcand_add_base(struct icem *icem, unsigned compid, uint16_t lprio,
-			const char *ifname, enum ice_transp transp,
-			const struct sa *addr)
+int icem_lcand_add_base(struct icem *icem, enum ice_cand_type type,
+			unsigned compid, uint16_t lprio, const char *ifname,
+			enum ice_transp transp, const struct sa *addr)
 {
 	struct icem_comp *comp;
 	struct ice_cand *cand;
 	int err;
 
+	if (type != ICE_CAND_TYPE_HOST && type != ICE_CAND_TYPE_RELAY)
+		return EINVAL;
+
 	comp = icem_comp_find(icem, compid);
 	if (!comp)
 		return ENOENT;
 
-	err = cand_alloc(&cand, icem, ICE_CAND_TYPE_HOST, compid,
-			 ice_cand_calc_prio(ICE_CAND_TYPE_HOST, lprio, compid),
+	err = cand_alloc(&cand, icem, type, compid,
+			 ice_cand_calc_prio(type, lprio, compid),
 			 ifname, transp, addr);
 	if (err)
 		return err;

--- a/src/ice/cand.c
+++ b/src/ice/cand.c
@@ -94,6 +94,10 @@ int icem_lcand_add_base(struct icem *icem, enum ice_cand_type type,
 	struct ice_cand *cand;
 	int err;
 
+	if (icem->conf.policy == ICE_POLICY_RELAY &&
+	    type != ICE_CAND_TYPE_RELAY)
+		return 0;
+
 	if (type != ICE_CAND_TYPE_HOST && type != ICE_CAND_TYPE_RELAY)
 		return EINVAL;
 
@@ -110,7 +114,11 @@ int icem_lcand_add_base(struct icem *icem, enum ice_cand_type type,
 	/* the base is itself */
 	cand->base = cand;
 
-	sa_set_port(&cand->addr, comp->lport);
+	if (type == ICE_CAND_TYPE_RELAY)
+		sa_cpy(&cand->rel, addr);
+
+	if (type == ICE_CAND_TYPE_HOST)
+		sa_set_port(&cand->addr, comp->lport);
 
 	return 0;
 }
@@ -122,6 +130,9 @@ int icem_lcand_add(struct icem *icem, struct ice_cand *base,
 {
 	struct ice_cand *cand;
 	int err;
+
+	if (icem->conf.policy == ICE_POLICY_RELAY)
+		return 0;
 
 	if (!base)
 		return EINVAL;

--- a/src/ice/ice.h
+++ b/src/ice/ice.h
@@ -111,9 +111,6 @@ struct ice_candpair {
 
 
 /* cand */
-int icem_lcand_add_base(struct icem *icem, unsigned compid, uint16_t lprio,
-			const char *ifname, enum ice_transp transp,
-			const struct sa *addr);
 int icem_rcand_add(struct icem *icem, enum ice_cand_type type, unsigned compid,
 		   uint32_t prio, const struct sa *addr,
 		   const struct sa *rel_addr, const struct pl *foundation);

--- a/src/ice/ice.h
+++ b/src/ice/ice.h
@@ -17,10 +17,6 @@ enum ice_checkl_state {
 	ICE_CHECKLIST_FAILED
 };
 
-enum ice_transp {
-	ICE_TRANSP_NONE = -1,
-	ICE_TRANSP_UDP  = IPPROTO_UDP
-};
 
 /** ICE protocol values */
 enum {

--- a/src/ice/icem.c
+++ b/src/ice/icem.c
@@ -29,6 +29,7 @@
 static const struct ice_conf conf_default = {
 	ICE_DEFAULT_RTO_RTP,
 	ICE_DEFAULT_RC,
+	ICE_POLICY_ALL,
 	false
 };
 

--- a/src/ice/icem.c
+++ b/src/ice/icem.c
@@ -236,28 +236,6 @@ int icem_comp_add(struct icem *icem, unsigned compid, void *sock)
 }
 
 
-/**
- * Add a new candidate to the ICE Media object
- *
- * @param icem    ICE Media object
- * @param compid  Component ID
- * @param lprio   Local priority
- * @param ifname  Name of the network interface
- * @param addr    Local network address
- *
- * @return 0 if success, otherwise errorcode
- */
-int icem_cand_add(struct icem *icem, unsigned compid, uint16_t lprio,
-		  const char *ifname, const struct sa *addr)
-{
-	if (!icem_comp_find(icem, compid))
-		return ENOENT;
-
-	return icem_lcand_add_base(icem, compid, lprio, ifname,
-				   ICE_TRANSP_UDP, addr);
-}
-
-
 static void *unique_handler(struct le *le1, struct le *le2)
 {
 	struct ice_cand *c1 = le1->data, *c2 = le2->data;


### PR DESCRIPTION
RFC 5245 and 8445 defines:


> Base: The transport address that an ICE agent sends from for a particular candidate.  For host, server-reflexive, and peer- > reflexive candidates, the base is the same as the host candidate. For relayed candidates, the base is the same as the relayed candidate (i.e., the transport address used by the TURN server to send from). 


This allows also a RELAY only policy (without any other candidates), like defined with iceTransportPolicy (WebRTC).