### PR TITLE
stun: add two deprecated STUN message attributes

### DIFF
--- a/include/re_stun.h
+++ b/include/re_stun.h
@@ -55,6 +55,11 @@ enum stun_attrib {
 	/* Comprehension-required range (0x0000-0x7FFF) */
 	STUN_ATTR_MAPPED_ADDR        = 0x0001,
 	STUN_ATTR_CHANGE_REQ         = 0x0003,
+
+	/* Deprecated STUN attributes */
+	STUN_ATTR_SRC_ADDR           = 0x0004,
+	STUN_ATTR_CHANGED_ADDR       = 0x0005,
+
 	STUN_ATTR_USERNAME           = 0x0006,
 	STUN_ATTR_MSG_INTEGRITY      = 0x0008,
 	STUN_ATTR_ERR_CODE           = 0x0009,

--- a/src/stun/attr.c
+++ b/src/stun/attr.c
@@ -204,6 +204,10 @@ int stun_attr_decode(struct stun_attr **attrp, struct mbuf *mb,
 
 	switch (attr->type) {
 
+	/* Deprecated STUN attributes */
+	case STUN_ATTR_SRC_ADDR:
+	case STUN_ATTR_CHANGED_ADDR:
+
 	case STUN_ATTR_MAPPED_ADDR:
 	case STUN_ATTR_ALT_SERVER:
 	case STUN_ATTR_RESP_ORIGIN:


### PR DESCRIPTION
The attributes SOURCE_ADDRESS and CHANGED_ADDRESS are contained in the STUN
response of e.g. stun.linphone.org. They simply should be ignored and not
terminate the call.
