### PR TITLE
tls: fix some doxygen warnings

### DIFF
--- a/include/re_tls.h
+++ b/include/re_tls.h
@@ -82,7 +82,7 @@ bool tls_get_session_reuse(const struct tls_conn *tc);
 int tls_reuse_session(const struct tls_conn *tc);
 bool tls_session_reused(const struct tls_conn *tc);
 int tls_update_sessions(const struct tls_conn *tc);
-void tls_set_posthandshake_auth(struct tls *tls, int enabled);
+void tls_set_posthandshake_auth(struct tls *tls, int value);
 
 /* TCP */
 

--- a/src/tls/stub.c
+++ b/src/tls/stub.c
@@ -100,10 +100,10 @@ int tls_set_certificate_der(struct tls *tls, enum tls_keytype keytype,
 }
 
 
-int tls_set_certificate(struct tls *tls, const char *cert, size_t len)
+int tls_set_certificate(struct tls *tls, const char *pem, size_t len)
 {
 	(void)tls;
-	(void)cert;
+	(void)pem;
 	(void)len;
 	return ENOSYS;
 }
@@ -298,10 +298,10 @@ int tls_update_sessions(const struct tls_conn *tc)
 }
 
 
-void tls_set_posthandshake_auth(struct tls *tls, int enabled)
+void tls_set_posthandshake_auth(struct tls *tls, int value)
 {
 	(void)tls;
-	(void)enabled;
+	(void)value;
 }
 
 


### PR DESCRIPTION
```
/home/alfredh/git/re/src/tls/openssl/tls.c:919: warning: argument 'pem' of command @param is not found in the argument list of tls_set_certificate(struct tls *tls, const char *cert, size_t len)
/home/alfredh/git/re/src/tls/openssl/tls.c:919: warning: The following parameter of tls_set_certificate(struct tls *tls, const char *cert, size_t len) is not documented:
  parameter 'cert'
/home/alfredh/git/re/src/tls/openssl/tls.c:2100: warning: argument 'value' of command @param is not found in the argument list of tls_set_posthandshake_auth(struct tls *tls, int enabled)
/home/alfredh/git/re/src/tls/openssl/tls.c:2100: warning: The following parameter of tls_set_posthandshake_auth(struct tls *tls, int enabled) is not documented:
  parameter 'enabled'
```
