### PR TITLE
dbg: add thread-safe identifier (WiP)

### DIFF
--- a/include/re_dbg.h
+++ b/include/re_dbg.h
@@ -44,6 +44,9 @@ enum {
 #endif
 
 
+#define DEBUG_ID(id) dbg_set_id(id)
+#define DEBUG_RESET_ID dbg_set_id(0)
+
 /**
  * @def DEBUG_WARNING(...)
  *
@@ -110,9 +113,12 @@ enum dbg_flags {
  * @param len   String length
  * @param arg   Handler argument
  */
-typedef void (dbg_print_h)(int level, const char *p, size_t len, void *arg);
+typedef void(dbg_print_h)(uintptr_t id, int level, const char *p, size_t len,
+			  void *arg);
 
 void dbg_init(int level, enum dbg_flags flags);
+int dbg_set_id(uintptr_t id);
+uintptr_t dbg_get_id(void);
 void dbg_close(void);
 int  dbg_logfile_set(const char *name);
 void dbg_handler_set(dbg_print_h *ph, void *arg);

--- a/test/main.c
+++ b/test/main.c
@@ -53,7 +53,8 @@ static void usage(void)
 #endif
 
 
-static void dbg_handler(uintptr_t id, int level, const char *p, size_t len, void *arg)
+static void dbg_handler(uintptr_t id, int level, const char *p, size_t len,
+			void *arg)
 {
 	(void)level;
 	(void)arg;

--- a/test/main.c
+++ b/test/main.c
@@ -53,10 +53,11 @@ static void usage(void)
 #endif
 
 
-static void dbg_handler(int level, const char *p, size_t len, void *arg)
+static void dbg_handler(uintptr_t id, int level, const char *p, size_t len, void *arg)
 {
 	(void)level;
 	(void)arg;
+	(void)id;
 
 	printf("%.*s", (int)len, p);
 }


### PR DESCRIPTION
Sometimes it's useful to identify/group log messages by an thread-safe identifier.

Let's say you have a application with multiple calls, we can add a call specific ID to log messages:

```c
DEBUG_ID(call_id);
DEBUG_WARNING("error message");
...
DEBUG_RESET_ID;
```

