### PR TITLE
stream: RX thread - separate thread safe receiver

### DIFF
--- a/include/re_rtp.h
+++ b/include/re_rtp.h
@@ -101,6 +101,7 @@ struct rtcp_msg {
 		unsigned int pt:8;       /**< RTCP packet type       */
 		uint16_t length;         /**< Packet length in words */
 	} hdr;
+	struct mbuf *mb;
 	union {
 		/** Sender report (SR) */
 		struct {

--- a/src/rtp/pkt.c
+++ b/src/rtp/pkt.c
@@ -75,6 +75,8 @@ static void rtcp_destructor(void *data)
 		/* nothing allocated */
 		break;
 	}
+
+	mem_deref(msg->mb);
 }
 
 
@@ -341,6 +343,7 @@ int rtcp_decode(struct rtcp_msg **msgp, struct mbuf *mb)
 	if (!msg)
 		return ENOMEM;
 
+	msg->mb = mem_ref(mb);
 	start = mb->pos;
 
 	/* decode and check header */


### PR DESCRIPTION
`rtcp_msg` gets a reference to the `mbuf` of the RTCP packet.

https://github.com/baresip/baresip/pull/2454 needs this to be able to decode a duplicate of the original `rtcp_msg`.

Maybe a better solution would be to implement a deep copy function of `rtcp_msg`.