### PR TITLE
types: add RE_ARG_SIZE struct pl (avoids wrong print fmt %r usage)

### DIFF
--- a/include/re_types.h
+++ b/include/re_types.h
@@ -334,6 +334,7 @@ typedef int re_sock_t;
 	char*:			sizeof(char *),                               \
 	void const*:		sizeof(void const *),                         \
 	void*:			sizeof(void *),                               \
+	struct pl:		sizeof(struct pl),                            \
 	default: sizeof(void*)                                                \
 )
 


### PR DESCRIPTION
```c
#include <re.h>

int main(void)
{
	struct pl r = {.p = "world",  str_len("world")};

	re_printf("hello %r\n", r); /* common mistake needs pointer "&r" */

	return 0;
}
```

`print: Format: "hello %r<-- SIZE ERROR`