### PR TITLE
types: add re_assert and re_assert_se definition

### DIFF
--- a/include/re_types.h
+++ b/include/re_types.h
@@ -4,6 +4,7 @@
  * Copyright (C) 2010 Creytiv.com
  */
 
+#include <assert.h>
 #include <stddef.h>
 #include <sys/types.h>
 
@@ -269,4 +270,34 @@ typedef size_t re_sock_t;
 #define RE_ERRNO_SOCK errno
 #define RE_BAD_SOCK -1
 typedef int re_sock_t;
+#endif
+
+
+/* re_assert helpers */
+
+/**
+ * @def re_assert(expr)
+ *
+ * If expression is false, prints error and calls abort() (not in
+ * RELEASE/NDEBUG builds)
+ *
+ * @param expr   expression
+ */
+
+
+/**
+ * @def re_assert_se(expr)
+ *
+ * If expression is false, prints error and calls abort(),
+ * in RELEASE/NDEBUG builds expression is always executed and keeps side effect
+ *
+ * @param expr   expression
+ */
+
+#if defined(RELEASE) || defined(NDEBUG)
+#define re_assert(expr) (void)0
+#define re_assert_se(expr) do(expr) while(false)
+#else
+#define re_assert(expr) assert(expr)
+#define re_assert_se(expr) assert(expr)
 #endif

--- a/include/re_types.h
+++ b/include/re_types.h
@@ -296,7 +296,7 @@ typedef int re_sock_t;
 
 #if defined(RELEASE) || defined(NDEBUG)
 #define re_assert(expr) (void)0
-#define re_assert_se(expr) do(expr) while(false)
+#define re_assert_se(expr) do{(void)(expr);} while(false)
 #else
 #define re_assert(expr) assert(expr)
 #define re_assert_se(expr) assert(expr)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,10 +68,10 @@ find_package(re CONFIG REQUIRED HINTS ../cmake)
 set(SRCS
   aac.c
   aes.c
+  async.c
   aubuf.c
   aulevel.c
   auresamp.c
-  async.c
   av1.c
   base64.c
   bfcp.c
@@ -134,6 +134,7 @@ set(SRCS
   trace.c
   trice.c
   turn.c
+  types.c
   udp.c
   unixsock.c
   uri.c

--- a/test/test.c
+++ b/test/test.c
@@ -144,6 +144,7 @@ static const struct test tests[] = {
 	TEST(test_odict_array),
 	TEST(test_pcp),
 	TEST(test_remain),
+	TEST(test_re_assert_se),
 	TEST(test_rtmp_play),
 	TEST(test_rtmp_publish),
 #ifdef USE_TLS

--- a/test/test.h
+++ b/test/test.h
@@ -253,6 +253,7 @@ int test_trice_candpair(void);
 int test_trice_checklist(void);
 int test_trice_loop(void);
 int test_remain(void);
+int test_re_assert_se(void);
 int test_rtmp_play(void);
 int test_rtmp_publish(void);
 #ifdef USE_TLS

--- a/test/types.c
+++ b/test/types.c
@@ -1,0 +1,16 @@
+/**
+ * @file types.c Types Testcode
+ *
+ */
+#include <re.h>
+#include "test.h"
+
+int test_re_assert_se(void)
+{
+	int err;
+
+	re_assert(true);
+	re_assert_se(!(err = 0));
+
+	return err;
+}


### PR DESCRIPTION
`cmake -B build -DCMAKE_BUILD_TYPE=Debug`
```c
int err;
re_assert(!(err = myfunc())); /* myfunc() is executed and assert() calls abort() if expr is false */
re_assert_se(!(err = myfunc())); /* myfunc() is executed and assert() calls abort() if expr is false  */
```

`cmake -B build -DCMAKE_BUILD_TYPE=Release`
```c
int err;
re_assert(!(err = myfunc())); /* myfunc() and assert() are not executed in release builds */
re_assert_se(!(err = myfunc())); /* myfunc() is executed in release build (keeps side effect) but assert() is not called */
```