### PR TITLE
ice: add candidate sdp mdns support

### DIFF
--- a/src/ice/connchk.c
+++ b/src/ice/connchk.c
@@ -400,6 +400,14 @@ static void pace_timeout(void *arg)
 }
 
 
+static void rcand_wait_timeout(void *arg)
+{
+	struct icem *icem = arg;
+
+	icem_conncheck_start(icem);
+}
+
+
 /**
  * Scheduling Checks
  *
@@ -413,6 +421,9 @@ int icem_conncheck_start(struct icem *icem)
 
 	if (!icem)
 		return EINVAL;
+
+	if (icem->rcand_wait)
+		tmr_start(&icem->tmr_rcand, 100, rcand_wait_timeout, icem);
 
 	err = icem_checklist_form(icem);
 	if (err)

--- a/src/ice/connchk.c
+++ b/src/ice/connchk.c
@@ -426,6 +426,7 @@ int icem_conncheck_start(struct icem *icem)
 		icem_printf(icem, "conncheck_start: "
 				  "waiting mDNS for remote candidate...\n");
 		tmr_start(&icem->tmr_rcand, 100, rcand_wait_timeout, icem);
+		return 0;
 	}
 
 	err = icem_checklist_form(icem);

--- a/src/ice/connchk.c
+++ b/src/ice/connchk.c
@@ -422,8 +422,11 @@ int icem_conncheck_start(struct icem *icem)
 	if (!icem)
 		return EINVAL;
 
-	if (icem->rcand_wait)
+	if (icem->rcand_wait) {
+		icem_printf(icem, "conncheck_start: "
+				  "waiting for remote candidate...");
 		tmr_start(&icem->tmr_rcand, 100, rcand_wait_timeout, icem);
+	}
 
 	err = icem_checklist_form(icem);
 	if (err)

--- a/src/ice/connchk.c
+++ b/src/ice/connchk.c
@@ -424,7 +424,7 @@ int icem_conncheck_start(struct icem *icem)
 
 	if (icem->rcand_wait) {
 		icem_printf(icem, "conncheck_start: "
-				  "waiting for remote candidate...");
+				  "waiting mDNS for remote candidate...\n");
 		tmr_start(&icem->tmr_rcand, 100, rcand_wait_timeout, icem);
 	}
 

--- a/src/ice/ice.h
+++ b/src/ice/ice.h
@@ -59,6 +59,7 @@ struct icem {
 	bool rmode_lite;             /**< Remote mode is Lite                */
 	enum ice_role lrole;         /**< Local role                         */
 	struct tmr tmr_pace;         /**< Timer for pacing STUN requests     */
+	struct tmr tmr_rcand;        /**< Timer for remote candidate wait    */
 	int proto;                   /**< Transport protocol                 */
 	int layer;                   /**< Protocol layer                     */
 	enum ice_checkl_state state; /**< State of the checklist             */
@@ -70,6 +71,7 @@ struct icem {
 	ice_connchk_h *chkh;         /**< Connectivity check handler         */
 	void *arg;                   /**< Handler argument                   */
 	char name[32];               /**< Name of the media stream           */
+	bool rcand_wait;             /**< Waiting for remote candidated      */
 };
 
 /** Defines a candidate */

--- a/src/ice/ice.h
+++ b/src/ice/ice.h
@@ -71,7 +71,7 @@ struct icem {
 	ice_connchk_h *chkh;         /**< Connectivity check handler         */
 	void *arg;                   /**< Handler argument                   */
 	char name[32];               /**< Name of the media stream           */
-	bool rcand_wait;             /**< Waiting for remote candidated      */
+	bool rcand_wait;             /**< Waiting for remote candidate       */
 };
 
 /** Defines a candidate */

--- a/src/ice/icem.c
+++ b/src/ice/icem.c
@@ -51,6 +51,7 @@ static void icem_destructor(void *data)
 {
 	struct icem *icem = data;
 
+	tmr_cancel(&icem->tmr_rcand);
 	tmr_cancel(&icem->tmr_pace);
 	list_flush(&icem->compl);
 	list_flush(&icem->validl);
@@ -105,6 +106,7 @@ int  icem_alloc(struct icem **icemp, enum ice_role role, int proto, int layer,
 	icem->conf = conf_default;
 
 	tmr_init(&icem->tmr_pace);
+	tmr_init(&icem->tmr_rcand);
 	list_init(&icem->lcandl);
 	list_init(&icem->rcandl);
 	list_init(&icem->checkl);

--- a/src/ice/icesdp.c
+++ b/src/ice/icesdp.c
@@ -262,7 +262,6 @@ static void rcand_dealloc(void *arg)
 
 	mem_deref(rcand->icem);
 	mem_deref((char *)rcand->foundation.p);
-	mem_deref(rcand->domain);
 }
 
 

--- a/src/ice/icesdp.c
+++ b/src/ice/icesdp.c
@@ -208,14 +208,9 @@ static int getaddr_rcand(void *arg)
 {
 	struct rcand *rcand = arg;
 	struct addrinfo *res, *res0 = NULL;
-	struct addrinfo hints;
 	int err;
 
-	memset(&hints, 0, sizeof(hints));
-	hints.ai_family = AF_UNSPEC;
-	hints.ai_flags	= AI_V4MAPPED | AI_ADDRCONFIG;
-
-	err = getaddrinfo(rcand->domain, NULL, &hints, &res0);
+	err = getaddrinfo(rcand->domain, NULL, NULL, &res0);
 	if (err)
 		return EADDRNOTAVAIL;
 

--- a/src/ice/icesdp.c
+++ b/src/ice/icesdp.c
@@ -251,6 +251,7 @@ static void delayed_rcand(int err, void *arg)
 		       &rcand->caddr, &rcand->rel_addr, &rcand->foundation);
 
 out:
+	rcand->icem->rcand_wait = false;
 	mem_deref(rcand);
 }
 
