### PR TITLE
sipsess/listen: Fix target_refresh_handler

### DIFF
--- a/src/sipsess/listen.c
+++ b/src/sipsess/listen.c
@@ -253,7 +253,7 @@ static void target_refresh_handler(struct sipsess_sock *sock,
 		return;
 	}
 
-	if (got_offer && !sess->refresh_allowed) {
+	if (got_offer && !sipsess_refresh_allowed(sess)) {
 		(void)sip_reply(sip, msg, 488, "Not Acceptable Here");
 		return;
 	}


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/baresip/re/pull/878 which results in re-INVITEs not being accepted at all.