### PR TITLE
aes: correct parameters for stub

### DIFF
--- a/src/aes/stub.c
+++ b/src/aes/stub.c
@@ -9,7 +9,7 @@
 
 int aes_alloc(struct aes **stp, enum aes_mode mode,
 	      const uint8_t *key, size_t key_bits,
-	      const uint8_t iv[AES_BLOCK_SIZE])
+	      const uint8_t *iv)
 {
 	(void)stp;
 	(void)mode;
@@ -20,9 +20,9 @@ int aes_alloc(struct aes **stp, enum aes_mode mode,
 }
 
 
-void aes_set_iv(struct aes *st, const uint8_t iv[AES_BLOCK_SIZE])
+void aes_set_iv(struct aes *aes, const uint8_t *iv)
 {
-	(void)st;
+	(void)aes;
 	(void)iv;
 }
 


### PR DESCRIPTION
When building with
```
cd build
cmake -DUSE_OPENSSL=no ..
make
```

There are warnings that the parameters of functions in stub.c mismatch.

relates to: https://github.com/baresip/re/pull/871