@@ -335,6 +336,8 @@ static int cand_decode(struct icem *icem, const char *val)
 
 		pl_dup(&rcand->foundation, &foundation);
 		(void)pl_strcpy(&addr, rcand->domain, sizeof(rcand->domain));
+
+		icem->rcand_wait = true;
 
 		err = re_thread_async(getaddr_rcand, delayed_rcand, rcand);
 		if (err)

--- a/src/ice/icesdp.c
+++ b/src/ice/icesdp.c
@@ -313,6 +313,7 @@ static int cand_decode(struct icem *icem, const char *val)
 	/* check for mdns .local address */
 	if (pl_strstr(&addr, ".local") != NULL) {
 		/* try non blocking getaddr mdns resolution */
+		icem_printf(icem, "mDNS remote cand: %r\n", &addr);
 		struct rcand *rcand =
 			mem_zalloc(sizeof(struct rcand), rcand_dealloc);
 		if (!rcand)

--- a/src/ice/icesdp.c
+++ b/src/ice/icesdp.c
@@ -212,7 +212,7 @@ static int getaddr_rcand(void *arg)
 	int err;
 
 	memset(&hints, 0, sizeof(hints));
-	hints.ai_family = AF_INET;
+	hints.ai_family = AF_UNSPEC;
 	hints.ai_flags	= AI_V4MAPPED | AI_ADDRCONFIG;
 
 	err = getaddrinfo(rcand->domain, NULL, &hints, &res0);

--- a/src/ice/icesdp.c
+++ b/src/ice/icesdp.c
@@ -3,6 +3,10 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
+#ifndef WIN32
+#include <netdb.h>
+#endif
+
 #include <string.h>
 #include <re_types.h>
 #include <re_fmt.h>
@@ -14,6 +18,7 @@
 #include <re_net.h>
 #include <re_stun.h>
 #include <re_ice.h>
+#include <re_main.h>
 #include "ice.h"
 
 
@@ -32,6 +37,19 @@ const char ice_attr_mismatch[]    = "ice-mismatch";
 
 static const char rel_addr_str[] = "raddr";
 static const char rel_port_str[] = "rport";
+
+
+struct rcand {
+	struct icem *icem;
+	enum ice_cand_type type;
+	unsigned cid;
+	uint32_t prio;
+	uint32_t port;
+	struct sa caddr;
+	struct sa rel_addr;
+	struct pl foundation;
+	char domain[128];
+};
 
 
 /* Encode SDP Attributes */
@@ -186,6 +204,67 @@ static int media_pwd_decode(struct icem *icem, const char *value)
 }
 
 
+static int getaddr_rcand(void *arg)
+{
+	struct rcand *rcand = arg;
+	struct addrinfo *res, *res0 = NULL;
+	struct addrinfo hints;
+	int err;
+
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_INET;
+	hints.ai_flags	= AI_V4MAPPED | AI_ADDRCONFIG;
+
+	err = getaddrinfo(rcand->domain, NULL, &hints, &res0);
+	if (err)
+		return EADDRNOTAVAIL;
+
+	for (res = res0; res; res = res->ai_next) {
+
+		err = sa_set_sa(&rcand->caddr, res->ai_addr);
+		if (err)
+			continue;
+
+		break;
+	}
+
+	sa_set_port(&rcand->caddr, rcand->port);
+
+	freeaddrinfo(res);
+
+	return 0;
+}
+
+
+static void delayed_rcand(int err, void *arg)
+{
+	struct rcand *rcand = arg;
+
+	if (err)
+		goto out;
+
+	/* add only if not exist */
+	if (icem_cand_find(&rcand->icem->rcandl, rcand->cid, &rcand->caddr))
+		goto out;
+
+	icem_rcand_add(rcand->icem, rcand->type, rcand->cid, rcand->prio,
+		       &rcand->caddr, &rcand->rel_addr, &rcand->foundation);
+
+out:
+	mem_deref(rcand);
+}
+
+
+static void rcand_dealloc(void *arg)
+{
+	struct rcand *rcand = arg;
+
+	mem_deref(rcand->icem);
+	mem_deref((char *)rcand->foundation.p);
+	mem_deref(rcand->domain);
+}
+
+
 static int cand_decode(struct icem *icem, const char *val)
 {
 	struct pl foundation, compid, transp, prio, addr, port, cand_type;
@@ -233,17 +312,40 @@ static int cand_decode(struct icem *icem, const char *val)
 		}
 	}
 
