### PR TITLE
sipsess: allow UPDATE and INFO in early dialog

### DIFF
--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -100,6 +100,14 @@ static void invite_resp_handler(int err, const struct sip_msg *msg, void *arg)
 				goto out;
 		}
 
+		if (pl_isset(&msg->to.tag)) {
+			err = sip_dialog_established(sess->dlg) ?
+					sip_dialog_update(sess->dlg, msg) :
+					sip_dialog_create(sess->dlg, msg);
+			if (err)
+				goto out;
+		}
+
 		if (sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE, "100rel")
 				&& sess->rel100_supported) {
 			if (sdp && !sess->sent_offer) {
@@ -107,9 +115,6 @@ static void invite_resp_handler(int err, const struct sip_msg *msg, void *arg)
 				err = sess->offerh(&desc, msg, sess->arg);
 			}
 
-			err |= sip_dialog_established(sess->dlg) ?
-					sip_dialog_update(sess->dlg, msg) :
-					sip_dialog_create(sess->dlg, msg);
 			err |= sipsess_prack(sess, msg->cseq.num, msg->rel_seq,
 					     &msg->cseq.met, desc);
 			mem_deref(desc);

--- a/src/sipsess/listen.c
+++ b/src/sipsess/listen.c
@@ -253,7 +253,12 @@ static void target_refresh_handler(struct sipsess_sock *sock,
 		return;
 	}
 
-	if (got_offer || is_invite) {
+	if (got_offer && !sess->refresh_allowed) {
+		(void)sip_reply(sip, msg, 488, "Not Acceptable Here");
+		return;
+	}
+
+	if (is_invite || got_offer) {
 		err = sess->offerh(&desc, msg, sess->arg);
 		if (err) {
 			(void)sip_reply(sip, msg, 488,

--- a/src/sipsess/update.c
+++ b/src/sipsess/update.c
@@ -154,10 +154,6 @@ int sipsess_update(struct sipsess *sess)
 	if (!sess || sess->terminated || !sess->ctype || !sess->desc)
 		return EINVAL;
 
-	if ((!sess->established && !sess->refresh_allowed)
-	    || sess->awaiting_answer)
-		return EPROTO;
-
 	err = sipsess_request_alloc(&req, sess, sess->ctype, sess->desc, NULL,
 				    NULL);
 	if (err)

--- a/test/test.c
+++ b/test/test.c
@@ -190,6 +190,7 @@ static const struct test tests[] = {
 	TEST(test_sipsess_100rel_421),
 	TEST(test_sipsess_update_uac),
 	TEST(test_sipsess_update_uas),
+	TEST(test_sipsess_update_no_sdp),
 	TEST(test_srtp),
 	TEST(test_srtcp),
 	TEST(test_srtp_gcm),

--- a/test/test.h
+++ b/test/test.h
@@ -309,6 +309,7 @@ int test_sipsess_100rel_420(void);
 int test_sipsess_100rel_421(void);
 int test_sipsess_update_uac(void);
 int test_sipsess_update_uas(void);
+int test_sipsess_update_no_sdp(void);
 int test_srtp(void);
 int test_srtcp(void);
 int test_srtp_gcm(void);


### PR DESCRIPTION
According to [RFC 3261 section 12.1](https://www.rfc-editor.org/rfc/rfc3261#section-12.1)
```
2xx and 101-199 responses with a To tag, where the request was
INVITE, will establish a dialog.  A dialog established by a non-final
response to a request is in the "early" state and it is called an
early dialog.
```
This means that UPDATE (or INFO) requests are allowed within early dialogs (RFC 6086 mentions this in section 4.2.1, RFC 3311 in section 5.1).

However, UPDATEs with SDP offers or answers are still only allowed in "early confirmed dialogs" which have been confirmed by a PRACK (see RFCs 3311 and 6337).