### PR TITLE
aubuf: set auframe fields correct in read_auframe loop

### DIFF
--- a/rem/aubuf/aubuf.c
+++ b/rem/aubuf/aubuf.c
@@ -73,6 +73,7 @@ static void read_auframe(struct aubuf *ab, struct auframe *af)
 	size_t sample_size = aufmt_sample_size(af->fmt);
 	size_t sz = auframe_size(af);
 	uint8_t *p = af->sampv;
+	bool first = true;
 
 	while (le) {
 		struct frame *f = le->data;
@@ -85,11 +86,13 @@ static void read_auframe(struct aubuf *ab, struct auframe *af)
 		(void)mbuf_read_mem(f->mb, p, n);
 		ab->cur_sz -= n;
 
-		af->id	      = f->af.id;
-		af->srate     = f->af.srate;
-		af->ch	      = f->af.ch;
-		af->timestamp = f->af.timestamp;
-		af->fmt       = f->af.fmt;
+		if (first) {
+			af->id	      = f->af.id;
+			af->srate     = f->af.srate;
+			af->ch	      = f->af.ch;
+			af->timestamp = f->af.timestamp;
+			af->fmt       = f->af.fmt;
+		}
 
 		if (!mbuf_get_left(f->mb)) {
 			mem_deref(f);
@@ -105,6 +108,7 @@ static void read_auframe(struct aubuf *ab, struct auframe *af)
 
 		p  += n;
 		sz -= n;
+		first = false;
 	}
 }
 

--- a/test/aubuf.c
+++ b/test/aubuf.c
@@ -122,7 +122,6 @@ static int test_aubuf_auframe(void)
 
 	/* write first frame (filling with wish_sz) */
 	auframe_init(&af, AUFMT_FLOAT, sampv_in, FRAMES, 48000, 2);
-	af.timestamp = 0;
 	af_in = af;
 
 	dt = FRAMES * AUDIO_TIMEBASE / (af_in.srate * af_in.ch);
@@ -190,7 +189,7 @@ static int test_aubuf_auframe(void)
 
 	TEST_EQUALS(2, af_out.ch);
 	TEST_EQUALS(48000, af_out.srate);
-	TEST_EQUALS(3 * dt, af_out.timestamp);
+	TEST_EQUALS(2 * dt, af_out.timestamp);
 
 	TEST_MEMCMP(sampv_in, sizeof(sampv_in), sampv_out, sizeof(sampv_out));
 	TEST_EQUALS(0, aubuf_cur_size(ab));


### PR DESCRIPTION
This avoids that the timestamp is overwritten with an intermediate timestamp if
the loop in read_auframe() is traversed more then once.

This lead to ugly ringtone artifacts.