### PR TITLE
tls: clear session callbacks in destructor

### DIFF
--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -98,8 +98,11 @@ static void destructor(void *data)
 {
 	struct tls *tls = data;
 
-	if (tls->ctx)
+	if (tls->ctx) {
+		SSL_CTX_sess_set_new_cb(tls->ctx, NULL);
+		SSL_CTX_sess_set_remove_cb(tls->ctx, NULL);
 		SSL_CTX_free(tls->ctx);
+	}
 
 	if (tls->cert)
 		X509_free(tls->cert);


### PR DESCRIPTION
This fixes a segmentation fault that appear when the tls object is freed before
the SSL object and TLS session reuse was enabled.
