### PR TITLE
rtp: fix video jitter calculation and add arrival time rtp header

### DIFF
--- a/include/re_rtp.h
+++ b/include/re_rtp.h
@@ -23,7 +23,7 @@ struct rtp_header {
 	uint8_t  pt;        /**< Payload type           */
 	uint16_t seq;       /**< Sequence number        */
 	uint32_t ts;        /**< Timestamp              */
-	uint32_t ts_arrive; /**< Arrival Timestamp      */
+	uint64_t ts_arrive; /**< Arrival Timestamp      */
 	uint32_t ssrc;      /**< Synchronization source */
 	uint32_t csrc[16];  /**< Contributing sources   */
 	struct {

--- a/include/re_rtp.h
+++ b/include/re_rtp.h
@@ -23,6 +23,7 @@ struct rtp_header {
 	uint8_t  pt;        /**< Payload type           */
 	uint16_t seq;       /**< Sequence number        */
 	uint32_t ts;        /**< Timestamp              */
+	uint32_t ts_arrive; /**< Arrival Timestamp      */
 	uint32_t ssrc;      /**< Synchronization source */
 	uint32_t csrc[16];  /**< Contributing sources   */
 	struct {

--- a/src/rtp/rtcp.h
+++ b/src/rtp/rtcp.h
@@ -44,6 +44,7 @@ struct rtp_source {
 	uint64_t sr_recv;         /**< When the last SR was received       */
 	struct ntp_time last_sr;  /**< NTP Timestamp from last SR received */
 	uint32_t rtp_ts;          /**< RTP timestamp                       */
+	uint32_t last_rtp_ts;     /**< Last RTP timestamp                  */
 	uint32_t psent;           /**< RTP packets sent                    */
 	uint32_t osent;           /**< RTP octets sent                     */
 };

--- a/src/rtp/rtcp.h
+++ b/src/rtp/rtcp.h
@@ -116,6 +116,5 @@ int  rtcp_send(struct rtp_sock *rs, struct mbuf *mb);
 void rtcp_handler(struct rtcp_sess *sess, struct rtcp_msg *msg);
 void rtcp_sess_tx_rtp(struct rtcp_sess *sess, uint32_t ts, uint64_t jfs_rt,
 		      size_t payload_size);
-void rtcp_sess_rx_rtp(struct rtcp_sess *sess, uint16_t seq, uint32_t ts,
-		      uint32_t src, size_t payload_size,
-		      const struct sa *peer);
+void rtcp_sess_rx_rtp(struct rtcp_sess *sess, struct rtp_header *hdr,
+		      size_t payload_size, const struct sa *peer);

--- a/src/rtp/rtp.c
+++ b/src/rtp/rtp.c
@@ -205,10 +205,8 @@ static void udp_recv_handler(const struct sa *src, struct mbuf *mb, void *arg)
 	if (err)
 		return;
 
-	if (rs->rtcp) {
-		rtcp_sess_rx_rtp(rs->rtcp, hdr.seq, hdr.ts,
-				 hdr.ssrc, mbuf_get_left(mb), src);
-	}
+	if (rs->rtcp)
+		rtcp_sess_rx_rtp(rs->rtcp, &hdr, mbuf_get_left(mb), src);
 
 	if (rs->recvh)
 		rs->recvh(src, &hdr, mb, rs->arg);

--- a/src/rtp/sess.c
+++ b/src/rtp/sess.c
@@ -563,47 +563,45 @@ void rtcp_sess_tx_rtp(struct rtcp_sess *sess, uint32_t ts, uint64_t jfs_rt,
 }
 
 
-void rtcp_sess_rx_rtp(struct rtcp_sess *sess, uint16_t seq, uint32_t ts,
-		      uint32_t ssrc, size_t payload_size,
-		      const struct sa *peer)
+void rtcp_sess_rx_rtp(struct rtcp_sess *sess, struct rtp_header *hdr,
+		      size_t payload_size, const struct sa *peer)
 {
 	struct rtp_member *mbr;
 
 	if (!sess)
 		return;
 
-	mbr = get_member(sess, ssrc);
+	mbr = get_member(sess, hdr->ssrc);
 	if (!mbr) {
-		DEBUG_NOTICE("could not add member: 0x%08x\n", ssrc);
+		DEBUG_NOTICE("could not add member: 0x%08x\n", hdr->ssrc);
 		return;
 	}
 
 	if (!mbr->s) {
 		mbr->s = mem_zalloc(sizeof(*mbr->s), NULL);
 		if (!mbr->s) {
-			DEBUG_NOTICE("could not add sender: 0x%08x\n", ssrc);
+			DEBUG_NOTICE("could not add sender: 0x%08x\n",
+				     hdr->ssrc);
 			return;
 		}
 
 		/* first packet - init sequence number */
-		source_init_seq(mbr->s, seq);
+		source_init_seq(mbr->s, hdr->seq);
 		/* probation not used */
 		sa_cpy(&mbr->s->rtp_peer, peer);
 		++sess->senderc;
 	}
 
-	if (!source_update_seq(mbr->s, seq)) {
+	if (!source_update_seq(mbr->s, hdr->seq)) {
 		DEBUG_WARNING("rtp_update_seq() returned 0\n");
 	}
 
 	if (sess->srate_rx) {
-
-		uint64_t ts_arrive;
-
 		/* Convert from wall-clock time to timestamp units */
-		ts_arrive = tmr_jiffies() * sess->srate_rx / 1000;
+		hdr->ts_arrive =
+			(uint32_t)(tmr_jiffies() * sess->srate_rx / 1000);
 
-		source_calc_jitter(mbr->s, ts, (uint32_t)ts_arrive);
+		source_calc_jitter(mbr->s, hdr->ts, hdr->ts_arrive);
 	}
 
 	mbr->s->rtp_rx_bytes += payload_size;


### PR DESCRIPTION
The receiver arrival time is useful for jitter handling and local playout time calculation. 
Fixing video jitter by calculating only when the timestamp is different than last packet (see RTP FAQ https://www.cs.columbia.edu/~hgs/rtp/faq.html#jitter).
