### PR TITLE
ice: AI_V4MAPPED doesn't exist on OpenBSD

### DIFF
--- a/src/ice/icesdp.c
+++ b/src/ice/icesdp.c
@@ -209,7 +209,11 @@ static int getaddr_rcand(void *arg)
 {
 	struct rcand *rcand = arg;
 	struct addrinfo *res, *res0 = NULL;
+#ifndef OPENBSD
 	struct addrinfo hints = {.ai_flags  = AI_V4MAPPED | AI_ADDRCONFIG,
+#else
+	struct addrinfo hints = {.ai_flags  = AI_ADDRCONFIG,
+#endif
 				 .ai_family = rcand->ai_family};
 	int err;
 


### PR DESCRIPTION
fixes #988