### PR TITLE
trace: add id handling

### DIFF
--- a/include/re_trace.h
+++ b/include/re_trace.h
@@ -3,6 +3,8 @@
  * JSON traces (chrome://tracing)
  */
 
+struct pl;
+
 typedef enum {
 	RE_TRACE_ARG_NONE,
 	RE_TRACE_ARG_INT,
@@ -14,37 +16,46 @@ typedef enum {
 int re_trace_init(const char *json_file);
 int re_trace_close(void);
 int re_trace_flush(void);
-void re_trace_event(const char *cat, const char *name, char ph, void *id,
-			int32_t async_id, re_trace_arg_type arg_type,
-			const char *arg_name, void *arg_value);
+void re_trace_event(const char *cat, const char *name, char ph, struct pl *id,
+		    re_trace_arg_type arg_type, const char *arg_name,
+		    void *arg_value);
 
 #ifdef RE_TRACE_ENABLED
 
 #define RE_TRACE_BEGIN(c, n) \
-	re_trace_event(c, n, 'B', 0, 0, RE_TRACE_ARG_NONE, NULL, NULL)
+	re_trace_event(c, n, 'B', NULL, RE_TRACE_ARG_NONE, NULL, NULL)
 #define RE_TRACE_END(c, n) \
-	re_trace_event(c, n, 'E', 0, 0, RE_TRACE_ARG_NONE, NULL, NULL)
+	re_trace_event(c, n, 'E', NULL, RE_TRACE_ARG_NONE, NULL, NULL)
 
 #define RE_TRACE_ID_BEGIN(c, n, id) \
-	re_trace_event(c, n, 'B', 0, id, RE_TRACE_ARG_NONE, NULL, NULL)
+	re_trace_event(c, n, 'B', id, RE_TRACE_ARG_NONE, NULL, NULL)
 #define RE_TRACE_ID_END(c, n, id) \
-	re_trace_event(c, n, 'E', 0, id, RE_TRACE_ARG_NONE, NULL, NULL)
+	re_trace_event(c, n, 'E', id, RE_TRACE_ARG_NONE, NULL, NULL)
 
 #define RE_TRACE_INSTANT(c, n) \
-	re_trace_event(c, n, 'I', 0, 0, RE_TRACE_ARG_NONE, NULL, NULL)
+	re_trace_event(c, n, 'I', NULL, RE_TRACE_ARG_NONE, NULL, NULL)
 #define RE_TRACE_INSTANT_C(c, n, vname, str) \
-	re_trace_event(c, n, 'I', 0, 0, RE_TRACE_ARG_STRING_CONST, \
+	re_trace_event(c, n, 'I', NULL, RE_TRACE_ARG_STRING_CONST, \
 	vname, (void *)(str))
 #define RE_TRACE_INSTANT_I(c, n, i) \
-	re_trace_event(c, n, 'I', 0, 0, RE_TRACE_ARG_INT, \
+	re_trace_event(c, n, 'I', NULL, RE_TRACE_ARG_INT, \
+	n, (void *)(intptr_t)i)
+
+#define RE_TRACE_ID_INSTANT(c, n, id) \
+	re_trace_event(c, n, 'I', id, RE_TRACE_ARG_NONE, NULL, NULL)
+#define RE_TRACE_ID_INSTANT_C(c, n, vname, str, id) \
+	re_trace_event(c, n, 'I', id, RE_TRACE_ARG_STRING_CONST, \
+	vname, (void *)(str))
+#define RE_TRACE_ID_INSTANT_I(c, n, i, id) \
+	re_trace_event(c, n, 'I', id, RE_TRACE_ARG_INT, \
 	n, (void *)(intptr_t)i)
 
 #define RE_TRACE_PROCESS_NAME(n) \
-	re_trace_event("", "process_name", 'M', 0, 0, \
+	re_trace_event("", "process_name", 'M', NULL, \
 	RE_TRACE_ARG_STRING_COPY, \
 	"name", (void *)(n))
 #define RE_TRACE_THREAD_NAME(n) \
-	re_trace_event("", "thread_name", 'M', 0, 0, \
+	re_trace_event("", "thread_name", 'M', NULL, \
 	RE_TRACE_ARG_STRING_COPY, \
 	"name", (void *)(n))
 
@@ -57,6 +68,9 @@ void re_trace_event(const char *cat, const char *name, char ph, void *id,
 #define RE_TRACE_INSTANT(c, n)
 #define RE_TRACE_INSTANT_C(c, n, str)
 #define RE_TRACE_INSTANT_I(c, n, i)
+#define RE_TRACE_ID_INSTANT(c, n, id)
+#define RE_TRACE_ID_INSTANT_C(c, n, str, id)
+#define RE_TRACE_ID_INSTANT_I(c, n, i, id)
 #define RE_TRACE_PROCESS_NAME(n)
 #define RE_TRACE_THREAD_NAME(n)
 

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -293,7 +293,7 @@ int re_trace_flush(void)
 		re_snprintf(name, sizeof(name), "\"name\":\"%s\"", e->name);
 
 		if (e->id) {
-			re_snprintf(id_str, sizeof(id_str), "\"id\":\"%r\"",
+			re_snprintf(id_str, sizeof(id_str), ", \"id\":\"%r\"",
 				    e->id);
 			mem_deref(e->id);
 		}

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -49,7 +49,7 @@
 struct trace_event {
 	const char *name;
 	const char *cat;
-	void *id;
+	struct pl *id;
 	uint64_t ts;
 	int pid;
 	unsigned long tid;
@@ -243,8 +243,9 @@ int re_trace_flush(void)
 	int i, flush_count;
 	struct trace_event *event_tmp;
 	struct trace_event *e;
-	char json_arg[256];
-	char name[128];
+	char json_arg[256] = {0};
+	char name[128]	   = {0};
+	char id_str[128]   = {0};
 
 #ifndef RE_TRACE_ENABLED
 	return 0;
@@ -291,12 +292,20 @@ int re_trace_flush(void)
 
 		re_snprintf(name, sizeof(name), "\"name\":\"%s\"", e->name);
 
+		if (e->id) {
+			re_snprintf(id_str, sizeof(id_str), "\"id\":\"%r\"",
+				    e->id);
+			mem_deref(e->id);
+		}
+
 		(void)re_fprintf(trace.f,
-			"%s{\"cat\":\"%s\",\"pid\":%i,\"tid\":%lu,\"ts\":%llu,"
-			"\"ph\":\"%c\",%s%s}",
+			"%s{\"cat\":\"%s\",\"pid\":%i,\"tid\":%lu,\"ts\":%Lu,"
+			"\"ph\":\"%c\",%s%s%s}",
 			trace.new ? "" : ",\n",
 			e->cat, e->pid, e->tid, e->ts - trace.start_time,
-			e->ph, name, str_isset(json_arg) ? json_arg : "");
+			e->ph, name,
+			e->id ? id_str : "",
+			str_isset(json_arg) ? json_arg : "");
 		trace.new = false;
 	}
 
@@ -305,9 +314,9 @@ int re_trace_flush(void)
 }
 
 
-void re_trace_event(const char *cat, const char *name, char ph, void *id,
-                    int32_t custom_id, re_trace_arg_type arg_type,
-                    const char *arg_name, void *arg_value)
+void re_trace_event(const char *cat, const char *name, char ph, struct pl *id,
+		    re_trace_arg_type arg_type, const char *arg_name,
+		    void *arg_value)
 {
 	struct trace_event *e;
 
@@ -329,17 +338,12 @@ void re_trace_event(const char *cat, const char *name, char ph, void *id,
 	mtx_unlock(&trace.lock);
 
 	e->ts = tmr_jiffies_usec();
-	e->id = id;
+	e->id = mem_ref(id);
 	e->ph = ph;
 	e->cat = cat;
 	e->name = name;
 	e->pid = get_process_id();
-	if (custom_id) {
-		e->tid = custom_id;
-	}
-	else {
-		e->tid = get_thread_id();
-	}
+	e->tid = get_thread_id();
 	e->arg_type = arg_type;
 	e->arg_name = arg_name;
 


### PR DESCRIPTION
Add identifier handling for custom id tracking like:
```json
{"cat":"jbuf","pid":490156,"tid":490156,"ts":1415394,"ph":"I","name":"flush","id":"call1_video"}
```