### PR TITLE
async: fix re_async_cancel mqueue handling

### DIFF
--- a/src/async/async.c
+++ b/src/async/async.c
@@ -333,7 +333,7 @@ void re_async_cancel(struct re_async *async, intptr_t id)
 		w->workh = NULL;
 		w->cb	 = NULL;
 		w->arg	 = mem_deref(w->arg);
-		list_move(&w->le, &async->freel);
+		/* No move to free list since queueh must always handled */
 		mtx_unlock(w->mtx);
 	}
 
@@ -351,7 +351,7 @@ void re_async_cancel(struct re_async *async, intptr_t id)
 		w->workh = NULL;
 		w->cb	 = NULL;
 		w->arg	 = mem_deref(w->arg);
-		list_move(&w->le, &async->freel);
+		/* No move to free list since queueh must always handled */
 		mtx_unlock(w->mtx);
 	}
 

--- a/src/async/async.c
+++ b/src/async/async.c
@@ -352,7 +352,7 @@ void re_async_cancel(struct re_async *async, intptr_t id)
 		w->cb	 = NULL;
 		w->arg	 = mem_deref(w->arg);
 		/* No move to free list since queueh must always handled if
-		 * mqueu_push is called*/
+		 * mqueue_push is called */
 		mtx_unlock(w->mtx);
 	}
 

--- a/src/async/async.c
+++ b/src/async/async.c
@@ -333,7 +333,7 @@ void re_async_cancel(struct re_async *async, intptr_t id)
 		w->workh = NULL;
 		w->cb	 = NULL;
 		w->arg	 = mem_deref(w->arg);
-		/* No move to free list since queueh must always handled */
+		list_move(&w->le, &async->freel);
 		mtx_unlock(w->mtx);
 	}
 
@@ -351,7 +351,8 @@ void re_async_cancel(struct re_async *async, intptr_t id)
 		w->workh = NULL;
 		w->cb	 = NULL;
 		w->arg	 = mem_deref(w->arg);
-		/* No move to free list since queueh must always handled */
+		/* No move to free list since queueh must always handled if
+		 * mqueu_push is called*/
 		mtx_unlock(w->mtx);
 	}
 


### PR DESCRIPTION
Since we can't clear/revert a mqueue_push, free list handling has always be done by async `queueh` and not within `re_async_cancel`. Otherwise job is reused and maybe executed twice or early.

fixes #992 