### PR TITLE
sip/transp: add win32 local transport addr fallback

### DIFF
--- a/src/sip/transp.c
+++ b/src/sip/transp.c
@@ -794,9 +794,13 @@ static int conn_send(struct sip_connqent **qentp, struct sip *sip, bool secure,
 
 	/* Fallback check for any address win32 */
 	if (!sa_isset(&conn->laddr, SA_ALL)) {
+		uint16_t port = sa_port(&conn->laddr);
 		err = sip_transp_laddr(sip, &conn->laddr, conn->tp, dst);
 		if (err)
 			goto out;
+
+		if (port)
+			sa_set_port(&conn->laddr, port);
 	}
 
 	if (connh) {

--- a/src/sip/transp.c
+++ b/src/sip/transp.c
@@ -792,8 +792,18 @@ static int conn_send(struct sip_connqent **qentp, struct sip *sip, bool secure,
 	if (err)
 		goto out;
 
-	if (connh)
+	/* Fallback check for any address win32 */
+	if (!sa_isset(&conn->laddr, SA_ALL)) {
+		err = sip_transp_laddr(sip, &conn->laddr, conn->tp, dst);
+		if (err)
+			goto out;
+	}
+
+	if (connh) {
 		err = connh(&conn->laddr, dst, mb, arg);
+		if (err)
+			goto out;
+	}
 
 	(void)tcp_conn_settos(conn->tc, sip->tos);
 #ifdef USE_TLS


### PR DESCRIPTION
`tcp_conn_local_get` function does not always return information about the host address when the socket has been bound to an unspecified address.

fixes https://github.com/baresip/baresip/issues/2797