### PR TITLE
Client cert renegotiation in http

### DIFF
--- a/include/re_http.h
+++ b/include/re_http.h
@@ -179,8 +179,16 @@ int http_client_set_tls_max_version(struct http_cli *cli, int version);
 struct http_sock;
 struct http_conn;
 
+enum re_https_verify_msg {
+	HTTPS_MSG_OK = 0,
+	HTTPS_MSG_REQUEST_CERT = 1,
+	HTTPS_MSG_IGNORE = 2,
+};
+
 typedef void (http_req_h)(struct http_conn *conn, const struct http_msg *msg,
 			  void *arg);
+typedef enum re_https_verify_msg (https_verify_msg_h)(struct http_conn *conn,
+	const struct http_msg *msg, void *arg);
 
 int http_listen_fd(struct http_sock **sockp, re_sock_t fd, http_req_h *reqh,
 		   void *arg);
@@ -188,10 +196,14 @@ int  http_listen(struct http_sock **sockp, const struct sa *laddr,
 		 http_req_h *reqh, void *arg);
 int  https_listen(struct http_sock **sockp, const struct sa *laddr,
 		  const char *cert, http_req_h *reqh, void *arg);
+int  https_set_verify_msgh(struct http_sock *sock,
+			   https_verify_msg_h *verify_msg_h);
 struct tcp_sock *http_sock_tcp(struct http_sock *sock);
+struct tls *http_sock_tls(struct http_sock *conn);
 const struct sa *http_conn_peer(const struct http_conn *conn);
 struct tcp_conn *http_conn_tcp(struct http_conn *conn);
 struct tls_conn *http_conn_tls(struct http_conn *conn);
