### PR TITLE
fmt: fix format string in fmt_timestamp()

### DIFF
--- a/src/fmt/time.c
+++ b/src/fmt/time.c
@@ -127,5 +127,5 @@ int fmt_timestamp(struct re_printf *pf, void *arg)
 #endif
 	(void)arg;
 
-	return re_hprintf(pf, "%02u:%02u:%02u.%03d", h, m, s, ms);
+	return re_hprintf(pf, "%02u:%02u:%02u.%03llu", h, m, s, ms);
 }


### PR DESCRIPTION
copied from https://github.com/baresip/re/pull/758