### PR TITLE
jbuf: refactor frame calculation

### DIFF
--- a/include/re_jbuf.h
+++ b/include/re_jbuf.h
@@ -36,3 +36,5 @@ int  jbuf_drain(struct jbuf *jb, struct rtp_header *hdr, void **mem);
 void jbuf_flush(struct jbuf *jb);
 int  jbuf_stats(const struct jbuf *jb, struct jbuf_stat *jstat);
 int  jbuf_debug(struct re_printf *pf, const struct jbuf *jb);
+uint32_t jbuf_frames(const struct jbuf *jb);
+uint32_t jbuf_packets(const struct jbuf *jb);

--- a/src/jbuf/jbuf.c
+++ b/src/jbuf/jbuf.c
@@ -542,6 +542,17 @@ int jbuf_drain(struct jbuf *jb, struct rtp_header *hdr, void **mem)
 	*hdr = f->hdr;
 	*mem = mem_ref(f->mem);
 
+	/* decrease not equal frames */
+	if (f->le.next) {
+		struct packet *next_f = f->le.next->data;
+
+		if (f->hdr.ts != next_f->hdr.ts)
+			--jb->nf;
+	}
+	else {
+		--jb->nf;
+	}
+
 	packet_deref(jb, f);
 
 out:

--- a/test/jbuf.c
+++ b/test/jbuf.c
@@ -47,6 +47,7 @@ int test_jbuf(void)
 	DEBUG_INFO("test frame: One frame\n");
 	memset(&hdr, 0, sizeof(hdr));
 	hdr.seq = 160;
+	hdr.ts = 1;
 	err = jbuf_put(jb, &hdr, frv[0]);
 	if (err)
 		goto out;
@@ -173,6 +174,7 @@ int test_jbuf_adaptive(void)
 	/* Two frames */
 	DEBUG_INFO("test frame: Two frames\n");
 	hdr.seq = 160;
+	hdr.ts = 160;
 	err = jbuf_put(jb, &hdr, frv[0]);
 	TEST_ERR(err);
 	TEST_EQUALS(EALREADY, jbuf_put(jb, &hdr, frv[0]));
@@ -181,6 +183,7 @@ int test_jbuf_adaptive(void)
 	TEST_EQUALS(ENOENT, jbuf_get(jb, &hdr2, &mem));
 
 	hdr.seq = 161;
+	hdr.ts = 161;
 	err = jbuf_put(jb, &hdr, frv[1]);
 	TEST_ERR(err);
 
@@ -199,37 +202,133 @@ int test_jbuf_adaptive(void)
 	DEBUG_INFO("test frame: Four frames\n");
 	jbuf_flush(jb);
 	hdr.seq = 320;
+	hdr.ts = 320;
 	err = jbuf_put(jb, &hdr, frv[0]);
 	TEST_ERR(err);
 
 	hdr.seq = 480;
+	hdr.ts = 480;
 	err = jbuf_put(jb, &hdr, frv[1]);
 	TEST_ERR(err);
 
 	hdr.seq = 490;
+	hdr.ts = 490;
 	err = jbuf_put(jb, &hdr, frv[2]);
 	TEST_ERR(err);
 
 	hdr.seq = 491;
+	hdr.ts = 491;
 	err = jbuf_put(jb, &hdr, frv[3]);
 	TEST_ERR(err);
 
-	TEST_EQUALS(EAGAIN, jbuf_get(jb, &hdr2, &mem));
+	err = jbuf_get(jb, &hdr2, &mem);
+	TEST_EQUALS(EAGAIN, err);
 	TEST_EQUALS(320, hdr2.seq);
 	TEST_EQUALS(mem, frv[0]);
 	mem = mem_deref(mem);
 
-	TEST_EQUALS(EAGAIN, jbuf_get(jb, &hdr2, &mem));
+	err = jbuf_get(jb, &hdr2, &mem);
+	TEST_EQUALS(EAGAIN, err);
 	TEST_EQUALS(480, hdr2.seq);
 	TEST_EQUALS(mem, frv[1]);
 	mem = mem_deref(mem);
 
-	TEST_EQUALS(0, jbuf_get(jb, &hdr2, &mem));
+	err = jbuf_get(jb, &hdr2, &mem);
+	TEST_EQUALS(0, err);
 	TEST_EQUALS(490, hdr2.seq);
 	TEST_EQUALS(mem, frv[2]);
 	mem = mem_deref(mem);
 