-	err = sa_set(&caddr, &addr, pl_u32(&port));
-	if (err)
-		return err;
-
+	(void)pl_strcpy(&cand_type, type, sizeof(type));
 	cid = pl_u32(&compid);
+
+	err = sa_set(&caddr, &addr, pl_u32(&port));
+	if (err) {
+		if (err != EINVAL)
+			return err;
+
+		/* try non blocking getaddr mdns resolution */
+		struct rcand *rcand =
+			mem_zalloc(sizeof(struct rcand), rcand_dealloc);
+		if (!rcand)
+			return ENOMEM;
+
+		rcand->icem	= mem_ref(icem);
+		rcand->type	= ice_cand_name2type(type);
+		rcand->cid	= cid;
+		rcand->prio	= pl_u32(&prio);
+		rcand->port	= pl_u32(&port);
+		rcand->rel_addr = rel_addr;
+
+		pl_dup(&rcand->foundation, &foundation);
+		(void)pl_strcpy(&addr, rcand->domain, sizeof(rcand->domain));
+
+		err = re_thread_async(getaddr_rcand, delayed_rcand, rcand);
+		if (err)
+			mem_deref(rcand);
+
+		return err;
+	}
 
 	/* add only if not exist */
 	if (icem_cand_find(&icem->rcandl, cid, &caddr))
 		return 0;
-
-	(void)pl_strcpy(&cand_type, type, sizeof(type));
 
 	return icem_rcand_add(icem, ice_cand_name2type(type), cid,
 			      pl_u32(&prio), &caddr, &rel_addr, &foundation);

--- a/src/ice/icesdp.c
+++ b/src/ice/icesdp.c
@@ -317,9 +317,6 @@ static int cand_decode(struct icem *icem, const char *val)
 
 	err = sa_set(&caddr, &addr, pl_u32(&port));
 	if (err) {
-		if (err != EINVAL)
-			return err;
-
 		/* try non blocking getaddr mdns resolution */
 		struct rcand *rcand =
 			mem_zalloc(sizeof(struct rcand), rcand_dealloc);

--- a/src/ice/icesdp.c
+++ b/src/ice/icesdp.c
@@ -315,8 +315,8 @@ static int cand_decode(struct icem *icem, const char *val)
 	(void)pl_strcpy(&cand_type, type, sizeof(type));
 	cid = pl_u32(&compid);
 
-	err = sa_set(&caddr, &addr, pl_u32(&port));
-	if (err) {
+	/* check for mdns .local address */
+	if (pl_strstr(&addr, ".local") != NULL) {
 		/* try non blocking getaddr mdns resolution */
 		struct rcand *rcand =
 			mem_zalloc(sizeof(struct rcand), rcand_dealloc);
@@ -341,6 +341,10 @@ static int cand_decode(struct icem *icem, const char *val)
 
 		return err;
 	}
+
+	err = sa_set(&caddr, &addr, pl_u32(&port));
+	if (err)
+		return err;
 
 	/* add only if not exist */
 	if (icem_cand_find(&icem->rcandl, cid, &caddr))


### PR DESCRIPTION
Some browsers anonymize local webrtc sdp candidate ip addresses with mDNS `[UUID].local` (like "1bbabc05-80d2-4386-8e39-9666b53900d0.local"), this PR uses getaddrinfo to resolve these if needed.

TODO: 
- [x] a callback notification is needed (rcand is ready)
- [x] Tested with Safari iOS (16.6), Firefox (116.0.3)  and Chromium (116.0.5845.110)

refs https://github.com/baresip/baresip/discussions/2137

https://datatracker.ietf.org/doc/html/draft-ietf-mmusic-mdns-ice-candidates-03

Manual Testing:

- Start `baresip-webrtc -v`
- Open URL in Browser (private browser mode) Check `recvonly` (no microphone/camera permission) and connect
- You should see mDNS remote candidates:
```
{      audio. } mDNS remote cand: 4e712009-4a6c-40df-87a5-55bda80e6257.local
{      audio. } conncheck_start: waiting mDNS for remote candidate...
{      video. } mDNS remote cand: 4e712009-4a6c-40df-87a5-55bda80e6257.local
{      video. } conncheck_start: waiting mDNS for remote candidate...
```