### PR TITLE
sa,unixsock: add unix domain socket support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,6 +361,8 @@ set(SRCS
   src/uri/uri.c
   src/uri/uric.c
 
+  src/unixsock/unixsock.c
+
   src/websock/websock.c
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,12 @@ set(HEADERS
   include/re_websock.h
 )
 
+if(USE_UNIXSOCK)
+  list(APPEND HEADERS
+    include/re_unixsock.h
+  )
+endif()
+
 set(SRCS
 
   src/av1/depack.c
@@ -361,11 +367,14 @@ set(SRCS
   src/uri/uri.c
   src/uri/uric.c
 
-  src/unixsock/unixsock.c
-
   src/websock/websock.c
 )
 
+if(USE_UNIXSOCK)
+  list(APPEND SRCS
+    src/unixsock/unixsock.c
+  )
+endif()
 
 if(USE_BFCP)
   list(APPEND SRCS

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Patches can sent via Github
 | turn     | stable   | Obtaining Relay Addresses from STUN (TURN)     |
 | trace    | testing  | Trace Helpers JSON traces (chrome://tracing)   |
 | udp      | stable   | UDP transport                                  |
+| unixsock | testing  | Unix domain sockets                            |
 | uri      | stable   | Generic URI library                            |
 | websock  | stable   | WebSocket Client and Server                    |
 

--- a/cmake/re-config.cmake
+++ b/cmake/re-config.cmake
@@ -8,6 +8,7 @@ find_package(ZLIB)
 find_package(OpenSSL)
 
 option(USE_OPENSSL "Enable OpenSSL" ${OPENSSL_FOUND})
+option(USE_UNIXSOCK "Enable Unix Domain Sockets" ON)
 
 check_symbol_exists("arc4random" "stdlib.h" HAVE_ARC4RANDOM)
 if(HAVE_ARC4RANDOM)
@@ -112,6 +113,11 @@ if(USE_OPENSSL)
   )
 endif()
 
+if(USE_UNIXSOCK)
+  list(APPEND RE_DEFINITIONS
+    -DHAVE_UNIXSOCK
+  )
+endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   list(APPEND RE_DEFINITIONS -DDARWIN)

--- a/include/re.h
+++ b/include/re.h
@@ -63,6 +63,7 @@ extern "C" {
 #include "re_tls.h"
 #include "re_turn.h"
 #include "re_udp.h"
+#include "re_unixsock.h"
 #include "re_websock.h"
 #include "re_shim.h"
 #include "re_trice.h"

--- a/include/re_sa.h
+++ b/include/re_sa.h
@@ -35,7 +35,9 @@ struct sa {
 	union {
 		struct sockaddr sa;
 		struct sockaddr_in in;
+#ifdef HAVE_UNIXSOCK
 		struct sockaddr_un un;
+#endif
 #ifdef HAVE_INET6
 		struct sockaddr_in6 in6;
 #endif

--- a/include/re_sa.h
+++ b/include/re_sa.h
@@ -6,10 +6,18 @@
 #if defined(WIN32)
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#if !defined(UNIX_PATH_MAX)
+#define UNIX_PATH_MAX 108
+typedef struct sockaddr_un {
+	ADDRESS_FAMILY sun_family;
+	char sun_path[UNIX_PATH_MAX];
+} SOCKADDR_UN, *PSOCKADDR_UN;
+#endif
 #else
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <sys/un.h>
 #endif
 
 
@@ -27,6 +35,7 @@ struct sa {
 	union {
 		struct sockaddr sa;
 		struct sockaddr_in in;
+		struct sockaddr_un un;
 #ifdef HAVE_INET6
 		struct sockaddr_in6 in6;
 #endif

--- a/include/re_unixsock.h
+++ b/include/re_unixsock.h
@@ -1,2 +1,2 @@
 
-int unixsock_listen_fd(re_sock_t *fd, const struct sa *local);
+int unixsock_listen_fd(re_sock_t *fd, const struct sa *sock);

--- a/include/re_unixsock.h
+++ b/include/re_unixsock.h
@@ -1,2 +1,2 @@
 
-int unixsock_listen_fd(re_sock_t *fd, const struct sa *sock);
+int unixsock_listen_fd(re_sock_t *fdp, const struct sa *sock);

--- a/include/re_unixsock.h
+++ b/include/re_unixsock.h
@@ -1,0 +1,2 @@
+
+int unixsock_listen_fd(re_sock_t *fd, const struct sa *local);

--- a/src/sa/sa.c
+++ b/src/sa/sa.c
@@ -108,11 +108,13 @@ int sa_pton(const char *addr, struct sa *sa)
 	if (inet_pton(AF_INET, addr, &sa->u.in.sin_addr) > 0) {
 		sa->u.in.sin_family = AF_INET;
 	}
+#ifdef HAVE_UNIXSOCK
 	else if (!strncmp(addr, "unix:", 5)) {
 		sa->u.un.sun_family = AF_UNIX;
 		str_ncpy(sa->u.un.sun_path, addr + 5,
 			 sizeof(sa->u.un.sun_path));
 	}
+#endif
 #ifdef HAVE_INET6
 	else if (!strncmp(addr, "fe80:", 5) && strrchr(addr, '%')) {
 		err = sa_addrinfo(addr, sa);
@@ -159,9 +161,11 @@ int sa_set_str(struct sa *sa, const char *addr, uint16_t port)
 
 	switch (sa->u.sa.sa_family) {
 
+#ifdef HAVE_UNIXSOCK
 	case AF_UNIX:
 		sa->len = sizeof(struct sockaddr_un);
 		break;
+#endif
 
 	case AF_INET:
 		sa->u.in.sin_port = htons(port);
@@ -412,11 +416,12 @@ int sa_ntop(const struct sa *sa, char *buf, int size)
 		return EINVAL;
 
 	switch (sa->u.sa.sa_family) {
-
+#ifdef HAVE_UNIXSOCK
 	case AF_UNIX:
 		str_ncpy(buf, sa->u.un.sun_path, size);
 		ret = buf;
 		break;
+#endif
 
 	case AF_INET:
 		ret = inet_ntop(AF_INET, &sa->u.in.sin_addr, buf, size);
@@ -482,9 +487,11 @@ bool sa_isset(const struct sa *sa, int flag)
 
 	switch (sa->u.sa.sa_family) {
 
+#ifdef HAVE_UNIXSOCK
 	case AF_UNIX:
 		return str_isset(sa->u.un.sun_path);
 		break;
+#endif
 
 	case AF_INET:
 		if (flag & SA_ADDR)
@@ -595,12 +602,14 @@ bool sa_cmp(const struct sa *l, const struct sa *r, int flag)
 
 	switch (l->u.sa.sa_family) {
 
+#ifdef HAVE_UNIXSOCK
 	case AF_UNIX:
 		if (0 == str_cmp(l->u.un.sun_path, r->u.un.sun_path))
 			return true;
 		else
 			return false;
 		break;
+#endif
 
 	case AF_INET:
 		if (flag & SA_ADDR)

--- a/src/unixsock/unixsock.c
+++ b/src/unixsock/unixsock.c
@@ -28,8 +28,8 @@ int unixsock_listen_fd(re_sock_t *fd, const struct sa *local)
 		return EINVAL;
 
 	*fd = socket(AF_UNIX, SOCK_STREAM, 0);
-	if (*fd == BAD_SOCK) {
-		err = ERRNO_SOCK;
+	if (*fd == RE_BAD_SOCK) {
+		err = RE_ERRNO_SOCK;
 		goto out;
 	}
 
@@ -42,22 +42,22 @@ int unixsock_listen_fd(re_sock_t *fd, const struct sa *local)
 	(void)unlink(local->u.un.sun_path);
 
 	if (bind(*fd, &local->u.sa, local->len) < 0) {
-		err = ERRNO_SOCK;
+		err = RE_ERRNO_SOCK;
 		DEBUG_WARNING("bind(): %m (%J)\n", err, local);
 		goto out;
 	}
 
 	if (listen(*fd, SOMAXCONN) < 0) {
-		err = ERRNO_SOCK;
+		err = RE_ERRNO_SOCK;
 		DEBUG_WARNING("listen(): %m (%J)\n", err, local);
 		goto out;
 	}
 
 out:
 	if (err) {
-		if (*fd != BAD_SOCK)
+		if (*fd != RE_BAD_SOCK)
 			(void)close(*fd);
-		*fd = BAD_SOCK;
+		*fd = RE_BAD_SOCK;
 	}
 
 	return err;

--- a/src/unixsock/unixsock.c
+++ b/src/unixsock/unixsock.c
@@ -1,3 +1,9 @@
+/**
+ * @file unixsock/unixsock.c  Unix domain sockets
+ *
+ * Copyright (C) 2022 Sebastian Reimers
+ */
+
 #include <stdio.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -17,6 +23,16 @@
 #endif
 
 
+/**
+ * Listen for incoming connections on a Unix domain socket.
+ *
+ * @param fd    Pointer to a re_sock_t variable where the listening socket
+ *              file descriptor will be stored.
+ * @param sock  Pointer to a struct sa containing the address of the
+ *              Unix domain socket.
+ *
+ * @return 0 if success, otherwise errorcode
+ */
 int unixsock_listen_fd(re_sock_t *fd, const struct sa *sock)
 {
 	int err = 0;

--- a/src/unixsock/unixsock.c
+++ b/src/unixsock/unixsock.c
@@ -1,0 +1,64 @@
+#include <stdio.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include <re_types.h>
+#include <re_sa.h>
+#include <re_net.h>
+#include <re_unixsock.h>
+
+#define DEBUG_MODULE "unixsock"
+#define DEBUG_LEVEL 5
+#include <re_dbg.h>
+
+#ifdef WIN32
+#define close closesocket
+#define unlink _unlink
+#endif
+
+
+int unixsock_listen_fd(re_sock_t *fd, const struct sa *local)
+{
+	int err = 0;
+
+	if (!fd || !local)
+		return EINVAL;
+
+	if (sa_af(local) != AF_UNIX || !sa_isset(local, SA_ADDR))
+		return EINVAL;
+
+	*fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (*fd == BAD_SOCK) {
+		err = ERRNO_SOCK;
+		goto out;
+	}
+
+	err = net_sockopt_blocking_set(*fd, false);
+	if (err) {
+		DEBUG_WARNING("unix listen: nonblock set: %m\n", err);
+		goto out;
+	}
+
+	(void)unlink(local->u.un.sun_path);
+
+	if (bind(*fd, &local->u.sa, local->len) < 0) {
+		err = ERRNO_SOCK;
+		DEBUG_WARNING("bind(): %m (%J)\n", err, local);
+		goto out;
+	}
+
+	if (listen(*fd, SOMAXCONN) < 0) {
+		err = ERRNO_SOCK;
+		DEBUG_WARNING("listen(): %m (%J)\n", err, local);
+		goto out;
+	}
+
+out:
+	if (err) {
+		if (*fd != BAD_SOCK)
+			(void)close(*fd);
+		*fd = BAD_SOCK;
+	}
+
+	return err;
+}

--- a/src/unixsock/unixsock.c
+++ b/src/unixsock/unixsock.c
@@ -17,14 +17,14 @@
 #endif
 
 
-int unixsock_listen_fd(re_sock_t *fd, const struct sa *local)
+int unixsock_listen_fd(re_sock_t *fd, const struct sa *sock)
 {
 	int err = 0;
 
-	if (!fd || !local)
+	if (!fd || !sock)
 		return EINVAL;
 
-	if (sa_af(local) != AF_UNIX || !sa_isset(local, SA_ADDR))
+	if (sa_af(sock) != AF_UNIX || !sa_isset(sock, SA_ADDR))
 		return EINVAL;
 
 	*fd = socket(AF_UNIX, SOCK_STREAM, 0);
@@ -39,17 +39,17 @@ int unixsock_listen_fd(re_sock_t *fd, const struct sa *local)
 		goto out;
 	}
 
-	(void)unlink(local->u.un.sun_path);
+	(void)unlink(sock->u.un.sun_path);
 
-	if (bind(*fd, &local->u.sa, local->len) < 0) {
+	if (bind(*fd, &sock->u.sa, sock->len) < 0) {
 		err = RE_ERRNO_SOCK;
-		DEBUG_WARNING("bind(): %m (%J)\n", err, local);
+		DEBUG_WARNING("bind(): %m (%J)\n", err, sock);
 		goto out;
 	}
 
 	if (listen(*fd, SOMAXCONN) < 0) {
 		err = RE_ERRNO_SOCK;
-		DEBUG_WARNING("listen(): %m (%J)\n", err, local);
+		DEBUG_WARNING("listen(): %m (%J)\n", err, sock);
 		goto out;
 	}
 

--- a/src/unixsock/unixsock.c
+++ b/src/unixsock/unixsock.c
@@ -54,11 +54,8 @@ int unixsock_listen_fd(re_sock_t *fd, const struct sa *local)
 	}
 
 out:
-	if (err) {
-		if (*fd != RE_BAD_SOCK)
-			(void)close(*fd);
-		*fd = RE_BAD_SOCK;
-	}
+	if (err && *fd != RE_BAD_SOCK)
+		(void)close(*fd);
 
 	return err;
 }


### PR DESCRIPTION
Usage example:

```c
	struct sa srv;
	re_sock_t fd;

	err = sa_set_str(&srv, "unix:/run/http.sock", 0);
	if (err)
		return err;

	err = unixsock_listen_fd(&fd, &srv);
	if (err)
		return err;

	re_printf("listen: %j\n", &srv);

	err = http_listen_fd(sock, fd, http_req_handler, mix);
```