### PR TITLE
tmr,main: thread safe tmr handling

### DIFF
--- a/include/re_main.h
+++ b/include/re_main.h
@@ -67,6 +67,7 @@ void re_thread_async_cancel(intptr_t id);
 
 void re_set_mutex(void *mutexp);
 
+struct tmrl *re_tmrl_get(void);
 
 /** Polling methods */
 enum poll_method {

--- a/include/re_thread.h
+++ b/include/re_thread.h
@@ -23,6 +23,9 @@
 
 #if defined(WIN32)
 
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #define ONCE_FLAG_INIT INIT_ONCE_STATIC_INIT
 typedef INIT_ONCE once_flag;

--- a/include/re_thread.h
+++ b/include/re_thread.h
@@ -13,6 +13,9 @@
  * Copyright (C) 2022 Sebastian Reimers
  */
 
+#ifndef RE_H_THREAD__
+#define RE_H_THREAD__
+
 #if defined(HAVE_THREADS)
 #include <threads.h>
 
@@ -286,3 +289,5 @@ int mutex_alloc(mtx_t **mtx);
  */
 int thread_create_name(thrd_t *thr, const char *name, thrd_start_t func,
 		     void *arg);
+
+#endif /* RE_H_THREAD__ */

--- a/include/re_tmr.h
+++ b/include/re_tmr.h
@@ -5,12 +5,16 @@
  */
 
 
+#include <re_thread.h>
+
 /**
  * Defines the timeout handler
  *
  * @param arg Handler argument
  */
 typedef void (tmr_h)(void *arg);
+
+struct tmrl;
 
 /** Defines a timer */
 struct tmr {
@@ -20,14 +24,15 @@ struct tmr {
 	uint64_t jfs;       /**< Jiffies for timeout */
 	const char *file;
 	int line;
+	mtx_t *lock;
 };
 
-
-void     tmr_poll(struct list *tmrl);
+int      tmrl_alloc(struct tmrl **tmrl);
+void     tmr_poll(struct tmrl *tmrl);
 uint64_t tmr_jiffies_usec(void);
 uint64_t tmr_jiffies(void);
 uint64_t tmr_jiffies_rt_usec(void);
-uint64_t tmr_next_timeout(struct list *tmrl);
+uint64_t tmr_next_timeout(struct tmrl *tmrl);
 void     tmr_debug(void);
 int      tmr_status(struct re_printf *pf, void *unused);
 

--- a/include/re_tmr.h
+++ b/include/re_tmr.h
@@ -19,12 +19,12 @@ struct tmrl;
 /** Defines a timer */
 struct tmr {
 	struct le le;       /**< Linked list element */
+	mtx_t *lock;        /**< Mutex lock          */
 	tmr_h *th;          /**< Timeout handler     */
 	void *arg;          /**< Handler argument    */
 	uint64_t jfs;       /**< Jiffies for timeout */
 	const char *file;
 	int line;
-	mtx_t *lock;
 };
 
 int      tmrl_alloc(struct tmrl **tmrl);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1376,13 +1376,12 @@ int re_thread_check(void)
  *
  * @note only used by tmr module
  */
-struct tmrl *tmrl_get(void);
-struct tmrl *tmrl_get(void)
+struct tmrl *re_tmrl_get(void)
 {
 	struct re *re = re_get();
 
 	if (!re) {
-		DEBUG_WARNING("tmrl_get: re not ready\n");
+		DEBUG_WARNING("re_tmrl_get: re not ready\n");
 		return NULL;
 	}
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1034,7 +1034,7 @@ int re_main(re_signal_h *signalh)
 #endif
 #ifdef WIN32
 			if (WSAEINVAL == err) {
-				tmr_poll(&re->tmrl);
+				tmr_poll(re->tmrl);
 				continue;
 			}
 #endif

--- a/src/tmr/tmr.c
+++ b/src/tmr/tmr.c
@@ -65,7 +65,7 @@ int tmrl_alloc(struct tmrl **tmrl)
 	if (!tmrl)
 		return EINVAL;
 
-	l = mem_zalloc(sizeof(struct tmrl), tmrl_destructor);
+	l = mem_zalloc(sizeof(struct tmrl), NULL);
 	if (!l)
 		return ENOMEM;
 
@@ -76,6 +76,8 @@ int tmrl_alloc(struct tmrl **tmrl)
 		mem_deref(l);
 		return err;
 	}
+
+	mem_destructor(l, tmrl_destructor);
 
 	*tmrl = l;
 

--- a/src/tmr/tmr.c
+++ b/src/tmr/tmr.c
@@ -42,8 +42,6 @@ struct tmrl {
 	mtx_t *lock;
 };
 
-extern struct tmrl *tmrl_get(void);
-
 
 static void tmrl_destructor(void *arg)
 {
@@ -291,7 +289,7 @@ out:
 
 int tmr_status(struct re_printf *pf, void *unused)
 {
-	struct tmrl *tmrl = tmrl_get();
+	struct tmrl *tmrl = re_tmrl_get();
 	struct le *le;
 	uint32_t n;
 	int err = 0;
@@ -352,7 +350,7 @@ void tmr_init(struct tmr *tmr)
 void tmr_start_dbg(struct tmr *tmr, uint64_t delay, tmr_h *th, void *arg,
 		   const char *file, int line)
 {
-	struct tmrl *tmrl = tmrl_get();
+	struct tmrl *tmrl = re_tmrl_get();
 	struct le *le;
 	mtx_t *lock;
 

--- a/src/tmr/tmr.c
+++ b/src/tmr/tmr.c
@@ -360,7 +360,7 @@ void tmr_start_dbg(struct tmr *tmr, uint64_t delay, tmr_h *th, void *arg,
 	if (!tmr->lock || !tmr->le.list)
 		lock = tmrl->lock;
 	else
-	 	lock = tmr->lock; /* use old lock for unlinking */
+		lock = tmr->lock; /* use old lock for unlinking */
 
 	mtx_lock(lock);
 

--- a/src/tmr/tmr.c
+++ b/src/tmr/tmr.c
@@ -303,9 +303,6 @@ int tmr_status(struct re_printf *pf, void *unused)
 
 	mtx_lock(tmrl->lock);
 
-	if (!list_isempty(&tmrl->list))
-		goto out;
-
 	n = list_count(&tmrl->list);
 	if (!n)
 		goto out;


### PR DESCRIPTION
It's possible that a worker thread can reuse a `tmr` (for example if `turnc` recv helper is executed from a different re poll thread and stun refresh tmr is updated). The new worker thread has to unlink the old `tmr` from main thread timer list. This needs thread safe mutex handling. The impact on performance is likely to be small because the competitive situation is low.