### PR TITLE
misc: add Makefile helpers and exclude retest from all target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: cmake
       run: |
-        cmake -B build && cmake --build build
+        cmake -B build && cmake --build build -t retest
     
     - name: retest
       run: |

--- a/.github/workflows/cmake_win.yml
+++ b/.github/workflows/cmake_win.yml
@@ -45,5 +45,5 @@ jobs:
           cmake --version
           ninja --version
           cmake -S . -B build -G "${{ matrix.config.generators }}" -DCMAKE_C_FLAGS="/WX" -DCMAKE_BUILD_TYPE=${{ matrix.config.build }}
-          cmake --build build --parallel
+          cmake --build build --parallel -t retest
           build\test\retest.exe -r -v

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
     - name: make
       run: | 
         cmake -B build -DCMAKE_C_FLAGS="--coverage" -DCMAKE_EXE_LINKER_FLAGS="--coverage"
-        cmake --build build -j
+        cmake --build build -j -t retest
 
     - name: retest
       run: |

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: cmake
       run: |
-        cmake -B build -DHAVE_THREADS= && cmake --build build -j
+        cmake -B build -DHAVE_THREADS= && cmake --build build -j -t retest
 
     - name: retest
       run: |

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: make
       run: |
-        cmake -B build && cmake --build build -j
+        cmake -B build && cmake --build build -j -t retest
 
     - name: retest
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build*
+/dist
 test.d
 test.o
 *stamp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -740,4 +740,4 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libre.pc
 # Test
 #
 
-add_subdirectory(test)
+add_subdirectory(test EXCLUDE_FROM_ALL)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+.PHONY: build
+build:
+	[ -d build ] || cmake -B build
+	cmake --build build --parallel
+
+.PHONY: ninja
+ninja:
+	[ -d build ] || cmake -B build -G Ninja
+	make build
+
+.PHONY: dist
+dist: build
+	cmake --install build --prefix dist
+
+.PHONY: test
+test: build
+	cmake --build build --parallel -t retest
+	build/test/retest -rv
+
+.PHONY: clean
+clean:
+	@rm -Rf build dist CMakeCache.txt CMakeFiles
+
+
+###############################################################################
+#
+# Documentation section
+#
+DOX_DIR=../re-dox
+
+$(DOX_DIR):
+	@mkdir $@
+
+$(DOX_DIR)/Doxyfile: mk/Doxyfile Makefile
+	@cp $< $@
+	@perl -pi -e 's/PROJECT_NUMBER\s*=.*/PROJECT_NUMBER = $(VERSION)/' \
+	$(DOX_DIR)/Doxyfile
+
+.PHONY:
+dox:	$(DOX_DIR) $(DOX_DIR)/Doxyfile
+	@doxygen $(DOX_DIR)/Doxyfile 2>&1 | grep -v DEBUG_ ; true
+	echo "Doxygen docs in $(DOX_DIR)"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ libre is a Generic library for real-time communications with async IO support.
 
 ## Building
 
-libre is using GNU makefiles. Make and OpenSSL development headers must be
+libre is using CMake. CMake and OpenSSL development headers must be
 installed before building.
 
 
@@ -43,6 +43,13 @@ $ cmake -B build
 $ cmake --build build -j
 $ sudo cmake --install build
 $ sudo ldconfig
+```
+
+### Build/run tests
+
+```
+cmake -B build && cmake --build build -t retest -j
+build/test/retest -rv
 ```
 
 On some distributions, /usr/local/lib may not be included in ld.so.conf. 


### PR DESCRIPTION
`retest` target is not needed for normal builds and should be build separate (includes automatic `re/libre` target):

```bash
cmake -B build && cmake --build build -t retest -j
```