### PR TITLE
CI: Add support for building Windows ARM

### DIFF
--- a/.github/workflows/cmake_win.yml
+++ b/.github/workflows/cmake_win.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         config:
         - {
-            name: "Windows (VS 2022/Ninja) Debug",
+            name: "Windows Debug",
             os: windows-2022,
             environment_script: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat",
             generators: "Ninja",
@@ -27,7 +27,7 @@ jobs:
             testing: true
           }
         - {
-            name: "Windows (VS 2022/Ninja) Release",
+            name: "Windows Release",
             os: windows-2022,
             environment_script: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat",
             generators: "Ninja",
@@ -37,7 +37,7 @@ jobs:
             testing: true
           }
         - {
-            name: "Windows (VS 2022/Ninja) Debug 32-bit",
+            name: "Windows Debug 32-bit",
             os: windows-2022,
             environment_script: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsamd64_x86.bat",
             generators: "Ninja",
@@ -48,7 +48,7 @@ jobs:
             testing: true
           }
         - {
-            name: "Windows (VS 2022/Ninja) Debug ARM 64-bit",
+            name: "Windows Debug ARM64",
             os: windows-2022,
             environment_script: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsamd64_arm64.bat",
             generators: "Ninja",

--- a/.github/workflows/cmake_win.yml
+++ b/.github/workflows/cmake_win.yml
@@ -21,14 +21,20 @@ jobs:
             os: windows-2022,
             environment_script: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat",
             generators: "Ninja",
-            build: "Debug"
+            build: "Debug",
+            openssl: true,
+            disable_openssl: "OFF",
+            testing: true
           }
         - {
             name: "Windows (VS 2022/Ninja) Release",
             os: windows-2022,
             environment_script: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat",
             generators: "Ninja",
-            build: "Release"
+            build: "Release",
+            openssl: true,
+            disable_openssl: "OFF",
+            testing: true
           }
         - {
             name: "Windows (VS 2022/Ninja) Debug 32-bit",
@@ -36,13 +42,37 @@ jobs:
             environment_script: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsamd64_x86.bat",
             generators: "Ninja",
             build: "Debug",
-            choco: "--x86"
+            openssl: true,
+            disable_openssl: "OFF",
+            choco: "--x86",
+            testing: true
+          }
+        - {
+            name: "Windows (VS 2022/Ninja) Debug 32-bit",
+            os: windows-2022,
+            environment_script: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsamd64_x86.bat",
+            generators: "Ninja",
+            build: "Debug",
+            openssl: true,
+            disable_openssl: "OFF",
+            testing: true
+          }
+        - {
+            name: "Windows (VS 2022/Ninja) Debug ARM 64-bit",
+            os: windows-2022,
+            environment_script: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsamd64_arm64.bat",
+            generators: "Ninja",
+            build: "Debug",
+            openssl: false,
+            disable_openssl: "ON",
+            testing: false
           }
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install deps
+      - name: Install OpenSSL
+        if: ${{ matrix.config.openssl }}
         run: |
           choco install --no-progress ${{ matrix.config.choco }} openssl
 
@@ -52,10 +82,11 @@ jobs:
           call "${{ matrix.config.environment_script }}"
           cmake --version
           ninja --version
-          cmake -S . -B build -G "${{ matrix.config.generators }}" -DCMAKE_C_FLAGS="/WX" -DCMAKE_BUILD_TYPE=${{ matrix.config.build }}
+          cmake -S . -B build -G "${{ matrix.config.generators }}" -DCMAKE_C_FLAGS="/WX" -DCMAKE_BUILD_TYPE=${{ matrix.config.build }} -DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL=${{ matrix.config.disable_openssl }}
           cmake --build build --parallel -t retest
 
       - name: retest
+        if: ${{ matrix.config.testing }}
         shell: cmd
         run: |
           build\test\retest.exe -a -v

--- a/.github/workflows/cmake_win.yml
+++ b/.github/workflows/cmake_win.yml
@@ -48,16 +48,6 @@ jobs:
             testing: true
           }
         - {
-            name: "Windows (VS 2022/Ninja) Debug 32-bit",
-            os: windows-2022,
-            environment_script: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsamd64_x86.bat",
-            generators: "Ninja",
-            build: "Debug",
-            openssl: true,
-            disable_openssl: "OFF",
-            testing: true
-          }
-        - {
             name: "Windows (VS 2022/Ninja) Debug ARM 64-bit",
             os: windows-2022,
             environment_script: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsamd64_arm64.bat",


### PR DESCRIPTION
This is based on this PR: https://github.com/baresip/re/pull/780

It adds support for building on Windows ARM.

For this build configuration, OpenSSL is disabled and native crypto APIs are used.