-	TEST_EQUALS(ENOENT, jbuf_get(jb, &hdr2, &mem));
+	err = jbuf_get(jb, &hdr2, &mem);
+	TEST_EQUALS(ENOENT, err);
+
+	err = 0;
+
+ out:
+	mem_deref(jb);
+	mem_deref(mem);
+	for (i=0; i<RE_ARRAY_SIZE(frv); i++)
+		mem_deref(frv[i]);
+
+	return err;
+}
+
+
+int test_jbuf_adaptive_video(void)
+{
+	struct rtp_header hdr, hdr2;
+	struct jbuf *jb = NULL;
+	char *frv[4];
+	uint32_t i;
+	void *mem = NULL;
+	int err;
+
+	memset(frv, 0, sizeof(frv));
+	memset(&hdr, 0, sizeof(hdr));
+	memset(&hdr2, 0, sizeof(hdr2));
+	hdr.ssrc = 1;
+
+	err = jbuf_alloc(&jb, 1, 10);
+	TEST_ERR(err);
+	err = jbuf_set_type(jb, JBUF_ADAPTIVE);
+	TEST_ERR(err);
+
+	for (i=0; i<RE_ARRAY_SIZE(frv); i++) {
+		frv[i] = mem_zalloc(32, NULL);
+		if (frv[i] == NULL) {
+			err = ENOMEM;
+			goto out;
+		}
+	}
+
+	/* Four packets */
+	DEBUG_INFO("test: 4 packets (3 frames)\n");
+	jbuf_flush(jb);
+	hdr.seq = 320;
+	hdr.ts = 320;
+	err = jbuf_put(jb, &hdr, frv[0]);
+	TEST_ERR(err);
+	TEST_EQUALS(1, jbuf_frames(jb));
+
+	hdr.seq = 480;
+	hdr.ts = 320; /* Same frame */
+	err = jbuf_put(jb, &hdr, frv[1]);
+	TEST_ERR(err);
+	TEST_EQUALS(1, jbuf_frames(jb));
+
+	hdr.seq = 490;
+	hdr.ts = 490;
+	err = jbuf_put(jb, &hdr, frv[2]);
+	TEST_ERR(err);
+	TEST_EQUALS(2, jbuf_frames(jb));
+
+	hdr.seq = 491;
+	hdr.ts = 491;
+	err = jbuf_put(jb, &hdr, frv[3]);
+	TEST_ERR(err);
+	TEST_EQUALS(3, jbuf_frames(jb));
+
+	err = jbuf_get(jb, &hdr2, &mem);
+	TEST_EQUALS(EAGAIN, err);
+	TEST_EQUALS(320, hdr2.seq);
+	TEST_EQUALS(mem, frv[0]);
+	mem = mem_deref(mem);
+
+	err = jbuf_get(jb, &hdr2, &mem);
+	TEST_EQUALS(EAGAIN, err);
+	TEST_EQUALS(480, hdr2.seq);
+	TEST_EQUALS(mem, frv[1]);
+	mem = mem_deref(mem);
+
+	err = jbuf_get(jb, &hdr2, &mem);
+	TEST_EQUALS(0, err);
+	TEST_EQUALS(490, hdr2.seq);
+	TEST_EQUALS(mem, frv[2]);
+	mem = mem_deref(mem);
+
+	err = jbuf_get(jb, &hdr2, &mem);
+	TEST_EQUALS(ENOENT, err);
+
 	err = 0;
 
  out:

--- a/test/test.c
+++ b/test/test.c
@@ -122,6 +122,7 @@ static const struct test tests[] = {
 	TEST(test_ice_loop),
 	TEST(test_jbuf),
 	TEST(test_jbuf_adaptive),
+	TEST(test_jbuf_adaptive_video),
 	TEST(test_json),
 	TEST(test_json_file),
 	TEST(test_json_unicode),

--- a/test/test.h
+++ b/test/test.h
@@ -229,6 +229,7 @@ int test_ice_loop(void);
 int test_ice_cand(void);
 int test_jbuf(void);
 int test_jbuf_adaptive(void);
+int test_jbuf_adaptive_video(void);
 int test_json(void);
 int test_json_bad(void);
 int test_json_file(void);


### PR DESCRIPTION
A video frame is usually divided into smaller packets. Since the rtp marker bit is not very reliable (packet can be lost) or has a different meaning for audio codecs (talk spurt), frames should be detected by timestamp after sequence deduplication and ordering.