### PR TITLE
ci: avoid hardcoded OpenSSL path on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     - name: openssl path macos
       if: ${{ runner.os == 'macOS' }}
       run: |
-        echo "OPENSSL_ROOT_DIR=/usr/local/opt/openssl" >> $GITHUB_ENV
+        echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl)" >> $GITHUB_ENV
 
     - name: fix flaky azure mirrors
       if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
Avoid hardcoded OpenSSL path on macOS