### PR TITLE
sip/auth: use long long for time_t (avoids 2038 bugs)

### DIFF
--- a/cmake/re-config.cmake
+++ b/cmake/re-config.cmake
@@ -188,3 +188,10 @@ else()
     set(CMAKE_ENABLE_EXPORTS ON)
   endif()
 endif()
+
+# Enable 64-bit time on 32-bit, to enable glibc >=2.34 2038 suppport
+check_symbol_exists("__GLIBC__" "stdlib.h" LIBC_IS_GLIBC)
+if(LIBC_IS_GLIBC AND CMAKE_SIZEOF_VOID_P EQUAL 4)
+  list(APPEND RE_DEFINITIONS -D_FILE_OFFSET_BITS=64)
+  list(APPEND RE_DEFINITIONS -D_TIME_BITS=64)
+endif()

--- a/src/sip/auth.c
+++ b/src/sip/auth.c
@@ -342,13 +342,13 @@ static int gen_nonce(char **noncep, time_t ts, const struct sa *src,
 	if (!mb)
 		return ENOMEM;
 
-	err = mbuf_printf(mb,"%lu%j%s", (long unsigned)ts, src, realm);
+	err = mbuf_printf(mb,"%llu%j%s", ts, src, realm);
 	if (err)
 		goto out;
 
 	md5(mb->buf, mb->end, key);
 	mbuf_rewind(mb);
-	err = mbuf_printf(mb,"%w%016lx", key, sizeof(key), (long unsigned)ts);
+	err = mbuf_printf(mb,"%w%016llx", key, sizeof(key), ts);
 	if (err)
 		goto out;
 


### PR DESCRIPTION
TODO:

check if all platforms use/support 64-bit `time_t`, looks like glibc needs `_TIME_BITS=64` on 32-bit:

https://sourceware.org/glibc/wiki/Y2038ProofnessDesign


| libc | type (`time_t`) | size |
| --- | --- | --- |
| musl 32-/64-bit | _Int64 | 64-bit |
| glibc >=2.34 32-bit _TIME_BITS=64 |  __time_64_t (__int64_t)  | 64-bit |
| glibc >=2.34 64-bit  |  __time_t (long int)  | 64-bit |
| win32 32-/64-bit | _time64 | 64-bit |
| win32 32-bit `_USE_32BIT_TIME_T` | _time32 | 32-bit |
| glibc >=2.34 32-bit  |  __time_t (long int)  | 32-bit |
| glibc <2.34 32-bit `_TIME_BITS=64` |   __time_t (long int)  | 32-bit |


