### PR TITLE
rtp: lock more fields from rtcp_sess

### DIFF
--- a/src/rtp/fb.c
+++ b/src/rtp/fb.c
@@ -12,7 +12,6 @@
 #include <re_sys.h>
 #include <re_sa.h>
 #include <re_rtp.h>
-#include <re_thread.h>
 #include "rtcp.h"
 
 

--- a/src/rtp/member.c
+++ b/src/rtp/member.c
@@ -12,7 +12,6 @@
 #include <re_hash.h>
 #include <re_sa.h>
 #include <re_rtp.h>
-#include <re_thread.h>
 #include "rtcp.h"
 
 

--- a/src/rtp/pkt.c
+++ b/src/rtp/pkt.c
@@ -12,7 +12,6 @@
 #include <re_sys.h>
 #include <re_sa.h>
 #include <re_rtp.h>
-#include <re_thread.h>
 #include "rtcp.h"
 
 

--- a/src/rtp/rr.c
+++ b/src/rtp/rr.c
@@ -13,7 +13,6 @@
 #include <re_sys.h>
 #include <re_net.h>
 #include <re_rtp.h>
-#include <re_thread.h>
 #include "rtcp.h"
 
 

--- a/src/rtp/rtcp.c
+++ b/src/rtp/rtcp.c
@@ -11,7 +11,6 @@
 #include <re_list.h>
 #include <re_sa.h>
 #include <re_rtp.h>
-#include <re_thread.h>
 #include "rtcp.h"
 
 

--- a/src/rtp/rtcp.h
+++ b/src/rtp/rtcp.h
@@ -47,8 +47,6 @@ struct rtp_source {
 	uint32_t last_rtp_ts;     /**< Last RTP timestamp                  */
 	uint32_t psent;           /**< RTP packets sent                    */
 	uint32_t osent;           /**< RTP octets sent                     */
-
-	mtx_t *lock;              /**< Lock for this struct                */
 };
 
 /** RTP Member */
@@ -73,8 +71,6 @@ void source_calc_jitter(struct rtp_source *s, uint32_t rtp_ts,
 			uint32_t arrival);
 int  source_calc_lost(const struct rtp_source *s);
 uint8_t source_calc_fraction_lost(struct rtp_source *s);
-int source_lock(struct rtp_source *s);
-int source_unlock(struct rtp_source *s);
 
 /* RR (Reception report) */
 int rtcp_rr_alloc(struct rtcp_rr **rrp, size_t count);

--- a/src/rtp/rtp.c
+++ b/src/rtp/rtp.c
@@ -13,7 +13,6 @@
 #include <re_sys.h>
 #include <re_net.h>
 #include <re_udp.h>
-#include <re_thread.h>
 #include <re_rtp.h>
 #include <re_atomic.h>
 #include "rtcp.h"

--- a/src/rtp/sdes.c
+++ b/src/rtp/sdes.c
@@ -11,7 +11,6 @@
 #include <re_list.h>
 #include <re_sa.h>
 #include <re_rtp.h>
-#include <re_thread.h>
 #include "rtcp.h"
 
 

--- a/src/rtp/source.c
+++ b/src/rtp/source.c
@@ -11,7 +11,6 @@
 #include <re_list.h>
 #include <re_hash.h>
 #include <re_sa.h>
-#include <re_thread.h>
 #include <re_rtp.h>
 #include "rtcp.h"
 
@@ -175,16 +174,4 @@ uint8_t source_calc_fraction_lost(struct rtp_source *s)
 		fraction = (lost_interval << 8) / expected_interval;
 
 	return fraction;
-}
-
-
-int source_lock(struct rtp_source *s)
-{
-	return mtx_lock(s->lock);
-}
-
-
-int source_unlock(struct rtp_source *s)
-{
-	return mtx_unlock(s->lock);
 }


### PR DESCRIPTION
We need to lock more fields of `rtcp_sess`.

This was found because of
```patch
commit 22bb762de43a895c57984f20dc1771f7529150ee
Author: Christian Spielberger <c.spielberger@commend.com>
Date:   Wed Jan 3 14:53:23 2024 +0100

    test: call - concurrency test for audio_debug()
```

This PR removes the shortly added lock for `rtcp_source`. Instead the lock of `rtcp_sess` is used over larger code parts.

The concurrency test in baresip was intensified in order to find concurrency problems and possible deadlocks with a higher chance.

```patch
commit e267bb2d1655d2b93cbfce21648de47847bf7912 (HEAD -> rx_thread_activate, origin/rx_thread_activate)
Author: Christian Spielberger <c.spielberger@commend.com>
Date:   Thu Jan 4 14:09:34 2024 +0100

    test: call - intensify RTCP/audio_debug concurrency test
```