### PR TITLE
sdp: lock r/w of ldir and rdir

### DIFF
--- a/include/re_atomic.h
+++ b/include/re_atomic.h
@@ -701,16 +701,16 @@ static __forceinline unsigned __int64 _re_atomic_load(
 	assert(size == 1u || size == 2u || size == 4u || size == 8u);
 	switch (size) {
 	case 1u:
-		v = _InterlockedCompareExchange8((char*)a, 0, 0);
+		v = _InterlockedCompareExchange8((const char*)a, 0, 0);
 		break;
 	case 2u:
-		v = _InterlockedCompareExchange16((short*)a, 0, 0);
+		v = _InterlockedCompareExchange16((const short*)a, 0, 0);
 		break;
 	case 4u:
-		v = _InterlockedCompareExchange((long*)a, 0, 0);
+		v = _InterlockedCompareExchange((const long*)a, 0, 0);
 		break;
 	default:
-		v = _InterlockedCompareExchange64((__int64*)a, 0, 0);
+		v = _InterlockedCompareExchange64((const __int64*)a, 0, 0);
 		break;
 	}
 

--- a/include/re_atomic.h
+++ b/include/re_atomic.h
@@ -701,16 +701,16 @@ static __forceinline unsigned __int64 _re_atomic_load(
 	assert(size == 1u || size == 2u || size == 4u || size == 8u);
 	switch (size) {
 	case 1u:
-		v = _InterlockedCompareExchange8((const char*)a, 0, 0);
+		v = _InterlockedCompareExchange8((char*)a, 0, 0);
 		break;
 	case 2u:
-		v = _InterlockedCompareExchange16((const short*)a, 0, 0);
+		v = _InterlockedCompareExchange16((short*)a, 0, 0);
 		break;
 	case 4u:
-		v = _InterlockedCompareExchange((const long*)a, 0, 0);
+		v = _InterlockedCompareExchange((long*)a, 0, 0);
 		break;
 	default:
-		v = _InterlockedCompareExchange64((const __int64*)a, 0, 0);
+		v = _InterlockedCompareExchange64((__int64*)a, 0, 0);
 		break;
 	}
 

--- a/include/re_sdp.h
+++ b/include/re_sdp.h
@@ -101,6 +101,7 @@ void sdp_media_set_lbandwidth(struct sdp_media *m, enum sdp_bandwidth type,
 void sdp_media_set_lport_rtcp(struct sdp_media *m, uint16_t port);
 void sdp_media_set_laddr_rtcp(struct sdp_media *m, const struct sa *laddr);
 void sdp_media_set_ldir(struct sdp_media *m, enum sdp_dir dir);
+void sdp_media_set_rdir(struct sdp_media *m, enum sdp_dir dir);
 int  sdp_media_set_lattr(struct sdp_media *m, bool replace,
 			 const char *name, const char *value, ...);
 void sdp_media_del_lattr(struct sdp_media *m, const char *name);

--- a/src/sdp/attr.c
+++ b/src/sdp/attr.c
@@ -11,6 +11,7 @@
 #include <re_list.h>
 #include <re_sa.h>
 #include <re_sdp.h>
+#include <re_thread.h>
 #include "sdp.h"
 
 

--- a/src/sdp/attr.c
+++ b/src/sdp/attr.c
@@ -11,6 +11,7 @@
 #include <re_list.h>
 #include <re_sa.h>
 #include <re_sdp.h>
+#include <re_atomic.h>
 #include "sdp.h"
 
 

--- a/src/sdp/attr.c
+++ b/src/sdp/attr.c
@@ -11,7 +11,6 @@
 #include <re_list.h>
 #include <re_sa.h>
 #include <re_sdp.h>
-#include <re_thread.h>
 #include "sdp.h"
 
 

--- a/src/sdp/format.c
+++ b/src/sdp/format.c
@@ -12,6 +12,7 @@
 #include <re_list.h>
 #include <re_sa.h>
 #include <re_sdp.h>
+#include <re_thread.h>
 #include "sdp.h"
 
 

--- a/src/sdp/format.c
+++ b/src/sdp/format.c
@@ -12,7 +12,6 @@
 #include <re_list.h>
 #include <re_sa.h>
 #include <re_sdp.h>
-#include <re_thread.h>
 #include "sdp.h"
 
 

--- a/src/sdp/format.c
+++ b/src/sdp/format.c
@@ -12,6 +12,7 @@
 #include <re_list.h>
 #include <re_sa.h>
 #include <re_sdp.h>
+#include <re_atomic.h>
 #include "sdp.h"
 
 

--- a/src/sdp/media.c
+++ b/src/sdp/media.c
@@ -12,7 +12,6 @@
 #include <re_list.h>
 #include <re_sa.h>
 #include <re_sdp.h>
-#include <re_thread.h>
 #include "sdp.h"
 
 
@@ -40,7 +39,6 @@ static void destructor(void *arg)
 	mem_deref(m->name);
 	mem_deref(m->proto);
 	mem_deref(m->uproto);
-	mem_deref(m->lock);
 }
 
 
@@ -48,17 +46,10 @@ static int media_alloc(struct sdp_media **mp, struct list *list)
 {
 	struct sdp_media *m;
 	int i;
-	int err;
 
 	m = mem_zalloc(sizeof(*m), destructor);
 	if (!m)
 		return ENOMEM;
-
-	err  = mutex_alloc(&m->lock);
-	if (err) {
-		mem_deref(m);
-		return err;
-	}
 
 	list_append(list, &m->le, m);
 
@@ -543,9 +534,7 @@ void sdp_media_set_ldir(struct sdp_media *m, enum sdp_dir dir)
 	if (!m)
 		return;
 
-	mtx_lock(m->lock);
 	m->ldir = dir;
-	mtx_unlock(m->lock);
 }
 
 
@@ -693,15 +682,7 @@ int32_t sdp_media_rbandwidth(const struct sdp_media *m,
  */
 enum sdp_dir sdp_media_ldir(const struct sdp_media *m)
 {
-	enum sdp_dir ldir;
-
-	if (!m)
-		return SDP_INACTIVE;
-
-	mtx_lock(m->lock);
-	ldir = m->ldir;
-	mtx_unlock(m->lock);
-	return ldir;
+	return m ? m->ldir : SDP_INACTIVE;
 }
 
 
@@ -714,15 +695,7 @@ enum sdp_dir sdp_media_ldir(const struct sdp_media *m)
  */
 enum sdp_dir sdp_media_rdir(const struct sdp_media *m)
 {
-	enum sdp_dir rdir;
-
-	if (!m)
-		return SDP_INACTIVE;
-
-	mtx_lock(m->lock);
-	rdir = m->rdir;
-	mtx_unlock(m->lock);
-	return rdir;
+	return m ? m->rdir : SDP_INACTIVE;
 }
 
 
@@ -735,15 +708,7 @@ enum sdp_dir sdp_media_rdir(const struct sdp_media *m)
  */
 enum sdp_dir sdp_media_dir(const struct sdp_media *m)
 {
-	enum sdp_dir dir;
-
-	if (!m)
-		return SDP_INACTIVE;
-
-	mtx_lock(m->lock);
-	dir = (enum sdp_dir)(m->ldir & m->rdir);
-	mtx_unlock(m->lock);
-	return dir;
+	return m ? (enum sdp_dir)(m->ldir & m->rdir) : SDP_INACTIVE;
 }
 
 

--- a/src/sdp/media.c
+++ b/src/sdp/media.c
@@ -540,6 +540,21 @@ void sdp_media_set_ldir(struct sdp_media *m, enum sdp_dir dir)
 
 
 /**
+ * Set the remote direction flag of an SDP Media line
+ *
+ * @param m   SDP Media line
+ * @param dir Media direction flag
+ */
+void sdp_media_set_rdir(struct sdp_media *m, enum sdp_dir dir)
+{
+	if (!m)
+		return;
+
+	re_atomic_rlx_set(&m->rdir, dir);
+}
+
+
+/**
  * Set a local attribute of an SDP Media line
  *
  * @param m       SDP Media line

--- a/src/sdp/msg.c
+++ b/src/sdp/msg.c
@@ -221,10 +221,10 @@ static int media_decode(struct sdp_media **mp, struct sdp_session *sess,
 	m->raddr = sess->raddr;
 	sa_set_port(&m->raddr, m->uproto ? 0 : pl_u32(&port));
 
-	re_atomic_rlx_set(&m->rdir, sess->rdir);
+	sdp_media_set_rdir(m, sess->rdir);
 
 	if (!pl_u32(&port))
-		re_atomic_rlx_set(&m->rdir, SDP_INACTIVE);
+		sdp_media_set_rdir(m, SDP_INACTIVE);
 
 	*mp = m;
 
@@ -289,7 +289,7 @@ int sdp_decode(struct sdp_session *sess, struct mbuf *mb, bool offer)
 						  m ? &rdir : &sess->rdir,
 						  &val);
 				if (m)
-					re_atomic_rlx_set(&m->rdir, rdir);
+					sdp_media_set_rdir(m, rdir);
 				break;
 
 			case 'b':
@@ -464,8 +464,8 @@ static int media_encode(const struct sdp_media *m, struct mbuf *mb, bool offer)
 		err |= mbuf_printf(mb, "a=rtcp:%u\r\n",
 				   sa_port(&m->laddr_rtcp));
 
-	ldir = re_atomic_rlx(&m->ldir);
-	rdir = re_atomic_rlx(&m->rdir);
+	ldir = sdp_media_ldir(m);
+	rdir = sdp_media_rdir(m);
 	err |= mbuf_printf(mb, "a=%s\r\n", disabled ?
 		sdp_dir_name(SDP_INACTIVE) :
 		sdp_dir_name(offer ? ldir : ldir & rdir));

--- a/src/sdp/msg.c
+++ b/src/sdp/msg.c
@@ -10,7 +10,6 @@
 #include <re_list.h>
 #include <re_sa.h>
 #include <re_sdp.h>
-#include <re_thread.h>
 #include "sdp.h"
 
 

--- a/src/sdp/msg.c
+++ b/src/sdp/msg.c
@@ -285,6 +285,7 @@ int sdp_decode(struct sdp_session *sess, struct mbuf *mb, bool offer)
 			switch (type) {
 
 			case 'a':
+				rdir = SDP_SENDRECV;
 				err = attr_decode(sess, m,
 						  m ? &rdir : &sess->rdir,
 						  &val);

--- a/src/sdp/msg.c
+++ b/src/sdp/msg.c
@@ -10,6 +10,7 @@
 #include <re_list.h>
 #include <re_sa.h>
 #include <re_sdp.h>
+#include <re_thread.h>
 #include "sdp.h"
 
 

--- a/src/sdp/sdp.h
+++ b/src/sdp/sdp.h
@@ -43,8 +43,8 @@ struct sdp_media {
 	char *uproto;           /* unsupported protocol */
 	sdp_media_enc_h *ench;
 	void *arg;
-	enum sdp_dir ldir;
-	enum sdp_dir rdir;
+	RE_ATOMIC enum sdp_dir ldir;
+	RE_ATOMIC enum sdp_dir rdir;
 	bool fmt_ignore;
 	bool disabled;
 	int dynpt;

--- a/src/sdp/sdp.h
+++ b/src/sdp/sdp.h
@@ -48,7 +48,6 @@ struct sdp_media {
 	bool fmt_ignore;
 	bool disabled;
 	int dynpt;
-	mtx_t *lock;
 };
 
 

--- a/src/sdp/sdp.h
+++ b/src/sdp/sdp.h
@@ -48,6 +48,7 @@ struct sdp_media {
 	bool fmt_ignore;
 	bool disabled;
 	int dynpt;
+	mtx_t *lock;
 };
 
 

--- a/src/sdp/session.c
+++ b/src/sdp/session.c
@@ -12,6 +12,7 @@
 #include <re_sa.h>
 #include <re_sdp.h>
 #include <re_sys.h>
+#include <re_atomic.h>
 #include "sdp.h"
 
 

--- a/src/sdp/session.c
+++ b/src/sdp/session.c
@@ -12,7 +12,6 @@
 #include <re_sa.h>
 #include <re_sdp.h>
 #include <re_sys.h>
-#include <re_thread.h>
 #include "sdp.h"
 
 

--- a/src/sdp/session.c
+++ b/src/sdp/session.c
@@ -12,6 +12,7 @@
 #include <re_sa.h>
 #include <re_sdp.h>
 #include <re_sys.h>
+#include <re_thread.h>
 #include "sdp.h"
 
 


### PR DESCRIPTION
Belongs to planned RX thread.
( Should we create some kind of "label"? )

In the `rtp_handler()` there is only read access of
- sdp_media_ldir(s->sdp) the ldir may change during RX thread is running.
- sdp_media_name(s->sdp) does not change during RX thread

Only for discussion. 

- Better use Atomic?
- Should we make all sdp_media functions thread safe, with a lock?