### PR TITLE
main/init: fix upper signal handling

### DIFF
--- a/src/main/init.c
+++ b/src/main/init.c
@@ -36,7 +36,7 @@ static void signal_handler(int sig)
 		   &bt);
 	fflush(stderr);
 
-	exit(128 + sig);
+	(void)signal(sig, NULL);
 }
 
 

--- a/src/main/init.c
+++ b/src/main/init.c
@@ -28,6 +28,8 @@ static void signal_handler(int sig)
 {
 	struct btrace bt;
 
+	(void)signal(sig, NULL);
+
 	if (!exception_btrace)
 		return;
 
@@ -35,8 +37,6 @@ static void signal_handler(int sig)
 	re_fprintf(stderr, "Error: Signal (%d) %H\n", sig, btrace_println,
 		   &bt);
 	fflush(stderr);
-
-	(void)signal(sig, NULL);
 }
 
 


### PR DESCRIPTION
Prevent signal looping by unregistering instead of exiting to keep upper signal/coredump handling intact.