### PR TITLE
dtls: only refer to content_type_str when level is INFO or more

### DIFF
--- a/src/tls/openssl/tls_udp.c
+++ b/src/tls/openssl/tls_udp.c
@@ -754,7 +754,9 @@ static bool recv_handler(struct sa *src, struct mbuf *mb, void *arg)
 	if (b < 20 || b > 63)
 		return false;
 
+#if DEBUG_LEVEL >= 6
 	DEBUG_INFO("receive '%s' from %J\n", content_type_str(b), src);
+#endif
 
 	tc = conn_lookup(sock, src);
 	if (tc) {


### PR DESCRIPTION
this code does not compile when using fallback debug macros.

We seem to have some problematic code in re_dbg.h:


```c
/* No variable argument macros */
#else

#if (DEBUG_LEVEL >= 4)
#define DEBUG_WARNING dbg_warning
#else
#define DEBUG_WARNING dbg_noprintf
#endif

#if (DEBUG_LEVEL >= 5)
#define DEBUG_NOTICE dbg_notice
#else
#define DEBUG_NOTICE dbg_noprintf
#endif

#if (DEBUG_LEVEL >= 6)
#define DEBUG_INFO dbg_info
#else
#define DEBUG_INFO dbg_noprintf
#endif

#if (DEBUG_LEVEL >= 7)
#define DEBUG_PRINTF dbg_noprintf
#else
#define DEBUG_PRINTF dbg_noprintf
#endif

#endif
```


The function `dbg_noprintf` is called even if that debug level is off.


