### PR TITLE
aubuf: activate overrun/underrun statistics

### DIFF
--- a/include/rem_aubuf.h
+++ b/include/rem_aubuf.h
@@ -24,6 +24,8 @@ int  aubuf_get(struct aubuf *ab, uint32_t ptime, uint8_t *p, size_t sz);
 void aubuf_flush(struct aubuf *ab);
 int  aubuf_debug(struct re_printf *pf, const struct aubuf *ab);
 size_t aubuf_cur_size(const struct aubuf *ab);
+size_t aubuf_maxsz(const struct aubuf *ab);
+bool aubuf_started(const struct aubuf *ab);
 void aubuf_drop_auframe(struct aubuf *ab, const struct auframe *af);
 
 


### PR DESCRIPTION
This should make external overrun/underrun counting with remember of min/max
size obsolete.
