### PR TITLE
async: signal ESHUTDOWN to all open worker callbacks

### DIFF
--- a/include/re_types.h
+++ b/include/re_types.h
@@ -242,6 +242,10 @@ typedef SSIZE_T ssize_t;
 #define EKEYREJECTED 129
 #endif
 
+/* Cannot send after transport endpoint shutdown */
+#ifndef ESHUTDOWN
+#define ESHUTDOWN 108
+#endif
 
 /*
  * Give the compiler a hint which branch is "likely" or "unlikely" (inspired

--- a/src/async/async.c
+++ b/src/async/async.c
@@ -96,6 +96,21 @@ static void async_destructor(void *data)
 		thrd_join(async->thrd[i], NULL);
 	}
 
+	/* Notify worker callbacks (so they can call destructors) */
+	struct le *le;
+	LIST_FOREACH(&async->workl, le)
+	{
+		struct async_work *work = le->data;
+		if (work->cb)
+			work->cb(ESHUTDOWN, work->arg);
+	}
+	LIST_FOREACH(&async->curl, le)
+	{
+		struct async_work *work = le->data;
+		if (work->cb)
+			work->cb(ESHUTDOWN, work->arg);
+	}
+
 	list_flush(&async->workl);
 	list_flush(&async->curl);
 	list_flush(&async->freel);


### PR DESCRIPTION
So worker callbacks can execute destructors etc.