### PR TITLE
hmac: add support for native Windows API

### DIFF
--- a/src/hmac/hmac_sha1.c
+++ b/src/hmac/hmac_sha1.c
@@ -11,8 +11,76 @@
 #include <openssl/err.h>
 #elif defined (__APPLE__)
 #include <CommonCrypto/CommonHMAC.h>
+#elif defined (WIN32)
+#include <windows.h>
+#include <wincrypt.h>
 #endif
 #include <re_hmac.h>
+
+
+#define DEBUG_MODULE "hmac"
+#define DEBUG_LEVEL 5
+#include <re_dbg.h>
+
+
+#if !defined (USE_OPENSSL) && defined (WIN32)
+static void compute_hash(ALG_ID alg_id, const void* data, size_t dataSize,
+			 uint8_t hashBuf[64], DWORD hashSize,
+			 const void *hmacSecret, size_t hmacSecretSize)
+{
+	DWORD hashSizeSize = sizeof(hashSize);
+	HCRYPTPROV context;
+	HCRYPTKEY hmackey = 0;
+
+	CryptAcquireContext(&context, 0, 0, PROV_RSA_FULL,CRYPT_VERIFYCONTEXT);
+
+	struct HmacSecretBlob {
+		BLOBHEADER header;
+		DWORD hmacSecretSize;
+		BYTE hmacSecret[1];
+	};
+	size_t hmacSecretBlobSize =
+		MAX(offsetof(struct HmacSecretBlob, hmacSecret) +
+		    hmacSecretSize, sizeof(struct HmacSecretBlob));
+	uint8_t blobData[256];
+	struct HmacSecretBlob* hmacSecretBlob
+		= (struct HmacSecretBlob*) ( blobData );
+
+	hmacSecretBlob->header.bType = PLAINTEXTKEYBLOB;
+	hmacSecretBlob->header.bVersion = CUR_BLOB_VERSION;
+	hmacSecretBlob->header.reserved = 0;
+	hmacSecretBlob->header.aiKeyAlg = CALG_RC2;
+	hmacSecretBlob->hmacSecretSize = (DWORD)hmacSecretSize;
+	memcpy(hmacSecretBlob->hmacSecret, hmacSecret, hmacSecretSize);
+
+	CryptImportKey(context, blobData, (DWORD)hmacSecretBlobSize, 0,
+		       CRYPT_IPSEC_HMAC_KEY, &hmackey);
+
+	HCRYPTHASH hash;
+
+	if (CryptCreateHash(context, CALG_HMAC, hmackey, 0, &hash)) {
+
+		HMAC_INFO info = { 0 };
+		info.HashAlgid = alg_id;
+
+		CryptSetHashParam(hash, HP_HMAC_INFO, (BYTE *)&info, 0);
+
+		CryptGetHashParam(hash, HP_HASHSIZE,
+				  (BYTE *)&hashSize, &hashSizeSize, 0);
+		if (hashSize == 0) {
+			DEBUG_WARNING("INVALID HASHSIZE\n");
+		}
+
+		CryptHashData(hash, (BYTE*)data, (DWORD)dataSize, 0);
+		CryptGetHashParam(hash, HP_HASHVAL, hashBuf, &hashSize, 0);
+
+		CryptDestroyHash(hash);
+	}
+
+	CryptDestroyKey(hmackey);
+	CryptReleaseContext(context, 0);
+}
+#endif
 
 
 /**
@@ -41,6 +109,10 @@ void hmac_sha1(const uint8_t *k,  /* secret key */
 	(void)t;
 
 	CCHmac(kCCHmacAlgSHA1, k, lk, d, ld, out);
+
+#elif defined (WIN32)
+	compute_hash(CALG_SHA1, d, ld,
+		     out, (DWORD)t, k, lk);
 #else
 	(void)k;
 	(void)lk;
@@ -71,6 +143,10 @@ void hmac_sha256(const uint8_t *key, size_t key_len,
 	(void)out_len;
 
 	CCHmac(kCCHmacAlgSHA256, key, key_len, data, data_len, out);
+
+#elif defined (WIN32)
+	compute_hash(CALG_SHA_256, data, data_len,
+		     out, (DWORD)out_len, key, key_len);
 #else
 	(void)key;
 	(void)key_len;

--- a/src/md5/wrap.c
+++ b/src/md5/wrap.c
@@ -47,7 +47,7 @@ void md5(const uint8_t *d, size_t n, uint8_t *md)
 	CryptAcquireContext(&context, 0, 0, PROV_RSA_FULL,CRYPT_VERIFYCONTEXT);
 
 	CryptCreateHash(context, CALG_MD5, 0, 0, &hash);
-	CryptHashData(hash, d, n, 0);
+	CryptHashData(hash, d, (DWORD)n, 0);
 	CryptGetHashParam(hash, HP_HASHVAL, md, &hash_size, 0);
 
 	CryptDestroyHash(hash);

--- a/src/sha/wrap.c
+++ b/src/sha/wrap.c
@@ -28,7 +28,7 @@ static void compute_hash(ALG_ID alg_id, const void *data, size_t data_size,
 	CryptAcquireContext(&context, 0, 0, PROV_RSA_FULL,CRYPT_VERIFYCONTEXT);
 
 	CryptCreateHash(context, alg_id, 0, 0, &hash);
-	CryptHashData(hash, (BYTE*)data, data_size, 0);
+	CryptHashData(hash, (BYTE*)data, (DWORD)data_size, 0);
 	CryptGetHashParam(hash, HP_HASHVAL, md, &hash_size, 0);
 
 	CryptDestroyHash(hash);


### PR DESCRIPTION
* Add support for native HMAC-SHA api for Windows.
* Also fixes warnings in md5 and sha

This makes it possible to compile libre on Windows without using OpenSSL.
