### PR TITLE
Fix doxygen warnings

### DIFF
--- a/src/mod/win32/dll.c
+++ b/src/mod/win32/dll.c
@@ -13,7 +13,7 @@
 #include <re_dbg.h>
 
 
-/**
+/*
  * Open a DLL file
  *
  * @param name  Name of DLL to open
@@ -36,7 +36,7 @@ void *_mod_open(const char *name)
 }
 
 
-/**
+/*
  * Resolve a symbol address in a DLL
  *
  * @param h       DLL Handle
@@ -67,7 +67,7 @@ void *_mod_sym(void *h, const char *symbol)
 }
 
 
-/**
+/*
  * Close a DLL
  *
  * @param h DLL Handle

--- a/src/net/win32/wif.c
+++ b/src/net/win32/wif.c
@@ -113,7 +113,7 @@ static int if_list_gai(net_ifaddr_h *ifh, void *arg)
 }
 
 
-/**
+/*
  * Enumerate all network interfaces
  *
  * @param ifh Interface handler

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -1934,7 +1934,7 @@ EVP_PKEY *tls_cert_pkey(struct tls_cert *hc)
 }
 
 
-/**
+/*
  * Returns the certificate chain of the TLS certificate
  *
  * @param hc  TLS certificate


### PR DESCRIPTION
Fixes the warnings:

```
alfredh@debian:~/git/re$ doxygen mk/Doxyfile 
/home/alfredh/git/re/src/mod/mod_internal.h:15: warning: argument 'h' from the argument list of _mod_close has multiple @param documentation sections
/home/alfredh/git/re/src/mod/mod_internal.h:13: warning: argument 'name' from the argument list of _mod_open has multiple @param documentation sections
/home/alfredh/git/re/src/mod/mod_internal.h:14: warning: argument 'h' from the argument list of _mod_sym has multiple @param documentation sections
/home/alfredh/git/re/src/mod/mod_internal.h:14: warning: argument 'symbol' from the argument list of _mod_sym has multiple @param documentation sections
/home/alfredh/git/re/include/re_net.h:73: warning: argument 'ifh' from the argument list of net_if_list has multiple @param documentation sections
/home/alfredh/git/re/include/re_net.h:73: warning: argument 'arg' from the argument list of net_if_list has multiple @param documentation sections
/home/alfredh/git/re/src/tls/openssl/tls.c:1940: warning: argument 'hc' of command @param is not found in the argument list of STACK_OF(X509 *)
/home/alfredh/git/re/src/tls/openssl/tls.c:1940: warning: argument 'hc' of command @param is not found in the argument list of STACK_OF(X509 *)
```
