### PR TITLE
trace: fix coverity warnings

### DIFF
--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -144,11 +144,8 @@ static void flush_tmr(void *arg)
  */
 int re_trace_init(const char *json_file)
 {
+#ifdef RE_TRACE_ENABLED
 	int err = 0;
-
-#ifndef RE_TRACE_ENABLED
-	return 0;
-#endif
 
 	if (!json_file)
 		return EINVAL;
@@ -196,6 +193,10 @@ out:
 	}
 
 	return err;
+#else
+	(void)json_file;
+	return 0;
+#endif
 }
 
 
@@ -206,11 +207,8 @@ out:
  */
 int re_trace_close(void)
 {
+#ifdef RE_TRACE_ENABLED
 	int err = 0;
-
-#ifndef RE_TRACE_ENABLED
-	return 0;
-#endif
 
 	tmr_cancel(&trace.flush_tmr);
 	re_trace_flush();
@@ -230,6 +228,9 @@ int re_trace_close(void)
 	trace.f = NULL;
 
 	return 0;
+#else
+	return 0;
+#endif
 }
 
 
@@ -240,16 +241,13 @@ int re_trace_close(void)
  */
 int re_trace_flush(void)
 {
+#ifdef RE_TRACE_ENABLED
 	int i, flush_count;
 	struct trace_event *event_tmp;
 	struct trace_event *e;
 	char json_arg[256] = {0};
 	char name[128]	   = {0};
 	char id_str[128]   = {0};
-
-#ifndef RE_TRACE_ENABLED
-	return 0;
-#endif
 
 	if (!re_atomic_rlx(&trace.init))
 		return 0;
@@ -311,6 +309,9 @@ int re_trace_flush(void)
 
 	(void)fflush(trace.f);
 	return 0;
+#else
+	return 0;
+#endif
 }
 
 
@@ -318,11 +319,8 @@ void re_trace_event(const char *cat, const char *name, char ph, struct pl *id,
 		    re_trace_arg_type arg_type, const char *arg_name,
 		    void *arg_value)
 {
+#ifdef RE_TRACE_ENABLED
 	struct trace_event *e;
-
-#ifndef RE_TRACE_ENABLED
-	return;
-#endif
 
 	if (!re_atomic_rlx(&trace.init))
 		return;
@@ -361,4 +359,13 @@ void re_trace_event(const char *cat, const char *name, char ph, struct pl *id,
 			(const char *)arg_value);
 		break;
 	}
+#else
+	(void)cat;
+	(void)name;
+	(void)ph;
+	(void)id;
+	(void)arg_type;
+	(void)arg_name;
+	(void)arg_value;
+#endif
 }

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -46,6 +46,8 @@
 #endif
 
 
+#ifdef RE_TRACE_ENABLED
+
 struct trace_event {
 	const char *name;
 	const char *cat;
@@ -133,6 +135,7 @@ static void flush_tmr(void *arg)
 
 	tmr_start(&trace.flush_tmr, TRACE_FLUSH_TMR, flush_tmr, NULL);
 }
+#endif
 
 
 /**


### PR DESCRIPTION
Fixes around 4 warnings from Coverity 2023.6

```
145int re_trace_init(const char *json_file)
146{
147        int err = 0;
148
149#ifndef RE_TRACE_ENABLED
150        return 0;
151#endif
152
     	CID 469999: Structurally dead code (UNREACHABLE) [[select issue](https://scan8.scan.coverity.com/defectInstanceId=13589814&fileInstanceId=88291432&mergedDefectId=469999)]
153        if (!json_file)
154                return EINVAL;
155
156        if (re_atomic_rlx(&trace.init))
157                return EALREADY;
```
