### PR TITLE
ci/valgrind: use ubuntu-20.04

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   valgrind:
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Looks like github actions has bumped `ubuntu-latest`