### PR TITLE
hmac,md5,sha: add mbedtls backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,6 +535,7 @@ else()
   list(APPEND SRCS
     src/aes/stub.c
     src/hmac/hmac.c
+    src/tls/stub.c
   )
 endif()
 

--- a/cmake/FindMBEDTLS.cmake
+++ b/cmake/FindMBEDTLS.cmake
@@ -16,7 +16,7 @@ find_library(MBEDTLS_LIBRARY
 )
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(MbedTLS DEFAULT_MSG
+find_package_handle_standard_args(MBEDTLS DEFAULT_MSG
     MBEDTLS_INCLUDE_DIR MBEDTLS_LIBRARY)
 
 if(MBEDTLS_FOUND)

--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -1,0 +1,30 @@
+find_path(MBEDTLS_INCLUDE_DIR
+    NAMES mbedtls/ssl.h mbedtls/md.h mbedtls/md5.h mbedtls/error.h
+          mbedtls/sha1.h mbedtls/sha256.h
+    HINTS
+      "${MBEDTLS_INCLUDE_DIRS}"
+      "${MBEDTLS_HINTS}/include"
+    PATHS /usr/local/include /usr/include
+)
+
+find_library(MBEDTLS_LIBRARY
+  NAMES mbedtls mbedx509 mbedcrypto
+  HINTS
+    "${MBEDTLS_LIBRARY_DIRS}"
+    "${MBEDTLS_HINTS}/lib"
+  PATHS /usr/local/lib /usr/lib
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(MbedTLS DEFAULT_MSG
+    MBEDTLS_INCLUDE_DIR MBEDTLS_LIBRARY)
+
+if(MBEDTLS_FOUND)
+  set( MBEDTLS_INCLUDE_DIRS ${MBEDTLS_INCLUDE_DIR} )
+  set( MBEDTLS_LIBRARIES ${MBEDTLS_LIBRARY} )
+else()
+  set( MBEDTLS_INCLUDE_DIRS )
+  set( MBEDTLS_LIBRARIES )
+endif()
+
+mark_as_advanced(MBEDTLS_INCLUDE_DIRS MBEDTLS_LIBRARIES)

--- a/cmake/re-config.cmake
+++ b/cmake/re-config.cmake
@@ -2,14 +2,19 @@ include(CheckIncludeFile)
 include(CheckFunctionExists)
 include(CheckSymbolExists)
 
+option(USE_MBEDTLS "Enable MbedTLS" OFF)
+
 find_package(Backtrace)
 find_package(Threads REQUIRED)
 find_package(ZLIB)
-find_package(OpenSSL "1.1.1")
+
+if (USE_MBEDTLS)
 find_package(MBEDTLS)
+else()
+find_package(OpenSSL "1.1.1")
+endif()
 
 option(USE_OPENSSL "Enable OpenSSL" ${OPENSSL_FOUND})
-option(USE_MBEDTLS "Enable MbedTLS" ${MBEDTLS_FOUND})
 option(USE_UNIXSOCK "Enable Unix Domain Sockets" ON)
 option(USE_TRACE "Enable Tracing helpers" OFF)
 

--- a/cmake/re-config.cmake
+++ b/cmake/re-config.cmake
@@ -6,10 +6,10 @@ find_package(Backtrace)
 find_package(Threads REQUIRED)
 find_package(ZLIB)
 find_package(OpenSSL "1.1.1")
-find_package(MbedTLS)
+find_package(MBEDTLS)
 
 option(USE_OPENSSL "Enable OpenSSL" ${OPENSSL_FOUND})
-option(USE_MBEDTLS "Enable MbedTLS" ${MbedTLS_FOUND})
+option(USE_MBEDTLS "Enable MbedTLS" ${MBEDTLS_FOUND})
 option(USE_UNIXSOCK "Enable Unix Domain Sockets" ON)
 option(USE_TRACE "Enable Tracing helpers" OFF)
 

--- a/cmake/re-config.cmake
+++ b/cmake/re-config.cmake
@@ -6,8 +6,10 @@ find_package(Backtrace)
 find_package(Threads REQUIRED)
 find_package(ZLIB)
 find_package(OpenSSL "1.1.1")
+find_package(MbedTLS)
 
 option(USE_OPENSSL "Enable OpenSSL" ${OPENSSL_FOUND})
+option(USE_MBEDTLS "Enable MbedTLS" ${MbedTLS_FOUND})
 option(USE_UNIXSOCK "Enable Unix Domain Sockets" ON)
 option(USE_TRACE "Enable Tracing helpers" OFF)
 
@@ -132,6 +134,12 @@ if(USE_OPENSSL)
     -DUSE_OPENSSL_HMAC
     -DUSE_OPENSSL_SRTP
     -DUSE_TLS
+  )
+endif()
+
+if(USE_MBEDTLS)
+  list(APPEND RE_DEFINITIONS
+    -DUSE_MBEDTLS
   )
 endif()
 

--- a/src/hmac/hmac_sha1.c
+++ b/src/hmac/hmac_sha1.c
@@ -14,6 +14,9 @@
 #elif defined (WIN32)
 #include <windows.h>
 #include <wincrypt.h>
+#elif defined (USE_MBEDTLS)
+#include <mbedtls/md.h>
+#include <mbedtls/error.h>
 #endif
 #include <re_hmac.h>
 
@@ -113,6 +116,16 @@ void hmac_sha1(const uint8_t *k,  /* secret key */
 #elif defined (WIN32)
 	compute_hash(CALG_SHA1, d, ld,
 		     out, (DWORD)t, k, lk);
+#elif defined (MBEDTLS_MD_C)
+	int err;
+	(void)t;
+
+	err = mbedtls_md_hmac(mbedtls_md_info_from_type(MBEDTLS_MD_SHA1),
+			      k, lk, d, ld, out);
+	if (err)
+		DEBUG_WARNING("mbedtls_md_hmac: %s\n",
+			      mbedtls_high_level_strerr(err));
+
 #else
 	(void)k;
 	(void)lk;
@@ -147,6 +160,15 @@ void hmac_sha256(const uint8_t *key, size_t key_len,
 #elif defined (WIN32)
 	compute_hash(CALG_SHA_256, data, data_len,
 		     out, (DWORD)out_len, key, key_len);
+#elif defined (MBEDTLS_MD_C)
+	int err;
+	(void)out_len;
+
+	err = mbedtls_md_hmac(mbedtls_md_info_from_type(MBEDTLS_MD_SHA256),
+			      key, key_len, data, data_len, out);
+	if (err)
+		DEBUG_WARNING("mbedtls_md_hmac: %s\n",
+			      mbedtls_high_level_strerr(err));
 #else
 	(void)key;
 	(void)key_len;

--- a/src/md5/wrap.c
+++ b/src/md5/wrap.c
@@ -12,6 +12,9 @@
 #elif defined (WIN32)
 #include <windows.h>
 #include <wincrypt.h>
+#elif defined (USE_MBEDTLS)
+#include <mbedtls/md5.h>
+#include <mbedtls/error.h>
 #endif
 #include <re_types.h>
 #include <re_fmt.h>
@@ -19,6 +22,10 @@
 #include <re_mbuf.h>
 #include <re_md5.h>
 
+
+#define DEBUG_MODULE "md5"
+#define DEBUG_LEVEL 5
+#include <re_dbg.h>
 
 /**
  * Calculate the MD5 hash from a buffer
@@ -52,6 +59,13 @@ void md5(const uint8_t *d, size_t n, uint8_t *md)
 
 	CryptDestroyHash(hash);
 	CryptReleaseContext(context, 0);
+#elif defined (MBEDTLS_MD_C)
+	int err;
+
+	err = mbedtls_md5(d, n, md);
+	if (err)
+		DEBUG_WARNING("mbedtls_md5: %s\n",
+			      mbedtls_high_level_strerr(err));
 #else
 #error missing MD5 backend
 #endif

--- a/src/sha/wrap.c
+++ b/src/sha/wrap.c
@@ -14,9 +14,17 @@
 #elif defined (WIN32)
 #include <windows.h>
 #include <wincrypt.h>
+#elif defined (USE_MBEDTLS)
+#include <mbedtls/sha1.h>
+#include <mbedtls/sha256.h>
+#include <mbedtls/error.h>
 #endif
 #include <re_sha.h>
 
+
+#define DEBUG_MODULE "sha"
+#define DEBUG_LEVEL 5
+#include <re_dbg.h>
 
 #if !defined (USE_OPENSSL) && defined (WIN32)
 static void compute_hash(ALG_ID alg_id, const void *data, size_t data_size,
@@ -52,6 +60,13 @@ void sha1(const uint8_t *d, size_t n, uint8_t *md)
 	CC_SHA1(d, (uint32_t)n, md);
 #elif defined (WIN32)
 	compute_hash(CALG_SHA1, d, n, md, SHA1_DIGEST_SIZE);
+#elif defined (MBEDTLS_MD_C)
+	int err;
+
+	err = mbedtls_sha1(d, n, md);
+	if (err)
+		DEBUG_WARNING("mbedtls_sha1: %s\n",
+			      mbedtls_high_level_strerr(err));
 #else
 	(void)d;
 	(void)n;
@@ -76,6 +91,13 @@ void sha256(const uint8_t *d, size_t n, uint8_t *md)
 	CC_SHA256(d, (uint32_t)n, md);
 #elif defined (WIN32)
 	compute_hash(CALG_SHA_256, d, n, md, SHA256_DIGEST_SIZE);
+#elif defined (MBEDTLS_MD_C)
+	int err;
+
+	err = mbedtls_sha256(d, n, md, 0);
+	if (err)
+		DEBUG_WARNING("mbedtls_sha256: %s\n",
+			      mbedtls_high_level_strerr(err));
 #else
 	(void)d;
 	(void)n;

--- a/src/tls/stub.c
+++ b/src/tls/stub.c
@@ -1,0 +1,469 @@
+/**
+ * @file tls/stub.c TLS empty stub
+ *
+# Copyright (C) 2023 Christian Spielberger
+ */
+#include <string.h>
+#include <re_types.h>
+#include <re_mbuf.h>
+#include <re_sa.h>
+#include <re_srtp.h>
+#include <re_tls.h>
+
+
+int tls_alloc(struct tls **tlsp, enum tls_method method, const char *keyfile,
+	      const char *pwd)
+{
+	(void)tlsp;
+	(void)method;
+	(void)keyfile;
+	(void)pwd;
+	return ENOSYS;
+}
+
+
+int tls_add_ca(struct tls *tls, const char *cafile)
+{
+	(void)tls;
+	(void)cafile;
+	return ENOSYS;
+}
+
+int tls_add_cafile_path(struct tls *tls, const char *cafile,
+	const char *capath)
+{
+	(void)tls;
+	(void)cafile;
+	(void)capath;
+	return ENOSYS;
+}
+
+
+int tls_add_capem(const struct tls *tls, const char *capem)
+{
+	(void)tls;
+	(void)capem;
+	return ENOSYS;
+}
+
+
+int tls_add_crlpem(const struct tls *tls, const char *pem)
+{
+	(void)tls;
+	(void)pem;
+	return ENOSYS;
+}
+
+
+int tls_set_selfsigned_rsa(struct tls *tls, const char *cn, size_t bits)
+{
+	(void)tls;
+	(void)cn;
+	(void)bits;
+	return ENOSYS;
+}
+
+
+int tls_set_selfsigned_ec(struct tls *tls, const char *cn,
+	const char *curve_n)
+{
+	(void)tls;
+	(void)cn;
+	(void)curve_n;
+	return ENOSYS;
+}
+
+
+int tls_set_certificate_pem(struct tls *tls, const char *cert, size_t len_cert,
+			    const char *key, size_t len_key)
+{
+	(void)tls;
+	(void)cert;
+	(void)len_cert;
+	(void)key;
+	(void)len_key;
+	return ENOSYS;
+}
+
+
+int tls_set_certificate_der(struct tls *tls, enum tls_keytype keytype,
+			    const uint8_t *cert, size_t len_cert,
+			    const uint8_t *key, size_t len_key)
+{
+	(void)tls;
+	(void)keytype;
+	(void)cert;
+	(void)len_cert;
+	(void)key;
+	(void)len_key;
+	return ENOSYS;
+}
+
+
+int tls_set_certificate(struct tls *tls, const char *cert, size_t len)
+{
+	(void)tls;
+	(void)cert;
+	(void)len;
+	return ENOSYS;
+}
+
+
+void tls_set_verify_client(struct tls *tls)
+{
+	(void)tls;
+}
+
+
+void tls_set_verify_client_trust_all(struct tls *tls)
+{
+	(void)tls;
+}
+
+
+int tls_set_verify_client_handler(struct tls_conn *tc, int depth,
+	int (*verifyh) (int ok, void *arg), void *arg)
+{
+	(void)tc;
+	(void)depth;
+	(void)verifyh;
+	(void)arg;
+	return ENOSYS;
+}
+
+
+int tls_set_srtp(struct tls *tls, const char *suites)
+{
+	(void)tls;
+	(void)suites;
+	return ENOSYS;
+}
+
+
+int tls_fingerprint(const struct tls *tls, enum tls_fingerprint type,
+		    uint8_t *md, size_t size)
+{
+	(void)tls;
+	(void)type;
+	(void)md;
+	(void)size;
+	return ENOSYS;
+}
+
+
+int tls_peer_fingerprint(const struct tls_conn *tc, enum tls_fingerprint type,
+			 uint8_t *md, size_t size)
+{
+	(void)tc;
+	(void)type;
+	(void)md;
+	(void)size;
+	return ENOSYS;
+}
+
+
+int tls_peer_common_name(const struct tls_conn *tc, char *cn, size_t size)
+{
+	(void)tc;
+	(void)cn;
+	(void)size;
+	return ENOSYS;
+}
+
+
+int tls_set_verify_purpose(struct tls *tls, const char *purpose)
+{
+	(void)tls;
+	(void)purpose;
+	return ENOSYS;
+}
+
+
+int tls_peer_verify(const struct tls_conn *tc)
+{
+	(void)tc;
+	return ENOSYS;
+}
+
+
+int tls_srtp_keyinfo(const struct tls_conn *tc, enum srtp_suite *suite,
+		     uint8_t *cli_key, size_t cli_key_size,
+		     uint8_t *srv_key, size_t srv_key_size)
+{
+	(void)tc;
+	(void)suite;
+	(void)cli_key;
+	(void)cli_key_size;
+	(void)srv_key;
+	(void)srv_key_size;
+	return ENOSYS;
+}
+
+
+const char *tls_cipher_name(const struct tls_conn *tc)
+{
+	(void)tc;
+	return NULL;
+}
+
+
+int tls_set_ciphers(struct tls *tls, const char *cipherv[], size_t count)
+{
+	(void)tls;
+	(void)cipherv;
+	(void)count;
+	return ENOSYS;
+}
+
+
+int tls_set_verify_server(struct tls_conn *tc, const char *host)
+{
+	(void)tc;
+	(void)host;
+	return ENOSYS;
+}
+
+
+int tls_get_issuer(struct tls *tls, struct mbuf *mb)
+{
+	(void)tls;
+	(void)mb;
+	return ENOSYS;
+}
+
+
+int tls_get_subject(struct tls *tls, struct mbuf *mb)
+{
+	(void)tls;
+	(void)mb;
+	return ENOSYS;
+}
+
+
+void tls_disable_verify_server(struct tls *tls)
+{
+	(void)tls;
+}
+
+
+int tls_set_min_proto_version(struct tls *tls, int version)
+{
+	(void)tls;
+	(void)version;
+	return ENOSYS;
+}
+
+
+int tls_set_max_proto_version(struct tls *tls, int version)
+{
+	(void)tls;
+	(void)version;
+	return ENOSYS;
+}
+
+
+int tls_set_session_reuse(struct tls *tls, int enabled)
+{
+	(void)tls;
+	(void)enabled;
+	return ENOSYS;
+}
+
+
+bool tls_get_session_reuse(const struct tls_conn *tc)
+{
+	(void)tc;
+	return false;
+}
+
+
+int tls_reuse_session(const struct tls_conn *tc)
+{
+	(void)tc;
+	return ENOSYS;
+}
+
+
+bool tls_session_reused(const struct tls_conn *tc)
+{
+	(void)tc;
+	return false;
+}
+
+
+int tls_update_sessions(const struct tls_conn *tc)
+{
+	(void)tc;
+	return ENOSYS;
+}
+
+
+void tls_set_posthandshake_auth(struct tls *tls, int enabled)
+{
+	(void)tls;
+	(void)enabled;
+}
+
+
+int tls_conn_change_cert(struct tls_conn *tc, const char *file)
+{
+	(void)tc;
+	(void)file;
+	return ENOSYS;
+}
+
+
+int tls_start_tcp(struct tls_conn **ptc, struct tls *tls,
+		  struct tcp_conn *tcp, int layer)
+{
+	(void)ptc;
+	(void)tls;
+	(void)tcp;
+	(void)layer;
+	return ENOSYS;
+}
+
+
+int tls_verify_client_post_handshake(struct tls_conn *tc)
+{
+	(void)tc;
+	return ENOSYS;
+}
+
+
+const struct tcp_conn *tls_get_tcp_conn(const struct tls_conn *tc)
+{
+	(void)tc;
+	return NULL;
+}
+
+
+int dtls_listen(struct dtls_sock **sockp, const struct sa *laddr,
+		struct udp_sock *us, uint32_t htsize, int layer,
+		dtls_conn_h *connh, void *arg)
+{
+	(void)sockp;
+	(void)laddr;
+	(void)us;
+	(void)htsize;
+	(void)layer;
+	(void)connh;
+	(void)arg;
+	return ENOSYS;
+}
+
+
+struct udp_sock *dtls_udp_sock(struct dtls_sock *sock)
+{
+	(void)sock;
+	return NULL;
+}
+
+
+void dtls_set_mtu(struct dtls_sock *sock, size_t mtu)
+{
+	(void)sock;
+	(void)mtu;
+}
+
+
+int dtls_connect(struct tls_conn **ptc, struct tls *tls,
+		 struct dtls_sock *sock, const struct sa *peer,
+		 dtls_estab_h *estabh, dtls_recv_h *recvh,
+		 dtls_close_h *closeh, void *arg)
+{
+	(void)ptc;
+	(void)tls;
+	(void)sock;
+	(void)peer;
+	(void)estabh;
+	(void)recvh;
+	(void)closeh;
+	(void)arg;
+	return ENOSYS;
+}
+
+
+int dtls_accept(struct tls_conn **ptc, struct tls *tls,
+		struct dtls_sock *sock,
+		dtls_estab_h *estabh, dtls_recv_h *recvh,
+		dtls_close_h *closeh, void *arg)
+{
+	(void)ptc;
+	(void)tls;
+	(void)sock;
+	(void)estabh;
+	(void)recvh;
+	(void)closeh;
+	(void)arg;
+	return ENOSYS;
+}
+
+
+int dtls_send(struct tls_conn *tc, struct mbuf *mb)
+{
+	(void)tc;
+	(void)mb;
+	return ENOSYS;
+}
+
+
+void dtls_set_handlers(struct tls_conn *tc, dtls_estab_h *estabh,
+		       dtls_recv_h *recvh, dtls_close_h *closeh, void *arg)
+{
+	(void)tc;
+	(void)estabh;
+	(void)recvh;
+	(void)closeh;
+	(void)arg;
+}
+
+
+const struct sa *dtls_peer(const struct tls_conn *tc)
+{
+	(void)tc;
+	return NULL;
+}
+
+
+void dtls_set_peer(struct tls_conn *tc, const struct sa *peer)
+{
+	(void)tc;
+	(void)peer;
+}
+
+
+void dtls_recv_packet(struct dtls_sock *sock, const struct sa *src,
+		      struct mbuf *mb)
+{
+	(void)sock;
+	(void)src;
+	(void)mb;
+}
+
+
+void dtls_set_single(struct dtls_sock *sock, bool single)
+{
+	(void)sock;
+	(void)single;
+}
+
+
+int tls_set_certificate_openssl(struct tls *tls, struct x509_st *cert,
+				struct evp_pkey_st *pkey, bool up_ref)
+{
+	(void)tls;
+	(void)cert;
+	(void)pkey;
+	(void)up_ref;
+	return ENOSYS;
+}
+
+
+int tls_add_certf(struct tls *tls, const char *certf, const char *host)
+{
+	(void)tls;
+	(void)certf;
+	(void)host;
+	return ENOSYS;
+}


### PR DESCRIPTION
We are evaluating re/baresip on Cortex M7/M4 with Zephyr.

First step is to build re without TLS support. But at least the hash functions needs an MbedTLS backend.

Build with:
```
cd build
cmake -DUSE_OPENSSL=no ..
make
```