### PR TITLE
dtls: add single connection mode

### DIFF
--- a/include/re_tls.h
+++ b/include/re_tls.h
@@ -113,6 +113,7 @@ const struct sa *dtls_peer(const struct tls_conn *tc);
 void dtls_set_peer(struct tls_conn *tc, const struct sa *peer);
 void dtls_recv_packet(struct dtls_sock *sock, const struct sa *src,
 		      struct mbuf *mb);
+void dtls_set_single(struct dtls_sock *sock, bool single);
 
 
 struct x509_st;


### PR DESCRIPTION
When used with WebRTC, the remote endpoint may send DTLS packets from any port. In this context we should have only one DTLS connection that is used for e.g. SRTP keying and SCTP transport.

This happens with Safari 16.1 where it sends DTLS Handshake from one port, and DTLS Alert from another port.