### PR TITLE
async: clear callback function pointer after use (#992)

### DIFF
--- a/src/async/async.c
+++ b/src/async/async.c
@@ -68,8 +68,10 @@ static int worker_thread(void *arg)
 
 		work = le->data;
 		mtx_lock(work->mtx);
-		if (work->workh)
+		if (work->workh) {
 			work->err = work->workh(work->arg);
+			work->workh = NULL;
+		}
 		mtx_unlock(work->mtx);
 
 		mtx_lock(&a->mtx);
@@ -101,14 +103,18 @@ static void async_destructor(void *data)
 	LIST_FOREACH(&async->workl, le)
 	{
 		struct async_work *work = le->data;
-		if (work->cb)
+		if (work->cb) {
 			work->cb(ECANCELED, work->arg);
+			work->cb = NULL;
+		}
 	}
 	LIST_FOREACH(&async->curl, le)
 	{
 		struct async_work *work = le->data;
-		if (work->cb)
+		if (work->cb) {
 			work->cb(ECANCELED, work->arg);
+			work->cb = NULL;
+		}
 	}
 
 	list_flush(&async->workl);
@@ -146,8 +152,10 @@ static void queueh(int id, void *data, void *arg)
 	(void)id;
 
 	mtx_lock(work->mtx);
-	if (work->cb)
+	if (work->cb) {
 		work->cb(work->err, work->arg);
+		work->cb =NULL;
+	}
 	mtx_unlock(work->mtx);
 
 	mtx_lock(&async->mtx);


### PR DESCRIPTION
This solve some strange race condition which results in calling `cb` twice for
one async work object.
