### PR TITLE
rtpext: add support for Two-Byte headers

### DIFF
--- a/include/re_rtpext.h
+++ b/include/re_rtpext.h
@@ -10,7 +10,8 @@
  */
 
 #define RTPEXT_HDR_SIZE        4
-#define RTPEXT_TYPE_MAGIC 0xbede  /* One-Byte header */
+#define RTPEXT_TYPE_MAGIC      0xbede  /* One-Byte header */
+#define RTPEXT_TYPE_MAGIC_LONG 0x1000  /* Two-Byte header */
 
 enum {
 	RTPEXT_ID_MIN  =  1,
@@ -20,18 +21,23 @@ enum {
 enum {
 	RTPEXT_LEN_MIN =  1,
 	RTPEXT_LEN_MAX = 16,
+	RTPEXT_LEN_MAX_LONG = 256,
 };
 
 
 /** Defines an RTP header extension */
 struct rtpext {
-	unsigned id:4;                /**< Identifier             */
-	unsigned len:4;               /**< Length of data [bytes] */
-	uint8_t data[RTPEXT_LEN_MAX]; /**< Data field             */
+	uint8_t id;                        /**< Identifier             */
+	uint8_t len;                       /**< Length of data [bytes] */
+	uint8_t data[RTPEXT_LEN_MAX_LONG]; /**< Data field             */
 };
 
 
 int rtpext_hdr_encode(struct mbuf *mb, size_t num_bytes);
+int rtpext_hdr_encode_long(struct mbuf *mb, size_t num_bytes);
 int rtpext_encode(struct mbuf *mb, uint8_t id, size_t len,
 		  const uint8_t *data);
+int rtpext_encode_long(struct mbuf *mb, uint8_t id, uint8_t length,
+		       const uint8_t *data);
 int rtpext_decode(struct rtpext *ext, struct mbuf *mb);
+int rtpext_decode_long(struct rtpext *ext, struct mbuf *mb);

--- a/src/rtpext/rtpext.c
+++ b/src/rtpext/rtpext.c
@@ -8,6 +8,7 @@
 #include <re_types.h>
 #include <re_mbuf.h>
 #include <re_net.h>
+#include <re_fmt.h>
 #include <re_rtpext.h>
 
 
@@ -20,7 +21,9 @@
  * RFC 8285 A General Mechanism for RTP Header Extensions
  *
  * - One-Byte Header:  Supported
- * - Two-Byte Header:  Not supported
+ * - Two-Byte Header:  Supported
+ *
+ * https://datatracker.ietf.org/doc/html/rfc8285
  */
 
 
@@ -46,6 +49,34 @@ int rtpext_hdr_encode(struct mbuf *mb, size_t num_bytes)
 	}
 
 	err |= mbuf_write_u16(mb, htons(RTPEXT_TYPE_MAGIC));
+	err |= mbuf_write_u16(mb, htons((uint16_t)(num_bytes / 4)));
+
+	return err;
+}
+
+
+/**
+ * Encode the Two-Byte header for all RTP extensions
+ *
+ * @param mb        Buffer to encode into
+ * @param num_bytes Total size for all RTP extensions (multiple of 4)
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int rtpext_hdr_encode_long(struct mbuf *mb, size_t num_bytes)
+{
+	int err = 0;
+
+	if (!mb || !num_bytes)
+		return EINVAL;
+
+	if (num_bytes & 0x3) {
+		DEBUG_WARNING("hdr_encode: num_bytes (%zu) must be multiple"
+			      " of 4\n", num_bytes);
+		return EINVAL;
+	}
+
+	err |= mbuf_write_u16(mb, htons(RTPEXT_TYPE_MAGIC_LONG));
 	err |= mbuf_write_u16(mb, htons((uint16_t)(num_bytes / 4)));
 
 	return err;
@@ -127,6 +158,81 @@ int rtpext_decode(struct rtpext *ext, struct mbuf *mb)
 	}
 
 	err = mbuf_read_mem(mb, ext->data, ext->len);
+	if (err)
+		return err;
+
+	/* skip padding */
+	while (mbuf_get_left(mb)) {
+		uint8_t pad = mbuf_buf(mb)[0];
+
+		if (pad != 0x00)
+			break;
+
+		mbuf_advance(mb, 1);
+	}
+
+	return 0;
+}
+
+
+/**
+ * Encode an RTP header extension with Two-Byte header
+ *
+ * @param mb   Buffer to encode into
+ * @param id   Identifier
+ * @param len  Length of data field
+ * @param data Data bytes
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int rtpext_encode_long(struct mbuf *mb, uint8_t id, uint8_t length,
+		       const uint8_t *data)
+{
+	if (!mb)
+		return EINVAL;
+
+	int err  = mbuf_write_u8(mb, id);
+	err     |= mbuf_write_u8(mb, length);
+
+	if (data && length)
+		err |= mbuf_write_mem(mb, data, length);
+
+	return err;
+}
+
+
+/**
+ * Decode an RTP header extension with Two-Byte header
+ *
+ * @param ext RTP Extension object
+ * @param mb  Buffer to decode from
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int rtpext_decode_long(struct rtpext *ext, struct mbuf *mb)
+{
+	if (!ext || !mb)
+		return EINVAL;
+
+	if (mbuf_get_left(mb) < 2)
+		return EBADMSG;
+
+	memset(ext, 0, sizeof(*ext));
+
+	ext->id  = mbuf_read_u8(mb);
+	ext->len = mbuf_read_u8(mb);
+
+	if (ext->id == 0) {
+		DEBUG_WARNING("decode_long: invalid ID %u\n", ext->id);
+		return EBADMSG;
+	}
+	if (ext->len > mbuf_get_left(mb)) {
+		DEBUG_WARNING("decode_long: short read (%zu > %zu)\n",
+			      ext->len, mbuf_get_left(mb));
+		return ENODATA;
+	}
+
+	int err = mbuf_read_mem(mb, ext->data, ext->len);
 	if (err)
 		return err;
 

--- a/test/rtpext.c
+++ b/test/rtpext.c
@@ -27,6 +27,173 @@ static const uint8_t packet_bytes[] = {
 };
 
 
+struct rtpext_header {
+	uint16_t type;
+	uint16_t num_bytes;
+};
+
+
+/* Common for One-Byte and Two-Byte headers */
+static int rtpext_hdr_decode(struct rtpext_header *hdr, struct mbuf *mb)
+{
+	if (mbuf_get_left(mb) < RTPEXT_HDR_SIZE)
+		return EBADMSG;
+
+	hdr->type      = ntohs(mbuf_read_u16(mb));
+	hdr->num_bytes = ntohs(mbuf_read_u16(mb)) * 4;
+
+	if (mbuf_get_left(mb) < hdr->num_bytes)
+		return EBADMSG;
+
+	return 0;
+}
+
+
+static int test_rtpext_long(void)
+{
+	static const uint8_t TEST_EXTENSION_ID_TWOBYTE = 0xf0;
+	static const size_t TEST_DATA_LENGTH = 3;
+	static const size_t NUM_BYTES = 8;
+	static const uint8_t packet[RTPEXT_HDR_SIZE + NUM_BYTES] = {
+		0x10, 0x00, 0x00, 0x02,
+		0xf0, 0x03, 0x01, 0x02,
+		0x03, 0x00, 0x00, 0x00
+	};
+
+	static const uint8_t data[TEST_DATA_LENGTH] = { 0x01, 0x02, 0x03 };
+
+	struct mbuf *mb = mbuf_alloc(1024);
+	if (!mb)
+		return ENOMEM;
+
+	struct rtpext_header hdr;
+	struct rtpext ext;
+
+	/* Encode packet */
+
+	int err = rtpext_hdr_encode_long(mb, NUM_BYTES);
+	ASSERT_EQ(0, err);
+
+	err = rtpext_encode_long(mb, TEST_EXTENSION_ID_TWOBYTE,
+				 TEST_DATA_LENGTH, data);
+	ASSERT_EQ(0, err);
+
+	/* padding */
+	mbuf_fill(mb, 0x00, 3);
+
+	TEST_MEMCMP(packet, sizeof(packet), mb->buf, mb->end);
+
+	mb->pos = 0;
+
+	/* Decode packet */
+
+	err = rtpext_hdr_decode(&hdr, mb);
+	ASSERT_EQ(0, err);
+
+	ASSERT_EQ(RTPEXT_TYPE_MAGIC_LONG, hdr.type);
+	ASSERT_EQ(NUM_BYTES,              hdr.num_bytes);
+
+	err = rtpext_decode_long(&ext, mb);
+	ASSERT_EQ(0, err);
+
+	ASSERT_EQ(TEST_EXTENSION_ID_TWOBYTE, ext.id);
+	ASSERT_EQ(TEST_DATA_LENGTH,          ext.len);
+	TEST_MEMCMP(data, sizeof(data), ext.data, ext.len);
+
+ out:
+	mem_deref(mb);
+
+	return err;
+}
+
+
+/*
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |       0x10    |    0x00       |           length=3            |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |      ID       |     L=0       |     ID        |     L=1       |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |       data    |    0 (pad)    |       ID      |      L=4      |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                          data                                 |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+*/
+static int test_rtpext_long_rfc(void)
+{
+	static const size_t NUM_BYTES = 12;
+	struct mbuf *mb = mbuf_alloc(1024);
+	if (!mb)
+		return ENOMEM;
+
+	int err = rtpext_hdr_encode_long(mb, NUM_BYTES);
+	ASSERT_EQ(0, err);
+
+	/* Encode */
+
+	err = rtpext_encode_long(mb, 0x80, 0, NULL);
+	ASSERT_EQ(0, err);
+
+	err = rtpext_encode_long(mb, 0x81, 1, (uint8_t *)"A" );
+	ASSERT_EQ(0, err);
+
+	/* padding */
+	mbuf_write_u8(mb, 0x00);
+
+	err = rtpext_encode_long(mb, 0x82, 4, (uint8_t *)"ABCD" );
+	ASSERT_EQ(0, err);
+
+	static const uint8_t packet[RTPEXT_HDR_SIZE + NUM_BYTES] = {
+		0x10, 0x00, 0x00, 0x03,
+		0x80, 0x00, 0x81, 0x01,
+		0x41, 0x00, 0x82, 0x04,
+		0x41, 0x42, 0x43, 0x44,
+	};
+
+	TEST_MEMCMP(packet, sizeof(packet), mb->buf, mb->end);
+
+	mb->pos = 0;
+
+	/* Decode */
+
+	struct rtpext_header hdr;
+
+	err = rtpext_hdr_decode(&hdr, mb);
+	ASSERT_EQ(0, err);
+
+	ASSERT_EQ(RTPEXT_TYPE_MAGIC_LONG, hdr.type);
+	ASSERT_EQ(NUM_BYTES,              hdr.num_bytes);
+
+	struct rtpext ext;
+
+	err = rtpext_decode_long(&ext, mb);
+	ASSERT_EQ(0, err);
+
+	ASSERT_EQ(0x80, ext.id);
+	ASSERT_EQ(0,    ext.len);
+
+	err = rtpext_decode_long(&ext, mb);
+	ASSERT_EQ(0, err);
+
+	ASSERT_EQ(0x81, ext.id);
+	ASSERT_EQ(1,    ext.len);
+	ASSERT_EQ(0x41,    ext.data[0]);
+
+	err = rtpext_decode_long(&ext, mb);
+	ASSERT_EQ(0, err);
+
+	ASSERT_EQ(0x82, ext.id);
+	ASSERT_EQ(4,    ext.len);
+	TEST_MEMCMP(&packet[12], 4, ext.data, ext.len);
+
+ out:
+	mem_deref(mb);
+	return err;
+}
+
+
 int test_rtpext(void)
 {
 	struct mbuf *mb = mbuf_alloc(sizeof(packet_bytes));
@@ -64,6 +231,14 @@ int test_rtpext(void)
 	ASSERT_EQ(1, ext.id);
 	ASSERT_EQ(1, ext.len);
 	ASSERT_EQ(0xe0, ext.data[0]);
+
+	err = test_rtpext_long();
+	if (err)
+		goto out;
+
+	err = test_rtpext_long_rfc();
+	if (err)
+		goto out;
 
  out:
 	mem_deref(mb);

--- a/test/rtpext.c
+++ b/test/rtpext.c
@@ -53,8 +53,8 @@ static int test_rtpext_long(void)
 {
 	static const uint8_t TEST_EXTENSION_ID_TWOBYTE = 0xf0;
 	static const size_t TEST_DATA_LENGTH = 3;
-	static const size_t NUM_BYTES = 8;
-	static const uint8_t packet[RTPEXT_HDR_SIZE + NUM_BYTES] = {
+#define NUM_BYTES_LONG 8
+	static const uint8_t packet[RTPEXT_HDR_SIZE + NUM_BYTES_LONG] = {
 		0x10, 0x00, 0x00, 0x02,
 		0xf0, 0x03, 0x01, 0x02,
 		0x03, 0x00, 0x00, 0x00
@@ -71,7 +71,7 @@ static int test_rtpext_long(void)
 
 	/* Encode packet */
 
-	int err = rtpext_hdr_encode_long(mb, NUM_BYTES);
+	int err = rtpext_hdr_encode_long(mb, NUM_BYTES_LONG);
 	ASSERT_EQ(0, err);
 
 	err = rtpext_encode_long(mb, TEST_EXTENSION_ID_TWOBYTE,
@@ -91,7 +91,7 @@ static int test_rtpext_long(void)
 	ASSERT_EQ(0, err);
 
 	ASSERT_EQ(RTPEXT_TYPE_MAGIC_LONG, hdr.type);
-	ASSERT_EQ(NUM_BYTES,              hdr.num_bytes);
+	ASSERT_EQ(NUM_BYTES_LONG,         hdr.num_bytes);
 
 	err = rtpext_decode_long(&ext, mb);
 	ASSERT_EQ(0, err);

--- a/test/rtpext.c
+++ b/test/rtpext.c
@@ -52,7 +52,7 @@ static int rtpext_hdr_decode(struct rtpext_header *hdr, struct mbuf *mb)
 static int test_rtpext_long(void)
 {
 	static const uint8_t TEST_EXTENSION_ID_TWOBYTE = 0xf0;
-	static const size_t TEST_DATA_LENGTH = 3;
+#define TEST_DATA_LENGTH 3
 #define NUM_BYTES_LONG 8
 	static const uint8_t packet[RTPEXT_HDR_SIZE + NUM_BYTES_LONG] = {
 		0x10, 0x00, 0x00, 0x02,
@@ -123,12 +123,12 @@ static int test_rtpext_long(void)
 */
 static int test_rtpext_long_rfc(void)
 {
-	static const size_t NUM_BYTES = 12;
+	static const size_t NUM_BYTES_RFC = 12;
 	struct mbuf *mb = mbuf_alloc(1024);
 	if (!mb)
 		return ENOMEM;
 
-	int err = rtpext_hdr_encode_long(mb, NUM_BYTES);
+	int err = rtpext_hdr_encode_long(mb, NUM_BYTES_RFC);
 	ASSERT_EQ(0, err);
 
 	/* Encode */
@@ -145,7 +145,7 @@ static int test_rtpext_long_rfc(void)
 	err = rtpext_encode_long(mb, 0x82, 4, (uint8_t *)"ABCD" );
 	ASSERT_EQ(0, err);
 
-	static const uint8_t packet[RTPEXT_HDR_SIZE + NUM_BYTES] = {
+	static const uint8_t packet[RTPEXT_HDR_SIZE + NUM_BYTES_RFC] = {
 		0x10, 0x00, 0x00, 0x03,
 		0x80, 0x00, 0x81, 0x01,
 		0x41, 0x00, 0x82, 0x04,
@@ -164,7 +164,7 @@ static int test_rtpext_long_rfc(void)
 	ASSERT_EQ(0, err);
 
 	ASSERT_EQ(RTPEXT_TYPE_MAGIC_LONG, hdr.type);
-	ASSERT_EQ(NUM_BYTES,              hdr.num_bytes);
+	ASSERT_EQ(NUM_BYTES_RFC,          hdr.num_bytes);
 
 	struct rtpext ext;
 

--- a/test/rtpext.c
+++ b/test/rtpext.c
@@ -123,7 +123,7 @@ static int test_rtpext_long(void)
 */
 static int test_rtpext_long_rfc(void)
 {
-	static const size_t NUM_BYTES_RFC = 12;
+#define NUM_BYTES_RFC (12)
 	struct mbuf *mb = mbuf_alloc(1024);
 	if (!mb)
 		return ENOMEM;


### PR DESCRIPTION
Add support for Two-Byte headers for RTP Header Extensions.

Reference: https://datatracker.ietf.org/doc/html/rfc8285
