### PR TITLE
sipsess/connect: don't create a dialog for 100 responses

### DIFF
--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -93,6 +93,9 @@ static void invite_resp_handler(int err, const struct sip_msg *msg, void *arg)
 		sess->progrh(msg, sess->arg);
 		sdp = mbuf_get_left(msg->mb) > 0;
 
+		if (msg->scode == 100)
+			return;
+
 		if (sdp && sess->sent_offer) {
 			sess->awaiting_answer = false;
 			err = sess->answerh(msg, sess->arg);


### PR DESCRIPTION
According to RFC 3261, 100 responses can not create a dialog, so we MUST NOT do that.

This resulted in a bug because some proxies set a To tag in the 100 Trying response without sending a Contact header and we tried (and failed) to create a dialog from that.