### PR TITLE
aubuf: set sample format when frame is read

### DIFF
--- a/rem/aubuf/aubuf.c
+++ b/rem/aubuf/aubuf.c
@@ -89,6 +89,7 @@ static void read_auframe(struct aubuf *ab, struct auframe *af)
 		af->srate     = f->af.srate;
 		af->ch	      = f->af.ch;
 		af->timestamp = f->af.timestamp;
+		af->fmt       = f->af.fmt;
 
 		if (!mbuf_get_left(f->mb)) {
 			mem_deref(f);


### PR DESCRIPTION
It is possible that the reader expects a different sample format then stored
in the audio buffer.
