### PR TITLE
revert uri escaping commits

### DIFF
--- a/include/re_uri.h
+++ b/include/re_uri.h
@@ -43,7 +43,6 @@ int uri_param_escape(struct re_printf *pf, const struct pl *pl);
 int uri_param_unescape(struct re_printf *pf, const struct pl *pl);
 int uri_header_escape(struct re_printf *pf, const struct pl *pl);
 int uri_header_unescape(struct re_printf *pf, const struct pl *pl);
-int uri_display_name_escape(struct re_printf *pf, const struct pl *pl);
 int uri_escape_user(struct re_printf *pf, const char *user);
 int uri_escape(struct re_printf *pf, const char *uri);
 int uri_escape_pl(struct re_printf *pf, const struct pl *pl);

--- a/src/sip/contact.c
+++ b/src/sip/contact.c
@@ -47,15 +47,11 @@ int sip_contact_print(struct re_printf *pf, const struct sip_contact *contact)
 	if (!contact)
 		return 0;
 
-	if (contact->uri && strchr(contact->uri, ':')) {
-		return re_hprintf(pf, "Contact: <%H>\r\n", uri_escape,
-				  contact->uri);
-	}
-	else {
-		return re_hprintf(pf, "Contact: <sip:%H@%J%s>\r\n",
-				  uri_escape_user,
+	if (contact->uri && strchr(contact->uri, ':'))
+		return re_hprintf(pf, "Contact: <%s>\r\n", contact->uri);
+	else
+		return re_hprintf(pf, "Contact: <sip:%s@%J%s>\r\n",
 				  contact->uri,
 				  contact->addr,
 				  sip_transp_param(contact->tp));
-	}
 }

--- a/src/sip/ctrans.c
+++ b/src/sip/ctrans.c
@@ -59,8 +59,7 @@ static bool route_handler(const struct sip_hdr *hdr, const struct sip_msg *msg,
 			  void *arg)
 {
 	(void)msg;
-	return 0 != mbuf_printf(arg, "Route: %H\r\n", uri_escape_pl,
-				&hdr->val);
+	return 0 != mbuf_printf(arg, "Route: %r\r\n", &hdr->val);
 }
 
 

--- a/src/sip/dialog.c
+++ b/src/sip/dialog.c
@@ -113,19 +113,16 @@ int sip_dialog_alloc(struct sip_dialog **dlgp,
 	}
 
 	for (i=0; i<routec; i++) {
-		err |= mbuf_printf(dlg->mb, "Route: <%H;lr>\r\n", uri_escape,
-				   routev[i]);
+		err |= mbuf_printf(dlg->mb, "Route: <%s;lr>\r\n", routev[i]);
 		if (i == 0)
 			rend = dlg->mb->pos - 2;
 	}
-	err |= mbuf_printf(dlg->mb, "To: <%H>\r\n", uri_escape, to_uri);
+	err |= mbuf_printf(dlg->mb, "To: <%s>\r\n", to_uri);
 	dlg->cpos = dlg->mb->pos;
-	err |= mbuf_printf(dlg->mb, "From: ");
-	if (from_name) {
-		err |= mbuf_printf(dlg->mb, "\"%s\" ", from_name);
-	}
-	err |= mbuf_printf(dlg->mb, "<%H>", uri_escape, from_uri);
-	err |= mbuf_printf(dlg->mb, ";tag=%016llx\r\n", ltag);
+	err |= mbuf_printf(dlg->mb, "From: %s%s%s<%s>;tag=%016llx\r\n",
+			   from_name ? "\"" : "", from_name,
+			   from_name ? "\" " : "",
+			   from_uri, ltag);
 	if (err)
 		goto out;
 
@@ -159,7 +156,7 @@ static bool record_route_handler(const struct sip_hdr *hdr,
 	struct route_enc *renc = arg;
 	(void)msg;
 
-	if (mbuf_printf(renc->mb, "Route: %H\r\n", uri_escape_pl, &hdr->val))
+	if (mbuf_printf(renc->mb, "Route: %r\r\n", &hdr->val))
 		return true;
 
 	if (!renc->end)

--- a/src/sip/request.c
+++ b/src/sip/request.c
@@ -189,8 +189,7 @@ static int request(struct sip_request *req, enum sip_transp tp,
 		goto out;
 
 	mbuf_set_pos(mbs, 0);
-	err  = mbuf_printf(mb, "%s ", req->met);
-	err |= mbuf_printf(mb, "%H SIP/2.0\r\n", uri_escape, req->uri);
+	err  = mbuf_printf(mb, "%s %s SIP/2.0\r\n", req->met, req->uri);
 	err |= mbuf_printf(mb, "Via: SIP/2.0/%s %J;branch=%s;rport\r\n",
 			   sip_transp_name(tp), &laddr, branch);
 	err |= mbuf_write_mem(mb, mbuf_buf(mbs), mbuf_get_left(mbs));

--- a/src/uri/uric.c
+++ b/src/uri/uric.c
@@ -147,7 +147,7 @@ static int comp_escape(struct re_printf *pf, const struct pl *pl, esc_h *eh)
 			err = pf->vph(&c, 1, pf->arg);
 		}
 		else {
-			err = re_hprintf(pf, "%%%W", &c, 1);
+			err = re_hprintf(pf, "%%%02X", c);
 		}
 	}
 

--- a/test/uri.c
+++ b/test/uri.c
@@ -178,8 +178,7 @@ int test_uri_user(void)
 	} uriv[] = {
 		{"alice%40atlanta.com", "alice@atlanta.com"},
 		{"project%20x", "project x"},
-		{"*21%23", "*21#"},
-		{"*21%23%C3%A4%E2%82%AC%40%20", "*21#ä\xE2\x82\xAC@ "}
+		{"*21%23", "*21#"}
 	};
 	struct mbuf mbe, mbd;
 	int err = EINVAL;


### PR DESCRIPTION
Keep some API functions that could be useful for users of re.

This reverts commits:
- e03e282e743527b0f66c1a9c630462c97a561f87
- 5aaffb68aefcb56abb2cb3086bd3555a00efdae4

See BareSIP discussion for details: https://github.com/baresip/baresip/issues/2576
