### PR TITLE
aufile: add methods to get size in bytes/length in ms

### DIFF
--- a/include/rem_aufile.h
+++ b/include/rem_aufile.h
@@ -24,3 +24,7 @@ int aufile_open(struct aufile **afp, struct aufile_prm *prm,
 		const char *filename, enum aufile_mode mode);
 int aufile_read(struct aufile *af, uint8_t *p, size_t *sz);
 int aufile_write(struct aufile *af, const uint8_t *p, size_t sz);
+// return the size in bytes
+size_t aufile_get_size(struct aufile *af);
+// return the length in ms
+size_t aufile_get_length(struct aufile *af, struct aufile_prm *prm);

--- a/rem/aufile/aufile.c
+++ b/rem/aufile/aufile.c
@@ -260,17 +260,21 @@ size_t aufile_get_length(struct aufile *af, struct aufile_prm *prm)
 	switch (prm->fmt) {
 		case AUFMT_PCMA:
 		case AUFMT_PCMU:
-			return af->datasize * prm->channels * prm->srate / 1000;
+			return af->datasize * prm->channels * prm->srate
+				/ 1000;
 		case AUFMT_S16LE:
-			return af->datasize * 2 * prm->channels * prm->srate / 1000;
+			return af->datasize * 2 * prm->channels * prm->srate
+				/ 1000;
 		case AUFMT_S24_3LE:
-			return af->datasize * 3 * prm->channels * prm->srate / 1000;
+			return af->datasize * 3 * prm->channels * prm->srate
+				/ 1000;
 		case AUFMT_S32LE:
 		case AUFMT_FLOAT:
-			return af->datasize * 4 * prm->channels * prm->srate / 1000;
+			return af->datasize * 4 * prm->channels * prm->srate
+			/ 1000;
 		default:
-			return EINVAL;
+			return 0;
 	}
 
-	return EINVAL;
+	return 0;
 }

--- a/rem/aufile/aufile.c
+++ b/rem/aufile/aufile.c
@@ -228,3 +228,49 @@ int aufile_write(struct aufile *af, const uint8_t *p, size_t sz)
 
 	return 0;
 }
+
+/**
+ * Get size of a WAV file in bytes
+ *
+ * @param af  Audio-file
+ *
+ * @return size in bytes if success, otherwise EINVAL
+ */
+size_t aufile_get_size(struct aufile *af)
+{
+	if (!af)
+		return EINVAL;
+
+	return af->datasize;
+}
+
+/**
+ * Get size of a WAV file in bytes
+ *
+ * @param af  Audio-file
+ * @param prm Audio file parameters from aufile_open
+ *
+ * @return length in ms if success, otherwise EINVAL
+ */
+size_t aufile_get_length(struct aufile *af, struct aufile_prm *prm)
+{
+	if (!af)
+		return EINVAL;
+
+	switch (prm->fmt) {
+		case AUFMT_PCMA:
+		case AUFMT_PCMU:
+			return af->datasize * prm->channels * prm->srate / 1000;
+		case AUFMT_S16LE:
+			return af->datasize * 2 * prm->channels * prm->srate / 1000;
+		case AUFMT_S24_3LE:
+			return af->datasize * 3 * prm->channels * prm->srate / 1000;
+		case AUFMT_S32LE:
+		case AUFMT_FLOAT:
+			return af->datasize * 4 * prm->channels * prm->srate / 1000;
+		default:
+			return EINVAL;
+	}
+
+	return EINVAL;
+}

--- a/rem/aufile/aufile.c
+++ b/rem/aufile/aufile.c
@@ -234,12 +234,12 @@ int aufile_write(struct aufile *af, const uint8_t *p, size_t sz)
  *
  * @param af  Audio-file
  *
- * @return size in bytes if success, otherwise EINVAL
+ * @return size in bytes if success, otherwise 0.
  */
 size_t aufile_get_size(struct aufile *af)
 {
 	if (!af)
-		return EINVAL;
+		return 0;
 
 	return af->datasize;
 }
@@ -250,12 +250,12 @@ size_t aufile_get_size(struct aufile *af)
  * @param af  Audio-file
  * @param prm Audio file parameters from aufile_open
  *
- * @return length in ms if success, otherwise EINVAL
+ * @return length in ms if success, otherwise 0.
  */
 size_t aufile_get_length(struct aufile *af, struct aufile_prm *prm)
 {
 	if (!af)
-		return EINVAL;
+		return 0;
 
 	switch (prm->fmt) {
 		case AUFMT_PCMA:

--- a/rem/aufile/aufile.c
+++ b/rem/aufile/aufile.c
@@ -245,7 +245,7 @@ size_t aufile_get_size(struct aufile *af)
 }
 
 /**
- * Get size of a WAV file in bytes
+ * Get length of a WAV file in ms
  *
  * @param af  Audio-file
  * @param prm Audio file parameters from aufile_open


### PR DESCRIPTION
Create two new functions:
- `aufile_get_size()`
- `aufile_get_length()`

The former returns the size in bytes, the latter the length in milliseconds.