### PR TITLE
tmr: add tmr_continue()

### DIFF
--- a/include/re_tmr.h
+++ b/include/re_tmr.h
@@ -40,6 +40,9 @@ int      tmr_status(struct re_printf *pf, void *unused);
 void     tmr_init(struct tmr *tmr);
 void     tmr_start_dbg(struct tmr *tmr, uint64_t delay, tmr_h *th, void *arg,
 		   const char *file, int line);
+void     tmr_continue_dbg(struct tmr *tmr, uint64_t delay,
+                   tmr_h *th, void *arg,
+		   const char *file, int line);
 uint32_t tmrl_count(struct tmrl *tmrl);
 
 
@@ -55,6 +58,19 @@ uint32_t tmrl_count(struct tmrl *tmrl);
  */
 #define tmr_start(tmr, delay, th, arg)                                        \
 	tmr_start_dbg(tmr, delay, th, arg, __FILE__, __LINE__)
+
+/**
+ * @def tmr_continue(tmr, delay, th, arg)
+ *
+ * Continue a previously started timer with exactly added delay
+ *
+ * @param tmr   Timer to start
+ * @param delay Timer delay in [ms]
+ * @param th    Timeout handler
+ * @param arg   Handler argument
+ */
+#define tmr_continue(tmr, delay, th, arg)                                     \
+	tmr_continue_dbg(tmr, delay, th, arg, __FILE__, __LINE__)
 
 void     tmr_cancel(struct tmr *tmr);
 uint64_t tmr_get_expire(const struct tmr *tmr);

--- a/src/tmr/tmr.c
+++ b/src/tmr/tmr.c
@@ -382,7 +382,8 @@ void tmr_init(struct tmr *tmr)
 }
 
 
-void tmr_start_dbg(struct tmr *tmr, uint64_t delay, tmr_h *th, void *arg,
+static void tmr_startcont_dbg(struct tmr *tmr, uint64_t delay, bool syncnow,
+                   tmr_h *th, void *arg,
 		   const char *file, int line)
 {
 	struct tmrl *tmrl = re_tmrl_get();
@@ -420,7 +421,9 @@ void tmr_start_dbg(struct tmr *tmr, uint64_t delay, tmr_h *th, void *arg,
 		return;
 	}
 
-	tmr->jfs = delay + tmr_jiffies();
+	if (syncnow)
+		tmr->jfs = tmr_jiffies();
+	tmr->jfs += delay;
 
 	if (delay == 0) {
 		le = list_apply(&tmrl->list, true, inspos_handler_0,
@@ -443,6 +446,20 @@ void tmr_start_dbg(struct tmr *tmr, uint64_t delay, tmr_h *th, void *arg,
 	}
 
 	mtx_unlock(lock);
+}
+
+
+void tmr_start_dbg(struct tmr *tmr, uint64_t delay, tmr_h *th, void *arg,
+		   const char *file, int line)
+{
+	tmr_startcont_dbg(tmr, delay, true, th, arg, file, line);
+}
+
+
+void tmr_continue_dbg(struct tmr *tmr, uint64_t delay, tmr_h *th, void *arg,
+		   const char *file, int line)
+{
+	tmr_startcont_dbg(tmr, delay, false, th, arg, file, line);
 }
 
 


### PR DESCRIPTION
to allow jiffie-accurate interval timer continuation
usually called from within the handler function

RTP timing can normally be derived best from an audio source.
This does not work when delivering content from a file, or when
delivering generated content.

The `tmr_continue()` call is a slight modification of `tmr_start()`
and can be used to continue a timer after an internal, which is
added to the current timeout, avoiding stacking timing errors.