### PR TITLE
sipreg: supports PNS custom contact URI

### DIFF
--- a/include/re_sipreg.h
+++ b/include/re_sipreg.h
@@ -35,3 +35,4 @@ void sipreg_incfailc(struct sipreg *reg);
 
 int sipreg_set_fbregint(struct sipreg *reg, uint32_t fbregint);
 void sipreg_set_srcport(struct sipreg *reg, uint16_t srcport);
+int sipreg_set_contact_params(struct sipreg *reg, const char *cparams);

--- a/test/mock/sipsrv.c
+++ b/test/mock/sipsrv.c
@@ -23,6 +23,13 @@ static bool sip_msg_handler(const struct sip_msg *msg, void *arg)
 	int err;
 
 	if (0 == pl_strcmp(&msg->met, "REGISTER")) {
+		mbuf_set_pos(msg->mb, 0);
+		if (sip_msg_decode(&srv->sip_msgs[srv->n_register_req],
+					msg->mb)) {
+			DEBUG_NOTICE("sip message cannot be parsed (%r)\n",
+					&msg->met);
+			return false;
+		}
 		++srv->n_register_req;
 	}
 	else {
@@ -55,6 +62,8 @@ static void destructor(void *arg)
 	srv->terminate = true;
 
 	sip_close(srv->sip, false);
+	for (unsigned i=0; i<RE_ARRAY_SIZE(srv->sip_msgs); i++)
+	    mem_deref(srv->sip_msgs[i]);
 	mem_deref(srv->sip);
 }
 

--- a/test/test.h
+++ b/test/test.h
@@ -508,6 +508,7 @@ struct sip_server {
 	bool terminate;
 
 	unsigned n_register_req;
+	struct sip_msg *sip_msgs[16];
 };
 
 int sip_server_alloc(struct sip_server **srvp);


### PR DESCRIPTION
Not sure how safe it is changing the interfaces, using it to show what's the change needed for https://github.com/baresip/baresip/pull/2600/

Both re and baresip do build and test passed after the change.