### PR TITLE
cmake: remove obsolete $<INSTALL_INTERFACE:include for re-objs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -668,7 +668,6 @@ target_include_directories(re-objs PRIVATE
   ${OPENSSL_INCLUDE_DIR} ${ZLIB_INCLUDE_DIRS})
 target_include_directories(re-objs PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
   )
 
 


### PR DESCRIPTION
https://github.com/baresip/re/pull/845

Thanks to Kai Pastor for review comment.
