### PR TITLE
cmake, sa: enable unix sockets, if HAVE_UNIXSOCK is undefined

### DIFF
--- a/cmake/re-config.cmake
+++ b/cmake/re-config.cmake
@@ -115,7 +115,11 @@ endif()
 
 if(USE_UNIXSOCK)
   list(APPEND RE_DEFINITIONS
-    -DHAVE_UNIXSOCK
+    -DHAVE_UNIXSOCK=1
+  )
+else()
+  list(APPEND RE_DEFINITIONS
+    -DHAVE_UNIXSOCK=0
   )
 endif()
 

--- a/include/re_sa.h
+++ b/include/re_sa.h
@@ -35,7 +35,7 @@ struct sa {
 	union {
 		struct sockaddr sa;
 		struct sockaddr_in in;
-#ifdef HAVE_UNIXSOCK
+#if !defined(HAVE_UNIXSOCK) || HAVE_UNIXSOCK == 1
 		struct sockaddr_un un;
 #endif
 #ifdef HAVE_INET6

--- a/src/sa/sa.c
+++ b/src/sa/sa.c
@@ -108,7 +108,7 @@ int sa_pton(const char *addr, struct sa *sa)
 	if (inet_pton(AF_INET, addr, &sa->u.in.sin_addr) > 0) {
 		sa->u.in.sin_family = AF_INET;
 	}
-#ifdef HAVE_UNIXSOCK
+#if HAVE_UNIXSOCK == 1
 	else if (!strncmp(addr, "unix:", 5)) {
 		sa->u.un.sun_family = AF_UNIX;
 		str_ncpy(sa->u.un.sun_path, addr + 5,
@@ -161,7 +161,7 @@ int sa_set_str(struct sa *sa, const char *addr, uint16_t port)
 
 	switch (sa->u.sa.sa_family) {
 
-#ifdef HAVE_UNIXSOCK
+#if HAVE_UNIXSOCK == 1
 	case AF_UNIX:
 		sa->len = sizeof(struct sockaddr_un);
 		break;
@@ -416,7 +416,7 @@ int sa_ntop(const struct sa *sa, char *buf, int size)
 		return EINVAL;
 
 	switch (sa->u.sa.sa_family) {
-#ifdef HAVE_UNIXSOCK
+#if HAVE_UNIXSOCK == 1
 	case AF_UNIX:
 		str_ncpy(buf, sa->u.un.sun_path, size);
 		ret = buf;
@@ -487,7 +487,7 @@ bool sa_isset(const struct sa *sa, int flag)
 
 	switch (sa->u.sa.sa_family) {
 
-#ifdef HAVE_UNIXSOCK
+#if HAVE_UNIXSOCK == 1
 	case AF_UNIX:
 		return str_isset(sa->u.un.sun_path);
 		break;
@@ -602,7 +602,7 @@ bool sa_cmp(const struct sa *l, const struct sa *r, int flag)
 
 	switch (l->u.sa.sa_family) {
 
-#ifdef HAVE_UNIXSOCK
+#if HAVE_UNIXSOCK == 1
 	case AF_UNIX:
 		if (0 == str_cmp(l->u.un.sun_path, r->u.un.sun_path))
 			return true;


### PR DESCRIPTION
Unix sockets are turned on per default in cmake and are used in header re_sa.h. This PR enables the unix socket flag, if not explicitly defined during builds of external libs using re_sa.h.

Edit by @cspiel1 : Relates to https://github.com/baresip/baresip/issues/2402