### PR TITLE
Fix include of re_thread.h in re_tmr.h

### DIFF
--- a/include/re_tmr.h
+++ b/include/re_tmr.h
@@ -5,7 +5,7 @@
  */
 
 
-#include <re_thread.h>
+#include "re_thread.h"
 
 /**
  * Defines the timeout handler


### PR DESCRIPTION
This fixes an issue with cross-compiling and sysroot usage. It's the only patch I needed to add packages to Yocto for both libre and baresip.