### PR TITLE
test: move test_rtcp_decode_badmsg() to separate testcase

### DIFF
--- a/test/rtp.c
+++ b/test/rtp.c
@@ -324,17 +324,13 @@ int test_rtcp_decode_badmsg(void)
 {
 	struct rtcp_msg *msg = NULL;
 	uint32_t ssrc = 0xcafebabe;
-	struct mbuf *mb;
-	int err = 0;
 
-	mb = mbuf_alloc(128);
-	if (!mb) {
-		err = ENOMEM;
-		goto out;
-	}
+	struct mbuf *mb = mbuf_alloc(128);
+	if (!mb)
+		return ENOMEM;
 
-	err = rtcp_encode(mb, RTCP_PSFB, RTCP_PSFB_SLI,
-			  ssrc, ssrc, NULL, NULL);
+	int err = rtcp_encode(mb, RTCP_PSFB, RTCP_PSFB_SLI,
+			      ssrc, ssrc, NULL, NULL);
 	if (err)
 		goto out;
 
@@ -344,7 +340,8 @@ int test_rtcp_decode_badmsg(void)
 
 	mb->pos = 0;
 
-	if (EBADMSG != rtcp_decode(&msg, mb)) {
+	int ret = rtcp_decode(&msg, mb);
+	if (EBADMSG != ret && ret != ENOMEM) {
 		err = EBADMSG;
 		goto out;
 	}

--- a/test/rtp.c
+++ b/test/rtp.c
@@ -320,7 +320,7 @@ static const uint8_t rtcp_sdes[] =
 	"";
 
 
-static int test_rtcp_decode_badmsg(void)
+int test_rtcp_decode_badmsg(void)
 {
 	struct rtcp_msg *msg = NULL;
 	uint32_t ssrc = 0xcafebabe;
@@ -412,10 +412,6 @@ int test_rtcp_decode(void)
 
 	if (err)
 		goto out;
-
-	err = test_rtcp_decode_badmsg();
-	if (err)
-		return err;
 
  out:
 	mem_deref(msg);

--- a/test/test.c
+++ b/test/test.c
@@ -158,6 +158,7 @@ static const struct test tests[] = {
 	TEST(test_rtcp_encode),
 	TEST(test_rtcp_encode_afb),
 	TEST(test_rtcp_decode),
+	TEST(test_rtcp_decode_badmsg),
 	TEST(test_rtcp_packetloss),
 	TEST(test_rtcp_twcc),
 	TEST(test_sa_class),

--- a/test/test.h
+++ b/test/test.h
@@ -268,6 +268,7 @@ int test_rtpext(void);
 int test_rtcp_encode(void);
 int test_rtcp_encode_afb(void);
 int test_rtcp_decode(void);
+int test_rtcp_decode_badmsg(void);
 int test_rtcp_packetloss(void);
 int test_rtcp_twcc(void);
 int test_sa_class(void);


### PR DESCRIPTION
cppcheck:

```
test/rtp.c:424:9: warning: Identical condition and return expression 'err', return value is always 0 [identicalConditionAfterEarlyExit]
 return err;
        ^
test/rtp.c:417:6: note: If condition 'err' is true, the function will return/exit
 if (err)
     ^
test/rtp.c:424:9: note: Returning identical expression 'err'
 return err;
        ^
```
