### PR TITLE
hmac: add stateless HMAC-SHA256 wrapper

### DIFF
--- a/include/re_hmac.h
+++ b/include/re_hmac.h
@@ -12,6 +12,13 @@ void hmac_sha1(const uint8_t *k,   /* secret key */
 	       uint8_t*       out, /* output buffer, at least "t" bytes */
 	       size_t         t);
 
+void hmac_sha256(const uint8_t *key,
+		 size_t         key_len,
+		 const uint8_t *data,
+		 size_t         data_len,
+		 uint8_t       *out,
+		 size_t         out_len);
+
 
 enum hmac_hash {
 	HMAC_HASH_SHA1,

--- a/src/hmac/hmac_sha1.c
+++ b/src/hmac/hmac_sha1.c
@@ -54,3 +54,33 @@ void hmac_sha1(const uint8_t *k,  /* secret key */
 
 #endif
 }
+
+
+void hmac_sha256(const uint8_t *key, size_t key_len,
+		 const uint8_t *data, size_t data_len,
+		 uint8_t *out, size_t out_len)
+{
+#ifdef USE_OPENSSL
+
+	(void)out_len;
+
+	if (!HMAC(EVP_sha256(), key, (int)key_len, data, data_len, out, NULL))
+		ERR_clear_error();
+
+#elif defined (__APPLE__)
+	(void)out_len;
+
+	CCHmac(kCCHmacAlgSHA256, key, key_len, data, data_len, out);
+#else
+	(void)key;
+	(void)key_len;
+	(void)data;
+	(void)data_len;
+	(void)out;
+	(void)out_len;
+
+#error missing HMAC-SHA256 backend
+
+
+#endif
+}

--- a/test/hmac.c
+++ b/test/hmac.c
@@ -255,6 +255,16 @@ int test_hmac_sha256(void)
 		TEST_MEMCMP(digest, sizeof(digest), md, sizeof(md));
 
 		hmac = mem_deref(hmac);
+
+		/* Test Stateless API */
+
+		uint8_t md2[SHA256_DIGEST_LENGTH];
+
+		hmac_sha256(key, key_len,
+			    data, data_len,
+			    md2, sizeof(md2));
+
+		TEST_MEMCMP(digest, sizeof(digest), md2, sizeof(md2));
 	}
 
  out:


### PR DESCRIPTION
Add a wrapper for HMAC-SHA256 using OpenSSL or Apple CommonCrypto as backend
