### PR TITLE
sys/fs: fix fs_stdio_hide resource leak

### DIFF
--- a/src/sys/fs.c
+++ b/src/sys/fs.c
@@ -235,6 +235,9 @@ void fs_stdio_hide(void)
 #else
 	int fd = open("/dev/null", O_WRONLY);
 #endif
+	if (fd < 0)
+		return;
+
 	(void)dup2(fd, fileno(stdout));
 	(void)dup2(fd, fileno(stderr));
 

--- a/src/sys/fs.c
+++ b/src/sys/fs.c
@@ -237,6 +237,8 @@ void fs_stdio_hide(void)
 #endif
 	(void)dup2(fd, fileno(stdout));
 	(void)dup2(fd, fileno(stderr));
+
+	close(fd);
 }
 
 


### PR DESCRIPTION
*** CID 462173:  Resource leaks  (RESOURCE_LEAK)
Handle variable "fd" going out of scope leaks the handle.