### PR TITLE
sys/fs: fix fs_fopen read only mode (should not create file)

### DIFF
--- a/src/sys/fs.c
+++ b/src/sys/fs.c
@@ -190,10 +190,10 @@ int fs_fopen(FILE **fp, const char *file, const char *mode)
 	FILE *pfile;
 	int fd;
 
-	if (!fp || !file || !mode)
+	if (!fp || !file || !str_isset(mode))
 		return EINVAL;
 
-	if (fs_isfile(file))
+	if (mode[0] == 'r' || fs_isfile(file))
 		goto fopen;
 
 	fd = open(file, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR);


### PR DESCRIPTION
- `r` Opens for reading. If the file doesn't exist or can't be found, the fopen_s call fails.
- `r+` Opens for both reading and writing. The file must exist.