### PR TITLE
jbuf: fix for adaptive mode

### DIFF
--- a/include/re_jbuf.h
+++ b/include/re_jbuf.h
@@ -36,5 +36,4 @@ int  jbuf_drain(struct jbuf *jb, struct rtp_header *hdr, void **mem);
 void jbuf_flush(struct jbuf *jb);
 int  jbuf_stats(const struct jbuf *jb, struct jbuf_stat *jstat);
 int  jbuf_debug(struct re_printf *pf, const struct jbuf *jb);
-uint32_t jbuf_frames(const struct jbuf *jb);
 uint32_t jbuf_packets(const struct jbuf *jb);

--- a/src/jbuf/jbuf.c
+++ b/src/jbuf/jbuf.c
@@ -498,7 +498,6 @@ out:
 int jbuf_get(struct jbuf *jb, struct rtp_header *hdr, void **mem)
 {
 	struct packet *f;
-	uint32_t ts;
 	int err = 0;
 
 	if (!jb || !hdr || !mem)
@@ -521,7 +520,6 @@ int jbuf_get(struct jbuf *jb, struct rtp_header *hdr, void **mem)
 	   If not, we should consider that packet lost. */
 
 	f = jb->packetl.head->data;
-	ts = f->hdr.ts;
 
 #if JBUF_STAT
 	/* Check sequence of previously played packet */
@@ -548,9 +546,7 @@ int jbuf_get(struct jbuf *jb, struct rtp_header *hdr, void **mem)
 	packet_deref(jb, f);
 	if (jb->packetl.head) {
 		f = jb->packetl.head->data;
-		if (f->hdr.ts == ts)
-			err = EAGAIN;
-		else if (jb->n > jb->wish)
+		if (jb->n > jb->wish)
 			err = EAGAIN;
 	}
 

--- a/src/jbuf/jbuf.c
+++ b/src/jbuf/jbuf.c
@@ -346,7 +346,8 @@ static void calc_rdiff(struct jbuf *jb, uint16_t seq)
 		jb->wish = wish;
 	}
 	else if (wish < jb->wish) {
-		uint32_t dt = wish + 1 == jb->wish ? 6000 : 1000;
+		uint32_t dt = wish + 1 == jb->wish ? 6000 :
+			      wish < jb->wish / 2  ? 100 : 1000;
 		if (!tmr_isrunning(&jb->tmr) || tmr_get_expire(&jb->tmr) > dt)
 			tmr_start(&jb->tmr, dt, wish_down, jb);
 

--- a/src/jbuf/jbuf.c
+++ b/src/jbuf/jbuf.c
@@ -329,9 +329,7 @@ static void calc_rdiff(struct jbuf *jb, uint16_t seq)
 
 	rdiff = (int16_t)(jb->seq_put + 1 - seq);
 	adiff = abs(rdiff * JBUF_RDIFF_EMA_COEFF);
-	s = adiff > jb->rdiff ? JBUF_RDIFF_UP_SPEED :
-		jb->wish > 2  ? 1 :
-		jb->wish > 1  ? 2 : 3;
+	s = adiff > jb->rdiff ? JBUF_RDIFF_UP_SPEED : 1;
 	jb->rdiff += (adiff - jb->rdiff) * s / JBUF_RDIFF_EMA_COEFF;
 
 	wish = (uint32_t)(jb->rdiff / (float)JBUF_RDIFF_EMA_COEFF);


### PR DESCRIPTION
The adaptive mode was broken. Video frames are not relevant for the wish size. The estimation of the number of frames was not accurate because key frames have much higher #frame/#packet ratio then differential frames.

The wish size depends only on `rdiff`, the measure for how much packet sequence number differ from the expected sequence number if packets arrive out of order.

- jbuf: wish size is given in #packets
- test: jbuf packets with equal timestamps
- jbuf: trace data for plot
- jbuf: return EAGAIN only if wish size is exceeded
- jbuf: faster reduce wish size in adaptive mode
- jbuf: simplify rdiff computation

The plots generated from `baresip/tools/jbuf` of PR https://github.com/baresip/baresip/pull/2724 visualize how the adaptive mode works.
