### PR TITLE
vidmix: coverity fix

### DIFF
--- a/rem/vidmix/vidmix.c
+++ b/rem/vidmix/vidmix.c
@@ -62,13 +62,13 @@ static inline void clear_frame(struct vidframe *vf)
 
 static void clear_all(struct vidmix *mix)
 {
-	struct le *le;
-
-	for (le=mix->srcl.head; le; le=le->next) {
+	for (struct le *le=mix->srcl.head; le; le=le->next) {
 
 		struct vidmix_source *src = le->data;
 
+		mtx_lock(&src->mutex);
 		src->clear = true;
+		mtx_unlock(&src->mutex);
 	}
 }
 


### PR DESCRIPTION
New defect(s) Reported-by: Coverity Scan
Showing 12 of 12 defect(s)

** CID 462177:  Concurrent data access violations  (MISSING_LOCK)
/rem/vidmix/vidmix.c: 71 in clear_all()

________________________________________________________________________________________________________ *** CID 462177:  Concurrent data access violations  (MISSING_LOCK) /rem/vidmix/vidmix.c: 71 in clear_all()
65     	struct le *le;
66
67     	for (le=mix->srcl.head; le; le=le->next) {
68
69     		struct vidmix_source *src = le->data;
70
>>>     CID 462177:  Concurrent data access violations  (MISSING_LOCK)
>>>     Accessing "src->clear" without holding lock "vidmix_source.mutex". Elsewhere, "vidmix_source.clear" is accessed with "vidmix_source.mutex" held 5 out of 6 times.
71     		src->clear = true;
72     	}
73     }
74
75
76     static void destructor(void *arg)

** CID 462176:  Concurrent data access violations  (MISSING_LOCK)
/rem/aubuf/ajb.c: 155 in ajb_alloc()