### PR TITLE
TLS server support SNI based certificate selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,6 +471,7 @@ if(USE_OPENSSL)
     src/tls/openssl/tls_tcp.c
     src/tls/openssl/tls_udp.c
     src/tls/openssl/tls.c
+    src/tls/openssl/sni.c
     src/hmac/openssl/hmac.c
   )
 endif()

--- a/include/re_tls.h
+++ b/include/re_tls.h
@@ -120,3 +120,4 @@ struct evp_pkey_st;
 
 int tls_set_certificate_openssl(struct tls *tls, struct x509_st *cert,
 				struct evp_pkey_st *pkey, bool up_ref);
+int tls_add_certf(struct tls *tls, const char *certf, const struct pl *host);

--- a/include/re_tls.h
+++ b/include/re_tls.h
@@ -120,4 +120,4 @@ struct evp_pkey_st;
 
 int tls_set_certificate_openssl(struct tls *tls, struct x509_st *cert,
 				struct evp_pkey_st *pkey, bool up_ref);
-int tls_add_certf(struct tls *tls, const char *certf, const struct pl *host);
+int tls_add_certf(struct tls *tls, const char *certf, const char *host);

--- a/src/tls/openssl/sni.c
+++ b/src/tls/openssl/sni.c
@@ -116,7 +116,7 @@ struct tls_cert *tls_cert_for_sni(const struct tls *tls, const char *sni)
 		}
 
 		nm = X509_get_subject_name(x509);
-		X509_NAME_get_text_by_NID(nm, NID_commonName, cn, sz);
+		X509_NAME_get_text_by_NID(nm, NID_commonName, cn, (int) sz);
 		if (!str_cmp(sni, cn))
 			break;
 

--- a/src/tls/openssl/sni.c
+++ b/src/tls/openssl/sni.c
@@ -1,0 +1,185 @@
+/**
+ * @file openssl/sni.c Server Name Indication API
+ *
+ * Copyright (C) 2022 Commend.com - c.spielberger@commend.com
+ */
+#include <openssl/tls1.h>
+#include <string.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <re_types.h>
+#include <re_fmt.h>
+#include <re_mem.h>
+#include <re_sa.h>
+#include <re_srtp.h>
+#include <re_tls.h>
+#include "tls.h"
+#include "sni.h"
+
+
+#define DEBUG_MODULE "tls"
+#define DEBUG_LEVEL 5
+#include <re_dbg.h>
+
+#include <re_list.h>
+#include <re_hash.h>
+
+
+struct tls_conn;
+
+
+static int x509_match_alt_name(X509 *x509, const struct pl *sni, bool *match)
+{
+	GENERAL_NAMES *gs = NULL;
+	char *snistr;
+	ASN1_STRING *astr = NULL;
+	ASN1_OCTET_STRING *octet = NULL;
+	int i;
+	int err = 0;
+
+	*match = false;
+	gs = X509_get_ext_d2i(x509, NID_subject_alt_name, NULL, NULL);
+	if (!gs)
+		return 0;
+
+	err = pl_strdup(&snistr, sni);
+	if (err)
+		return err;
+
+	astr = ASN1_IA5STRING_new();
+	if (!astr) {
+		err = ENOMEM;
+		goto out;
+	}
+
+	if (!ASN1_STRING_set(astr, snistr, -1)) {
+		err = ENOMEM;
+		goto out;
+	}
+
+	octet = a2i_IPADDRESS(snistr);
+	for (i = 0; i < sk_GENERAL_NAME_num(gs); i++) {
+		GENERAL_NAME *g = sk_GENERAL_NAME_value(gs, i);
+
+		if (g->type == GEN_DNS) {
+			if (!ASN1_STRING_cmp(astr, g->d.dNSName)) {
+				*match = true;
+				break;
+			}
+		}
+		else if (g->type == GEN_IPADD) {
+			if (!ASN1_OCTET_STRING_cmp(octet, g->d.iPAddress)) {
+				*match = true;
+				break;
+			}
+		}
+	}
+
+out:
+	mem_deref(snistr);
+	ASN1_IA5STRING_free(astr);
+	ASN1_OCTET_STRING_free(octet);
+	return err;
+}
+
+
+struct tls_cert *tls_cert_for_sni(const struct tls *tls, const struct pl *sni)
+{
+	struct tls_cert *tls_cert = NULL;
+	struct le *le;
+	int sz;
+	char *cn;
+	const struct list *certs = tls_certs(tls);
+
+	if (!certs)
+		return NULL;
+
+	if (!pl_isset(sni))
+		return list_head(certs)->data;
+
+	if (sni->l >= TLSEXT_MAXLEN_host_name)
+		return NULL;
+
+	sz = (int) sni->l + 1;
+	cn = mem_zalloc(sz, NULL);
+	LIST_FOREACH(certs, le) {
+		X509 *x509;
+		X509_NAME *nm;
+		bool match = false;
+		int err;
+
+		tls_cert = le->data;
+		x509 = tls_cert_x509(tls_cert);
+		if (!x509) {
+			tls_cert = NULL;
+			continue;
+		}
+
+		nm = X509_get_subject_name(x509);
+		X509_NAME_get_text_by_NID(nm, NID_commonName, cn, sz);
+		if (!pl_strcmp(sni, cn))
+			break;
+
+		err = x509_match_alt_name(x509, sni, &match);
+		if (err) {
+			tls_cert = NULL;
+			break;
+		}
+
+		if (match)
+			break;
+	}
+
+	mem_deref(cn);
+	return tls_cert;
+}
+
+
+static int ssl_use_cert(SSL *ssl, struct tls_cert *uc)
+{
+	int err;
+	long r;
+
+#if !defined(LIBRESSL_VERSION_NUMBER)
+	SSL_certs_clear(ssl);
+#endif
+	r = SSL_clear_chain_certs(ssl);
+	if (r != 1)
+		return EINVAL;
+
+	r = SSL_use_cert_and_key(ssl, tls_cert_x509(uc), tls_cert_pkey(uc),
+				 tls_cert_chain(uc), 1);
+	if (r != 1)
+		return EINVAL;
+
+	err = ssl_set_verify_client(ssl, tls_cert_host(uc));
+	return err;
+}
+
+
+int ssl_servername_handler(SSL *ssl, int *al, void *arg)
+{
+	struct tls *tls = arg;
+	struct pl pl;
+	struct tls_cert *uc = NULL;
+	const char *sni;
+	(void)al;
+
+	sni = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
+	if (!str_isset(sni))
+		goto out;
+
+	pl_set_str(&pl, sni);
+
+	/* find and apply matching certificate */
+	uc = tls_cert_for_sni(tls, &pl);
+	if (!uc)
+		goto out;
+
+	(void)ssl_use_cert(ssl, uc);
+
+out:
+	return SSL_TLSEXT_ERR_OK;
+}

