### PR TITLE
rtp: add deep copy function for rtcp_msg

### DIFF
--- a/include/re_rtp.h
+++ b/include/re_rtp.h
@@ -277,6 +277,7 @@ int   rtcp_stats(struct rtp_sock *rs, uint32_t ssrc, struct rtcp_stats *stats);
 /* RTCP utils */
 int   rtcp_encode(struct mbuf *mb, enum rtcp_type type, uint32_t count, ...);
 int   rtcp_decode(struct rtcp_msg **msgp, struct mbuf *mb);
+int   rtcp_dup(struct rtcp_msg **msgp, struct rtcp_msg *msgs);
 int   rtcp_msg_print(struct re_printf *pf, const struct rtcp_msg *msg);
 int   rtcp_sdes_encode(struct mbuf *mb, uint32_t src, uint32_t itemc, ...);
 const char *rtcp_type_name(enum rtcp_type type);

--- a/src/rtp/rtcp.h
+++ b/src/rtp/rtcp.h
@@ -78,14 +78,18 @@ int rtcp_rr_decode(struct mbuf *mb, struct rtcp_rr *rr);
 
 /* SDES (Source Description) */
 int rtcp_sdes_decode(struct mbuf *mb, struct rtcp_sdes *sdes);
+int rtcp_sdes_dup(struct rtcp_sdes *sdes_dst, struct rtcp_sdes *sdes_src);
 
 /* RTCP Feedback */
 int rtcp_rtpfb_gnack_encode(struct mbuf *mb, uint16_t pid, uint16_t blp);
 int rtcp_psfb_sli_encode(struct mbuf *mb, uint16_t first, uint16_t number,
 			 uint8_t picid);
 int rtcp_rtpfb_twcc_decode(struct mbuf *mb, struct twcc *msg, int n);
+int rtcp_rtpfb_twcc_dup(struct twcc *msg, struct twcc *msgs);
 int rtcp_rtpfb_decode(struct mbuf *mb, struct rtcp_msg *msg);
+int rtcp_rtpfb_dup(struct rtcp_msg *msg, struct rtcp_msg *msgs);
 int rtcp_psfb_decode(struct mbuf *mb, struct rtcp_msg *msg);
+int rtcp_psfb_dup(struct rtcp_msg *msg, struct rtcp_msg *msgs);
 
 /** NTP Time */
 struct timeval;


### PR DESCRIPTION
We need the deep copy to pass RTCP messages from RX thread to main thread.

Is there a simpler solution? E.g. with encode + decode, or `rtcp_msg_print()` ?

TODO: retest