### PR TITLE
sa: add sa_struct_get_size() to check size

### DIFF
--- a/include/re_sa.h
+++ b/include/re_sa.h
@@ -72,6 +72,7 @@ bool     sa_is_any(const struct sa *sa);
 
 void     sa_set_scopeid(struct sa *sa, uint32_t scopeid);
 uint32_t sa_scopeid(const struct sa *sa);
+size_t   sa_struct_get_size(void);
 
 struct re_printf;
 int      sa_print_addr(struct re_printf *pf, const struct sa *sa);

--- a/src/sa/sa.c
+++ b/src/sa/sa.c
@@ -753,3 +753,14 @@ uint32_t sa_scopeid(const struct sa *sa)
 #endif
 	return 0;
 }
+
+
+/**
+ * Get the size of 'struct sa' as compiled by the library
+ *
+ * @return Size of 'struct sa' in bytes
+ */
+size_t sa_struct_get_size(void)
+{
+	return sizeof(struct sa);
+}

--- a/test/sa.c
+++ b/test/sa.c
@@ -212,6 +212,12 @@ int test_sa_class(void)
 	uint32_t i;
 	int err = 0;
 
+	/*
+	 * NOTE: The application and library must use the same build flags,
+	 *       so that the size of "struct sa" is the same.
+	 */
+	ASSERT_EQ(sizeof(struct sa), sa_struct_get_size());
+
 	for (i=0; i<RE_ARRAY_SIZE(testv); i++) {
 		struct sa sa;
 		int lo, ll, any;


### PR DESCRIPTION
The application and library must use the same build flags when building struct sa.

If different build flags are used, random and mysterious crashes may occur.