--- a/src/tls/openssl/sni.c
+++ b/src/tls/openssl/sni.c
@@ -97,8 +97,8 @@ struct tls_cert *tls_cert_for_sni(const struct tls *tls, const char *sni)
 	if (!str_isset(sni))
 		return list_head(certs)->data;
 
-	sz = str_len(sni);
-	if (sz >= TLSEXT_MAXLEN_host_name)
+	sz = str_len(sni) + 1;
+	if (sz > TLSEXT_MAXLEN_host_name)
 		return NULL;
 
 	cn = mem_zalloc(sz, NULL);
@@ -208,6 +208,7 @@ static int ssl_servername_handler(SSL *ssl, int *al, void *arg)
 	if (!uc)
 		goto out;
 
+	DEBUG_INFO("found cert for sni %s\n", sni);
 	(void)ssl_use_cert(ssl, uc);
 
 out:

--- a/src/tls/openssl/sni.h
+++ b/src/tls/openssl/sni.h
@@ -1,9 +1,0 @@
-/**
- * @file openssl/sni.h Server Name Indication (Internal API)
- *
- * Copyright (C) 2022 Commend.com - c.spielberger@commend.com
- */
-
-struct tls_cert *tls_cert_for_sni(const struct tls *tls, const struct pl *sni);
-int ssl_servername_handler(SSL *s, int *al, void *arg);
-int ssl_set_verify_client(SSL *ssl, const char *host);

--- a/src/tls/openssl/sni.h
+++ b/src/tls/openssl/sni.h
@@ -1,0 +1,9 @@
+/**
+ * @file openssl/sni.h Server Name Indication (Internal API)
+ *
+ * Copyright (C) 2022 Commend.com - c.spielberger@commend.com
+ */
+
+struct tls_cert *tls_cert_for_sni(const struct tls *tls, const struct pl *sni);
+int ssl_servername_handler(SSL *s, int *al, void *arg);
+int ssl_set_verify_client(SSL *ssl, const char *host);

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -1876,8 +1876,7 @@ int tls_add_certf(struct tls *tls, const char *certf, const char *host)
 		}
 	}
 
