### PR TITLE
ci: compile choco openssl with --x86 for 32-bits

### DIFF
--- a/.github/workflows/cmake_win.yml
+++ b/.github/workflows/cmake_win.yml
@@ -30,13 +30,21 @@ jobs:
             generators: "Ninja",
             build: "Release"
           }
+        - {
+            name: "Windows (VS 2022/Ninja) Debug 32-bit",
+            os: windows-2022,
+            environment_script: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsamd64_x86.bat",
+            generators: "Ninja",
+            build: "Debug",
+            choco: "--x86"
+          }
 
     steps:
       - uses: actions/checkout@v3
 
       - name: Install deps
         run: |
-          choco install --no-progress openssl
+          choco install --no-progress ${{ matrix.config.choco }} openssl
 
       - name: Build
         shell: cmd


### PR DESCRIPTION
related to: https://github.com/baresip/re/pull/780

Build openssl for either 32-bit or 64-bit intel.


no solution for ARM yet ...
