### PR TITLE
connect: do not enforce Contact header in 1XX responses with To tag

### DIFF
--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -103,7 +103,8 @@ static void invite_resp_handler(int err, const struct sip_msg *msg, void *arg)
 				goto out;
 		}
 
-		if (pl_isset(&msg->to.tag)) {
+		contact = sip_msg_hdr(msg, SIP_HDR_CONTACT);
+		if (pl_isset(&msg->to.tag) && contact) {
 			err = sip_dialog_established(sess->dlg) ?
 					sip_dialog_update(sess->dlg, msg) :
 					sip_dialog_create(sess->dlg, msg);


### PR DESCRIPTION
There are some SIP UAs which send 1XX responses with a To tag and without a Contact header.

This is enforced since v3.4.0 (#878) and with this change (#1028) we increase the compatibility with other SIP stacks while still staying compliant.

E.g. [Linphone only enforces](https://github.com/makinacorpus/linphone/blob/6979948c3eb1996c0e38e7a0fdcbcd10cc4dfa3d/coreapi/bellesip_sal/sal_op_call.c#L879C1-L888C3) sending of the Contact header when compiled with a special compile time option.

Further, [Kamailio removed the enforcing of this header too](https://github.com/kamailio/kamailio/issues/1720).