### PR TITLE
test: init err to 0 in sdp test (cppcheck)

### DIFF
--- a/test/sdp.c
+++ b/test/sdp.c
@@ -319,7 +319,7 @@ int test_sdp_parse(void)
 	struct mbuf *mb;
 	struct sa laddr;
 	uint32_t i;
-	int err;
+	int err = 0;
 
 	mb = mbuf_alloc(2048);
 	if (!mb)


### PR DESCRIPTION
$ cppcheck --version
Cppcheck 2.12.0


```
$ cppcheck -q -f --std=c11 .

src/main/main.c:704:6: error: Uninitialized variable: n [uninitvar]
 if (n < 0)
     ^
src/main/main.c:789:11: error: Uninitialized variable: fd [uninitvar]
  index = fd;
          ^
src/sipevent/sipevent.h:51:39: error: syntax error [syntaxError]
void sipnot_refresh(struct sipnot *not, uint32_t expires);
                                      ^
test/sdp.c:367:9: warning: Uninitialized variable: err [uninitvar]
 return err;
        ^
test/sdp.c:330:13: note: Assuming condition is false
 for (i=0; i<RE_ARRAY_SIZE(msgs); i++) {
            ^
test/sdp.c:367:9: note: Uninitialized variable: err
 return err;
        ^
```