+
 void http_conn_reset_timeout(struct http_conn *conn);
 void http_conn_close(struct http_conn *conn);
 int  http_reply(struct http_conn *conn, uint16_t scode, const char *reason,

--- a/include/re_tls.h
+++ b/include/re_tls.h
@@ -28,6 +28,10 @@ enum tls_keytype {
 	TLS_KEYTYPE_EC,
 };
 
+struct tls_conn_d {
+	int (*verifyh) (int ok, void *d);
+	void *verify_d;
+};
 
 int tls_alloc(struct tls **tlsp, enum tls_method method, const char *keyfile,
 	      const char *pwd);
@@ -46,6 +50,10 @@ int tls_set_certificate_der(struct tls *tls, enum tls_keytype keytype,
 			    const uint8_t *key, size_t len_key);
 int tls_set_certificate(struct tls *tls, const char *cert, size_t len);
 void tls_set_verify_client(struct tls *tls);
+void tls_set_verify_client_trust_all(struct tls *tls);
+int tls_set_verify_client_handler(struct tls_conn *tc, int depth,
+	int (*cb) (int ok, void *d), void *d);
+
 int tls_set_srtp(struct tls *tls, const char *suites);
 int tls_fingerprint(const struct tls *tls, enum tls_fingerprint type,
 		    uint8_t *md, size_t size);
@@ -74,12 +82,18 @@ bool tls_get_session_reuse(const struct tls_conn *tc);
 int tls_reuse_session(const struct tls_conn *tc);
 bool tls_session_reused(const struct tls_conn *tc);
 int tls_update_sessions(const struct tls_conn *tc);
+int tls_renegotiate(const struct tls_conn *tc);
+int tls_disable_session_on_reneg(struct tls_conn *tc);
+int tls_set_posthandshake_auth(struct tls *tls, int enabled);
 
 /* TCP */
 
 int tls_conn_change_cert(struct tls_conn *tc, const char *file);
 int tls_start_tcp(struct tls_conn **ptc, struct tls *tls,
 		  struct tcp_conn *tcp, int layer);
+
+int tls_verify_client_post_handshake(struct tls_conn *tc);
+const char* tls_version(struct tls_conn *tc);
 
 const struct tcp_conn *tls_get_tcp_conn(const struct tls_conn *tc);
 

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -23,6 +23,7 @@
 #include <re_sys.h>
 #include <re_tcp.h>
 #include <re_tls.h>
+#include <re_thread.h>
 #include "tls.h"
 
 
@@ -105,6 +106,7 @@ static void tls_keylogger_cb(const SSL *ssl,
 struct tls_conn {
 	SSL *ssl;
 	struct tls *tls;
+	struct tls_conn_d cd;
 };
 
 
@@ -205,6 +207,19 @@ int tls_verify_handler(int ok, X509_STORE_CTX *ctx)
 #endif
 
 
+static int tls_verify_idx = -1;
+static once_flag oflag = ONCE_FLAG_INIT;
+
+static void tls_init_verify_idx(void)
+{
+	if (tls_verify_idx > -1)
+		return;
+
+	tls_verify_idx = SSL_get_ex_new_index(0, "tls verify ud",
+		NULL, NULL, NULL);
+}
+
+
 /**
  * Allocate a new TLS context
  *
@@ -292,6 +307,8 @@ int tls_alloc(struct tls **tlsp, enum tls_method method, const char *keyfile,
 	err = hash_alloc(&tls->reuse.ht_sessions, 256);
 	if (err)
 		goto out;
+
+	call_once(&oflag, tls_init_verify_idx);
 
 	err = 0;
  out:
@@ -921,11 +938,12 @@ static int verify_trust_all(int ok, X509_STORE_CTX *ctx)
 
 
 /**
- * Set TLS server context to request certificate from client
+ * Set TLS server context to request certificate from peer
+ * and set trust all certificates of peer.
  *
  * @param tls    TLS Context
  */
-void tls_set_verify_client(struct tls *tls)
+void tls_set_verify_client_trust_all(struct tls *tls)
 {
 	if (!tls)
 		return;
@@ -933,6 +951,120 @@ void tls_set_verify_client(struct tls *tls)
 	SSL_CTX_set_verify_depth(tls->ctx, 0);
 	SSL_CTX_set_verify(tls->ctx, SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE,
 			   verify_trust_all);
+}
+
+
+/**
+ * Set TLS server context to request certificate from peer
+ * and set trust all certificates of peer.
+ *
+ * @deprecated Use tls_set_verify_peer_trust_all instead
+ * @param tls    TLS Context
+ */
+void tls_set_verify_client(struct tls *tls)
+{
+	if (!tls)
+		return;
+
+	tls_set_verify_client_trust_all(tls);
+}
+
+
+static int tls_verify_handler_ud(int ok, X509_STORE_CTX *ctx)
+{
+	int ret = ok;
+	struct tls_conn_d *d;
+	SSL *ssl;
+	int err, depth;
+
+	err = X509_STORE_CTX_get_error(ctx);
+
+#if (DEBUG_LEVEL >= 6)
+	char    buf[128];
+	X509   *err_cert;
+
+	err_cert = X509_STORE_CTX_get_current_cert(ctx);
+
+	X509_NAME_oneline(X509_get_subject_name(err_cert), buf, 128);
+	DEBUG_INFO("%s: subject_name = %s\n", __func__, buf);
+
+	X509_NAME_oneline(X509_get_issuer_name(err_cert), buf, 128);
+	DEBUG_INFO("%s: issuer_name  = %s\n", __func__, buf);
+#endif
+	if (err) {
+		depth = X509_STORE_CTX_get_error_depth(ctx);
+		DEBUG_WARNING("%s: err          = %d\n", __func__, err);
+		DEBUG_WARNING("%s: error_string = %s\n", __func__,
+				X509_verify_cert_error_string(err));
+		DEBUG_WARNING("%s: depth        = %d\n", __func__, depth);
+	}
+
+#if (DEBUG_LEVEL >= 6)
+	DEBUG_INFO("tls_verify_handler ok = %d\n", ok);
+#endif
+
+	ssl = X509_STORE_CTX_get_ex_data(ctx,
+		SSL_get_ex_data_X509_STORE_CTX_idx());
+
+	if (!ssl) {
+		DEBUG_WARNING("X509_STORE_CTX_get_ex_data (SSL*) failed\n");
+		return ret;
+	}
+
+	d = SSL_get_ex_data(ssl, tls_verify_idx);
+	if (!d) {
+		DEBUG_WARNING("SSL_get_app_data (struct tls_conn_d) failed\n");
+		return ret;
+	}
+
+	if (d->verifyh)
+		ret = d->verifyh(ok, d->verify_d);
+
+	return ret;
+}
+
+
+/**
+ * Enable request certificate from peer in TLS server connection
+ * Set verify handler.
+ *
+ * @param tc     TLS connection
+ * @param depth  Max depth certificate chain accepted.
+ *               A negative depth uses default depth.
+ * @param cb     SSL verify handler. If NULL default verify handler is used.
+ */
+int tls_set_verify_client_handler(struct tls_conn *tc, int depth,
+	int (*cb) (int ok, void *d), void *d)
+{
+#if !defined(LIBRESSL_VERSION_NUMBER)
+	int err = 0;
+	SSL_verify_cb tls_cb = tls_verify_handler_ud;
+	if (!tc)
+		return EINVAL;
+
+	if (!cb) {
+		tls_cb = tls_verify_handler;
+	}
+	else {
+		tc->cd.verifyh = cb;
+		tc->cd.verify_d = d;
+		SSL_set_ex_data(tc->ssl, tls_verify_idx, &tc->cd);
+	}
+
+	SSL_set_verify_depth(tc->ssl, depth < 0 ?
+		SSL_get_verify_depth(tc->ssl) : depth);
+	SSL_set_verify(tc->ssl, SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE,
+		tls_cb);
+
+	return err;
+#else
+	(void) tc;
+	(void) depth;
+	(void) cb;
+	(void) d;
+	(void) tls_verify_handler_ud;
+	return ENOSYS;
+#endif
 }
 
 
@@ -1955,4 +2087,138 @@ const char *tls_cert_host(struct tls_cert *hc)
 const struct list *tls_certs(const struct tls *tls)
 {
 	return tls ? &tls->certs : NULL;
+}
+
+
+/**
+ * Start tls renegotiation
+ * Sends a TLS "Hello Request" to the client.
+ *
+ * E.g. After "Client Hello" is sent the server can request
+ * a certificate from the client in the Server Hello response.
+ *
+ * @param tc  tlc connection object
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int tls_renegotiate(const struct tls_conn *tc)
+{
+	int err = 0;
+	if (!tc || !tc->tls)
+		return EINVAL;
+
+	if (SSL_renegotiate(tc->ssl) <= 0) {
+		err = EFAULT;
+		DEBUG_WARNING("%s: error: %m, ssl_err=%d\n", __func__, err,
+			SSL_get_error(tc->ssl, err));
+	}
+
+	/* process state machine */
+	if (SSL_do_handshake(tc->ssl) <= 0) {
+		err = EIO;
+		DEBUG_WARNING("%s: error: %m, ssl_err=%d\n", __func__, err,
+			SSL_get_error(tc->ssl, err));
+	}
+
+	return err;
+}
+
+
+/**
+ * Disable session resumption (server side only)
+ *
+ * @param tc  tlc connection object
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int tls_disable_session_on_reneg(struct tls_conn *tc)
+{
+	if (!tc)
+		return EINVAL;
+
+	SSL_set_options(tc->ssl,
+		SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
+
+	return 0;
+}
+
+
+/**
+ * Enable/disable posthandshake
+ * Only on client side for TLSv1.3
+ *
+ * @param tls  tls object
+ * @param value posthandshake auth value. 1 enabled, Default: 0
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int tls_set_posthandshake_auth(struct tls *tls, int value)
+{
+#if !defined(LIBRESSL_VERSION_NUMBER)
+	if (!tls)
+		return EINVAL;
+
+	SSL_CTX_set_post_handshake_auth(tls->ctx, value);
+
+	return 0;
+#else
+
+	(void)tls;
+	(void)value;
+	return ENOSYS;
+#endif
+}
+
+
+/**
+ * Request client certificate using post handshake
+ * Only on client side for TLSv1.3
+ *
+ * @param tc  tls connection
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int tls_verify_client_post_handshake(struct tls_conn *tc)
+{
+#if !defined(LIBRESSL_VERSION_NUMBER)
+	int ret;
+	int err = 0;
+	if (!tc || !tc->ssl)
+		return EINVAL;
+
+	if (!(ret=SSL_verify_client_post_handshake(tc->ssl))) {
+		err = EFAULT;
+		DEBUG_WARNING("%s: error: %m, ssl_err=%d\n", __func__, err,
+			SSL_get_error(tc->ssl, ret));
+	}
+
+	if (!(ret = SSL_do_handshake(tc->ssl))) {
+		err = EIO;
+		DEBUG_WARNING("%s: error: %m, ssl_err=%d\n", __func__, err,
+			SSL_get_error(tc->ssl, ret));
+	}
+
+	return err;
+#else
+
+	(void)tc;
+	return ENOSYS;
+#endif
+}
+
+
+/**
+ * Request client certificate using post handshake
+ * Only on client side for TLSv1.3
+ *
+ * @param tc  tls connection
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+const char* tls_version(struct tls_conn *tc)
+{
+	if (!tc || !tc->ssl)
+		return "";
+
+	return SSL_get_version(tc->ssl);
 }

--- a/src/tls/openssl/tls_tcp.c
+++ b/src/tls/openssl/tls_tcp.c
@@ -28,6 +28,7 @@
 struct tls_conn {
 	SSL *ssl;             /* inheritance */
 	struct tls *tls;      /* inheritance */
+	struct tls_conn_d cd; /* inheritance */
 	BIO_METHOD *biomet;
 	BIO *sbio_out;
 	BIO *sbio_in;

--- a/src/tls/openssl/tls_tcp.c
+++ b/src/tls/openssl/tls_tcp.c
@@ -230,7 +230,12 @@ static bool recv_handler(int *err, struct mbuf *mb, bool *estab, void *arg)
 
 	if (SSL_state(tc->ssl) != SSL_ST_OK) {
 
-		if (tc->up) {
+		if (tc->up
+#if !defined(LIBRESSL_VERSION_NUMBER)
+			&& SSL_state(tc->ssl) != TLS_ST_CW_CLNT_HELLO
+			&& SSL_state(tc->ssl) != TLS_ST_CW_FINISHED
+#endif
+		) {
 			*err = EPROTO;
 			return true;
 		}

--- a/src/tls/openssl/tls_tcp.c
+++ b/src/tls/openssl/tls_tcp.c
@@ -234,6 +234,7 @@ static bool recv_handler(int *err, struct mbuf *mb, bool *estab, void *arg)
 #if !defined(LIBRESSL_VERSION_NUMBER)
 			&& SSL_state(tc->ssl) != TLS_ST_CW_CLNT_HELLO
 			&& SSL_state(tc->ssl) != TLS_ST_CW_FINISHED
+			&& SSL_state(tc->ssl) != TLS_ST_SW_SRVR_DONE
 #endif
 		) {
 			*err = EPROTO;

--- a/src/tls/openssl/tls_udp.c
+++ b/src/tls/openssl/tls_udp.c
@@ -60,6 +60,7 @@ struct dtls_sock {
 struct tls_conn {
 	SSL *ssl;             /* inheritance */
 	struct tls *tls;      /* inheritance */
+	struct tls_conn_d cd; /* inheritance */
 	BIO_METHOD *biomet;
 	BIO *sbio_out;
 	BIO *sbio_in;

--- a/test/http.c
+++ b/test/http.c
@@ -133,6 +133,7 @@ struct test {
 	uint32_t n_response;
 	size_t i_req_body;
 	bool secure;
+	bool cert_auth;
 	int err;
 };
 
@@ -141,6 +142,31 @@ static void abort_test(struct test *t, int err)
 {
 	t->err = err;
 	re_cancel();
+}
+
+
+static enum re_https_verify_msg https_verify_msg_handler(
+	struct http_conn *conn, const struct http_msg *msg, void *arg)
+{
+	(void) conn;
+	struct test *t = arg;
+	int err = 0;
+	enum re_https_verify_msg res = HTTPS_MSG_OK;
+
+	if (!t->cert_auth)
+		goto out;
+
+	TEST_STRCMP("/auth/index.html", 11+5, msg->path.p, msg->path.l);
+
+	/* cert authorisation required, request client certificate */
+	res = HTTPS_MSG_REQUEST_CERT;
+out:
+	if (err) {
+		res = HTTPS_MSG_IGNORE;
+		abort_test(t, err);
+	}
+
+	return res;
 }
 
 
@@ -168,7 +194,14 @@ static void http_req_handler(struct http_conn *conn,
 	/* verify HTTP request */
 	TEST_STRCMP("1.1", 3, msg->ver.p, msg->ver.l);
 	TEST_STRCMP("GET", 3, msg->met.p, msg->met.l);
-	TEST_STRCMP("/index.html", 11, msg->path.p, msg->path.l);
+	if (t->cert_auth) {
+		TEST_STRCMP("/auth/index.html", 11+5, msg->path.p,
+			msg->path.l);
+	}
+	else {
+		TEST_STRCMP("/index.html", 11, msg->path.p, msg->path.l);
+	}
+
 	TEST_STRCMP("", 0, msg->prm.p, msg->prm.l);
 	TEST_EQUALS(t->clen, msg->clen);
 	TEST_STRCMP("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", 52,
@@ -195,16 +228,15 @@ static void http_req_handler(struct http_conn *conn,
 		goto out;
 
 	t->clen = mb_body->end;
-
 	err = http_reply(conn, 200, "OK",
-			 "Transfer-Encoding: chunked\r\n"
-			 "Content-Type: text/plain\r\n"
-			 "Content-Length: %zu\r\n"
-			 "\r\n"
-			 "%b",
-			 mb_body->end,
-			 mb_body->buf, mb_body->end
-			 );
+			"Transfer-Encoding: chunked\r\n"
+			"Content-Type: text/plain\r\n"
+			"Content-Length: %zu\r\n"
+			"\r\n"
+			"%b",
+			mb_body->end,
+			mb_body->buf, mb_body->end
+			);
 
  out:
 	mem_deref(mb_body);
@@ -396,7 +428,8 @@ static size_t http_req_long_body_handler(struct mbuf *mb, void *arg)
 
 
 static int test_http_loop_base(bool secure, const char *met, bool http_conn,
-	bool dns_srv_query, bool dns_set_conf_test)
+	bool dns_srv_query, bool dns_set_conf_test, bool client_cert,
+	bool tlsv12)
 {
 	struct http_sock *sock = NULL;
 	struct http_cli *cli = NULL;
@@ -427,6 +460,7 @@ static int test_http_loop_base(bool secure, const char *met, bool http_conn,
 	memset(&t, 0, sizeof(t));
 
 	t.secure = secure;
+	t.cert_auth = secure && client_cert;
 
 	if (dns_srv_query) {
 		/* Setup Mocking DNS Server */
@@ -443,12 +477,24 @@ static int test_http_loop_base(bool secure, const char *met, bool http_conn,
 	TEST_ERR(err);
 
 	if (secure) {
-
-		re_snprintf(path, sizeof(path), "%s/server-ecdsa.pem",
-			    test_datapath());
+		if (t.cert_auth)
+			re_snprintf(path, sizeof(path),
+				"%s/sni/server-interm.pem", test_datapath());
+		else
+			re_snprintf(path, sizeof(path), "%s/server-ecdsa.pem",
+					test_datapath());
 
 		err = https_listen(&sock, &srv, path,
 			put ? http_put_req_handler : http_req_handler, &t);
+		if (err)
+			goto out;
+
+		if (t.cert_auth)
+			err = https_set_verify_msgh(sock,
+				https_verify_msg_handler);
+
+		if (tlsv12)
+			tls_set_max_proto_version(http_sock_tls(sock), 0x0303);
 	}
 	else {
 		err = http_listen(&sock, &srv,
@@ -476,22 +522,78 @@ static int test_http_loop_base(bool secure, const char *met, bool http_conn,
 	if (err)
 		goto out;
 
+	if (secure) {
+		struct tls*	 cli_tls;
+		http_client_get_tls(cli, &cli_tls);
+
+		if (tlsv12)
+			tls_set_max_proto_version(cli_tls, 0x0303);
+
+		if (t.cert_auth) {
+			re_snprintf(path, sizeof(path),
+				"%s/sni/client-interm.pem", test_datapath());
+			err |= http_client_set_cert(cli, path);
+			err |= http_client_set_key(cli, path);
+			if (err)
+				goto out;
+
+			tls_set_posthandshake_auth(cli_tls, 1);
+
+			/* add CAs to http server */
+			re_snprintf(path, sizeof(path), "%s/sni/root-ca.pem",
+				test_datapath());
+
+			err |=  tls_add_ca(http_sock_tls(sock), path);
+			re_snprintf(path, sizeof(path),
+				"%s/sni/server-interm.pem", test_datapath());
+
+			err |=  tls_add_ca(http_sock_tls(sock), path);
+			if (err)
+				goto out;
+		}
+
+		if (http_conn && (!t.cert_auth || tlsv12))
+			err = tls_set_session_reuse(cli_tls, true);
+
+		if (err)
+			goto out;
+	}
+
 	if (put)
 		http_client_set_bufsize_max(cli, REQ_BODY_CHUNK_SIZE + 128);
 
 #ifdef USE_TLS
+	/* add root CA to http client */
 	if (secure) {
+		if (t.cert_auth)
+			re_snprintf(path, sizeof(path), "%s/sni/root-ca.pem",
+					test_datapath());
+		else
+			re_snprintf(path, sizeof(path), "%s/server-ecdsa.pem",
+					test_datapath());
 		err = http_client_add_ca(cli, path);
+		if (err)
+			goto out;
+	}
+
+	if (t.cert_auth) {
+		re_snprintf(path, sizeof(path), "%s/sni/client-interm.pem",
+				test_datapath());
+		err |= http_client_set_cert(cli, path);
+		err |= http_client_set_key(cli, path);
 		if (err)
 			goto out;
 	}
 #endif
 
 	(void)re_snprintf(url, sizeof(url),
-			  "http%s://%s:%u/index.html",
-			  secure ? "s" : "",
-			  dns_srv_query ? "test1.example.net" : "127.0.0.1",
-			  sa_port(&srv));
+					"http%s://%s:%u/%sindex.html",
+					secure ? "s" : "",
+					dns_srv_query ?
+					"test1.example.net"
+					: "127.0.0.1",
+					sa_port(&srv),
+					t.cert_auth ? "auth/" : "");
 
 	for (i = 1; i <= 10*REQ_HTTP_REQUESTS; i++) {
 		t.i_req_body = 0;
@@ -667,51 +769,74 @@ out:
 
 int test_http_loop(void)
 {
-	return test_http_loop_base(false, "GET", false, false, false);
+	return test_http_loop_base(false, "GET", false, false, false, false,
+		false);
 }
 
 
 #ifdef USE_TLS
 int test_https_loop(void)
 {
-	return test_http_loop_base(true, "GET", false, false, false);
+	return test_http_loop_base(true, "GET", false, false, false, false,
+		false);
 }
 #endif
 
 
 int test_http_large_body(void)
 {
-	return test_http_loop_base(false, "PUT", false, false, false);
+	return test_http_loop_base(false, "PUT", false, false, false, false,
+		false);
 }
 
 
 #ifdef USE_TLS
 int test_https_large_body(void)
 {
-	return test_http_loop_base(true, "PUT", false, false, false);
+	return test_http_loop_base(true, "PUT", false, false, false, false,
+		false);
 }
 #endif
 
 
 int test_http_conn(void)
 {
-	return test_http_loop_base(false, "GET", true, false, false);
+	return test_http_loop_base(false, "GET", true, false, false, false,
+		false);
 }
 
 
 int test_http_conn_large_body(void)
 {
-	return test_http_loop_base(false, "PUT", true, false, false);
+	return test_http_loop_base(false, "PUT", true, false, false, false,
+		false);
 }
 
 
 int test_dns_http_integration(void)
 {
-	return test_http_loop_base(false, "GET", true, true, false);
+	return test_http_loop_base(false, "GET", true, true, false, false,
+		false);
 }
 
 
 int test_dns_cache_http_integration(void)
 {
-	return test_http_loop_base(false, "GET", true, true, true);
+	return test_http_loop_base(false, "GET", true, true, true, false,
+		false);
 }
+
+#ifdef USE_TLS
+int test_https_conn_cert_reneg_tls(void)
+{
+	return test_http_loop_base(true, "GET", true, false, false, true,
+		false);
+}
+
+
+int test_https_conn_cert_reneg_tls_v12(void)
+{
+	return test_http_loop_base(true, "GET", true, false, false, true,
+		true);
+}
+#endif

--- a/test/test.c
+++ b/test/test.c
@@ -113,6 +113,8 @@ static const struct test tests[] = {
 	TEST(test_https_loop),
 	TEST(test_http_client_set_tls),
 	TEST(test_https_large_body),
+	TEST(test_https_conn_cert_reneg_tls_v12),
+	TEST(test_https_conn_cert_reneg_tls),
 #endif
 	TEST(test_httpauth_chall),
 	TEST(test_httpauth_resp),

--- a/test/test.h
+++ b/test/test.h
@@ -220,6 +220,8 @@ int test_dns_cache_http_integration(void);
 int test_https_loop(void);
 int test_http_client_set_tls(void);
 int test_https_large_body(void);
+int test_https_conn_cert_reneg_tls(void);
+int test_https_conn_cert_reneg_tls_v12(void);
 #endif
 int test_httpauth_chall(void);
 int test_httpauth_resp(void);


### PR DESCRIPTION
Add server support for certificate renegotiation.
Fix tls state machine on client and server for tls1.2 renegotiation.


Feature Commits:
tls: handle client hello/finished state during tls 1.2 renegotiation
tls: handle server done state during tls 1.2 renegotiation


Commits with new Apis:
tls, http: add tls and http apis for renegotiation
        Add tls_set_conn_verify_client_handler,
        tls_renegotiate, tls_disable_session_on_reneg,
        tls_set_posthandshake_auth, tls_conn_verify_client_post_handshake,
        tls_conn_version
        Add http_sock_tls


Commit to fix retest on win32:
http: fix read_file on win32 (incorrect get fsize)