### PR TITLE
dns/client: use info for getaddrinfo_h err

### DIFF
--- a/src/dns/client.c
+++ b/src/dns/client.c
@@ -892,7 +892,7 @@ static void getaddrinfo_h(int err, void *arg)
 		   cache ? "(caching)" : "");
 
 	if (err) {
-		DEBUG_WARNING("getaddrinfo_h: err %m\n", err);
+		DEBUG_INFO("getaddrinfo_h: err %m\n", err);
 	}
 	else {
 		struct le *le;


### PR DESCRIPTION
It's not fatal if getaddrinfo_h returns err, like not available 'AAAA' record.