### PR TITLE
atomic: Fix missing memory order arguments in MSVC atomic functions

### DIFF
--- a/include/re_atomic.h
+++ b/include/re_atomic.h
@@ -526,7 +526,7 @@ static __forceinline void _re_atomic_store(
 }
 
 static __forceinline unsigned __int64 _re_atomic_load(
-	size_t size, const void *a)
+	size_t size, const void *a, unsigned int mo)
 {
 	unsigned __int64 v;
 	assert(size == 1u || size == 2u || size == 4u || size == 8u);
@@ -591,7 +591,7 @@ static __forceinline void _re_atomic_store(
 }
 
 static __forceinline unsigned __int64 _re_atomic_load(
-	size_t size, const void *a)
+	size_t size, const void *a, unsigned int mo)
 {
 	unsigned __int64 v;
 	assert(size == 1u || size == 2u || size == 4u || size == 8u);
@@ -625,7 +625,7 @@ static __forceinline unsigned __int64 _re_atomic_load(
 #else
 
 static __forceinline void _re_atomic_store(
-	size_t size, void *a, unsigned __int64 v)
+	size_t size, void *a, unsigned __int64 v, unsigned int mo)
 {
 	assert(size == 1u || size == 2u || size == 4u || size == 8u);
 	_ReadWriteBarrier();
@@ -695,7 +695,7 @@ static __forceinline void _re_atomic_store(
 }
 
 static __forceinline unsigned __int64 _re_atomic_load(
-	size_t size, void *a)
+	size_t size, const void *a, unsigned int mo)
 {
 	unsigned __int64 v;
 	assert(size == 1u || size == 2u || size == 4u || size == 8u);
@@ -723,7 +723,7 @@ static __forceinline unsigned __int64 _re_atomic_load(
 	_re_atomic_store(sizeof(*(_a)), _a, _v, _mo);
 
 #define re_atomic_load(_a, _mo) \
-	_re_atomic_load(sizeof(*(_a)), _a)
+	_re_atomic_load(sizeof(*(_a)), _a, _mo)
 
 static __forceinline unsigned __int64 _re_atomic_exchange(
 	size_t size, void *a, unsigned __int64 v)


### PR DESCRIPTION
Fixes https://github.com/baresip/re/issues/763.

Also adds a missing `const` qualification in one `_re_atomic_load`.

This is not tested on ARM. @alfredh, please, test if it compiles for you.