-	BIO_free(bio);
-	bio = BIO_new_file(certf, "r");
+	BIO_reset(bio);
 	if (!bio) {
 		err = EIO;
 		goto out;

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -1838,6 +1838,9 @@ int tls_add_certf(struct tls *tls, const char *certf, const char *host)
 		return EINVAL;
 
 	uc = mem_zalloc(sizeof(*uc), tls_cert_destructor);
+	if (!uc)
+		return ENOMEM;
+
 	if (str_isset(host)) {
 		err = str_dup(&uc->host, host);
 		if (err)

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -290,7 +290,6 @@ int tls_alloc(struct tls **tlsp, enum tls_method method, const char *keyfile,
 		}
 	}
 
-	tls_enable_sni(tls);
 	err = hash_alloc(&tls->reuse.ht_sessions, 256);
 	if (err)
 		goto out;
@@ -1900,6 +1899,8 @@ out:
 	}
 	else {
 		list_append(&tls->certs, &uc->le, uc);
+		if (list_count(&tls->certs) == 1)
+			tls_enable_sni(tls);
 	}
 
 	return err;

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -1828,7 +1828,7 @@ static void tls_cert_destructor(void *arg)
  *
  * @return 0 if success, otherwise errorcode
  */
-int tls_add_certf(struct tls *tls, const char *certf, const struct pl *host)
+int tls_add_certf(struct tls *tls, const char *certf, const char *host)
 {
 	struct tls_cert *uc;
 	BIO *bio = NULL;
@@ -1838,8 +1838,8 @@ int tls_add_certf(struct tls *tls, const char *certf, const struct pl *host)
 		return EINVAL;
 
 	uc = mem_zalloc(sizeof(*uc), tls_cert_destructor);
-	if (pl_isset(host)) {
-		err = pl_strdup(&uc->host, host);
+	if (str_isset(host)) {
+		err = str_dup(&uc->host, host);
 		if (err)
 			goto out;
 	}

--- a/src/tls/openssl/tls.h
+++ b/src/tls/openssl/tls.h
@@ -27,8 +27,17 @@ typedef X509_NAME*(tls_get_certfield_h)(const X509 *);
 typedef X509_NAME*(tls_get_certfield_h)(X509 *);
 #endif
 
-
 struct tls;
+struct tls_cert;
 
 void tls_flush_error(void);
 SSL_CTX *tls_ssl_ctx(const struct tls *tls);
+X509 *tls_cert_x509(struct tls_cert *hc);
+EVP_PKEY *tls_cert_pkey(struct tls_cert *hc);
+STACK_OF(X509*) tls_cert_chain(struct tls_cert *hc);
+const char *tls_cert_host(struct tls_cert *hc);
+const struct list *tls_certs(const struct tls *tls);
+
+SSL *tls_conn_ssl(struct tls_conn *tc);
+struct tls *tls_conn_tls(struct tls_conn *tc);
+

--- a/src/tls/openssl/tls.h
+++ b/src/tls/openssl/tls.h
@@ -38,6 +38,9 @@ STACK_OF(X509*) tls_cert_chain(struct tls_cert *hc);
 const char *tls_cert_host(struct tls_cert *hc);
 const struct list *tls_certs(const struct tls *tls);
 
-SSL *tls_conn_ssl(struct tls_conn *tc);
-struct tls *tls_conn_tls(struct tls_conn *tc);
-
+struct tls_cert *tls_cert_for_sni(const struct tls *tls, const char *sni);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
+	!defined(LIBRESSL_VERSION_NUMBER)
+int tls_verify_handler(int ok, X509_STORE_CTX *ctx);
+void tls_enable_sni(struct tls *tls);
+#endif


### PR DESCRIPTION
    tls: support multiple TLS server certificates
    
    Multiple certificates combined with private key and host name for the host name
    verification can be added with a new function `tls_add_certf()`.
    
    For incoming SIP requests a certificate is selected by SNI in the TLS client
    hello before `SSL_accept()` is called.


e.g. use case: incoming OPTIONS from SIP servers for client is alive polling

TODO: maybe in follow up PRs in order to keep this PR small.
- cleanup/combine with
```
commit 21f36e31522b8d2106e6c1daf64ea0eba626f79c
Author: Christoph Huber <c.huber@commend.com>
Date:   Mon Apr 12 09:45:50 2021 +0200

    transp: add and use different client certificates
```
- The names `tls_set_verify_server()` and  `tls_set_verify_client()` are not very proper. Maybe we could add a deprecated logging/doxygen and add new functions:
  - `tls_conn_enable_verify_peer(struct tls_conn *tc, const char *host)` with optional `host` parameter and
  - `tls_trust_all(struct tls *tls)`