### PR TITLE
cmake: enable C11 for Windows (not MINGW)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,10 @@ else()
   set(PROJECT_VERSION_FULL ${PROJECT_VERSION})
 endif()
 
+if(WIN32 AND NOT MINGW)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std:c11" )
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
 ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
 endif()
 
 if(WIN32 AND NOT MINGW)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std:c11" )
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std:c11")
 endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)


### PR DESCRIPTION
Downstream patch:

    https://github.com/microsoft/vcpkg/blob/master/ports/baresip-libre/use-c11.patch