### PR TITLE
main: add re_thread_enter/leave polling check

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1215,6 +1215,9 @@ void re_thread_enter(void)
 		return;
 	}
 
+	if (!re_atomic_rlx(&re->polling))
+		return;
+
 	re_lock(re);
 
 	/* set only for non-re threads */
@@ -1235,6 +1238,10 @@ void re_thread_leave(void)
 		DEBUG_WARNING("re_thread_leave: re not ready\n");
 		return;
 	}
+
+	if (!re_atomic_rlx(&re->polling))
+		return;
+
 	/* Dummy async event, to ensure timers are properly handled */
 	if (re->async)
 		re_thread_async(NULL, NULL, NULL);


### PR DESCRIPTION
`re_lock()`/`re_unlock()` should only be needed if `re_main()` is running.