### PR TITLE
trace: add flush worker and optimize memory usage

### DIFF
--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -30,11 +30,11 @@
 #endif
 
 #ifndef TRACE_BUFFER_SIZE
-#define TRACE_BUFFER_SIZE 10000
+#define TRACE_BUFFER_SIZE 100000
 #endif
 
 enum {
-	TRACE_FLUSH_TMR = 1000,
+	TRACE_FLUSH_TMR = 10000,
 };
 
 #define DEBUG_MODULE "trace"
@@ -106,6 +106,7 @@ static inline int get_process_id(void)
 static int flush_worker(void *arg)
 {
 	(void)arg;
+
 	re_trace_flush();
 
 	return 0;

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -199,14 +199,14 @@ int re_trace_close(void)
 #ifndef RE_TRACE_ENABLED
 	return 0;
 #endif
-	tmr_cancel(&trace.flush_tmr);
 
+	tmr_cancel(&trace.flush_tmr);
 	re_trace_flush();
+	re_atomic_rlx_set(&trace.init, false);
 
 	trace.event_buffer = mem_deref(trace.event_buffer);
 	trace.event_buffer_flush = mem_deref(trace.event_buffer_flush);
 	mtx_destroy(&trace.lock);
-	re_atomic_rlx_set(&trace.init, false);
 
 	(void)re_fprintf(trace.f, "\n\t]\n}\n");
 	if (trace.f)


### PR DESCRIPTION
This reduces trace memory usage from ~137 MByte (1.000.000 entries) to 13,7 MByte (100.000 entries). Every second the trace buffer is flushed asynchronously if more than 1000 entries reached (`TRACE_FLUSH_THRESHOLD`).

All values can be overriden on compile time:
```c
-DCMAKE_C_FLAGS="-DTRACE_BUFFER_SIZE=10000 -DTRACE_FLUSH_THRESHOLD=100 -DTRACE_FLUSH_TMR=1000"
```
`TRACE_FLUSH_TMR` is in ms.
