### PR TITLE
fmt/print: improve print RE_VA_ARG debugging

### DIFF
--- a/include/re_types.h
+++ b/include/re_types.h
@@ -371,12 +371,10 @@ typedef int re_sock_t;
 	if (likely((safe))) {                                                 \
 		size_t sz = va_arg((ap), size_t);                             \
 		if (unlikely(!sz)) {                                          \
-			re_assert(0 && "RE_VA_ARG: no more arguments");       \
-			err = EOVERFLOW;                                      \
+			err = ENODATA;                                        \
 			goto out;                                             \
 		}                                                             \
 		if (unlikely(sz != sizeof(type))) {                           \
-			re_assert(0 && "RE_VA_ARG: arg is not compatible");   \
 			err = EOVERFLOW;                                      \
 			goto out;                                             \
 		}                                                             \

--- a/src/fmt/print.c
+++ b/src/fmt/print.c
@@ -4,11 +4,11 @@
  * Copyright (C) 2010 Creytiv.com
  */
 #include <string.h>
+#include <math.h>
 #include <re_types.h>
 #include <re_sa.h>
 #include <re_fmt.h>
 #include <re_mem.h>
-#include <math.h>
 #ifdef _MSC_VER
 #include <float.h>
 #ifndef isinf
@@ -26,6 +26,9 @@
 #define isnan(a) isnand((a))
 #endif
 
+#define DEBUG_MODULE "print"
+#define DEBUG_LEVEL 5
+#include <re_dbg.h>
 
 enum length_modifier {
 	LENMOD_NONE      = 0,
@@ -489,6 +492,17 @@ static int vhprintf(const char *fmt, va_list ap, re_vprintf_h *vph, void *arg,
 		err |= vph(p0, p - p0, arg);
 
 out:
+#ifndef RELEASE
+	if (err == ENODATA) {
+		DEBUG_WARNING("Format: \"%b<-- NO ARG\n", fmt, p - fmt + 1);
+		re_assert(0 && "RE_VA_ARG: no more arguments");
+	}
+	if (err == EOVERFLOW) {
+		DEBUG_WARNING("Format: \"%b<-- SIZE ERROR\n", fmt,
+			      p - fmt + 1);
+		re_assert(0 && "RE_VA_ARG: arg is not compatible");
+	}
+#endif
 	return err;
 }
 


### PR DESCRIPTION
```c
#include <re.h>

int main(void)
{
	re_printf("hello %s\n");

	return 0;
}
```
Output: `print: Format: "hello %s<-- NO ARG`

```c
#include <re.h>

int main(void)
{
	re_printf("hello %d\n", 1LL);

	return 0;
}
```
Output: `print: Format: "hello %d<-- SIZE ERROR`