### PR TITLE
rem: fix coverity defect in destructor

### DIFF
--- a/rem/aumix/aumix.c
+++ b/rem/aumix/aumix.c
@@ -62,7 +62,11 @@ static void destructor(void *arg)
 {
 	struct aumix *mix = arg;
 
-	if (mix->run) {
+	mtx_lock(&mix->mutex);
+	bool run = mix->run;
+	mtx_unlock(&mix->mutex);
+
+	if (run) {
 
 		mtx_lock(&mix->mutex);
 		mix->run = false;


### PR DESCRIPTION
```
static void destructor(void *arg)
 62{
 63        struct aumix *mix = arg;
 64
     	CID 470000: Data race condition (MISSING_LOCK) [[select issue](https://scan8.scan.coverity.com/defectInstanceId=13589806&fileInstanceId=88291460&mergedDefectId=470000)]
   	1. thread1_checks_field: Thread1 uses the value read from field run in the condition mix->run. It sees that the condition is true. Control is switched to Thread2.
   	2. thread2_checks_field: Thread2 uses the value read from field run in the condition mix->run. It sees that the condition is true.
   	Guard the modification of run and the read used to decide whether to modify run with the same set of locks.
 65        if (mix->run) {
 66
   	3. thread2_acquires_lock: Thread2 acquires lock aumix.mutex.
   	5. thread1_acquires_lock: Thread1 acquires lock aumix.mutex.
 67                mtx_lock(&mix->mutex);
   	4. thread2_modifies_field: Thread2 sets run to a new value. Note that this write can be reordered at runtime to occur before instructions that do not access this field within this locked region. After Thread2 leaves the critical section, control is switched back to Thread1.
   	
CID 470016 (#1 of 1): Check of thread-shared field evades lock acquisition (LOCK_EVASION)
6. thread1_overwrites_value_in_field: Thread1 sets run to a new value. Now the two threads have an inconsistent view of run and updates to fields correlated with run may be lost.
 68                mix->run = false;
 69                cnd_signal(&mix->cond);
 70                mtx_unlock(&mix->mutex);
 71
 72                thrd_join(mix->thread, NULL);
 73        }
 74
 75        mem_deref(mix->af);
 76}```
