### PR TITLE
ci: add run-on-arch for ARM64 linux

### DIFF
--- a/.github/workflows/run-on-arch.yml
+++ b/.github/workflows/run-on-arch.yml
@@ -6,12 +6,11 @@ jobs:
     runs-on: ubuntu-20.04
     name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
 
-    # Run steps on Bullseye=Debian 11
     strategy:
       matrix:
         include:
           - arch: aarch64
-            distro: buster
+            distro: bullseye
 
     steps:
       - uses: actions/checkout@v4
@@ -26,9 +25,6 @@ jobs:
           # Not required, but speeds up builds
           githubToken: ${{ github.token }}
 
-          env: |
-            CMAKE_GENERATOR: Ninja
-
           install: |
             case "${{ matrix.distro }}" in
               ubuntu*|jessie|stretch|buster|bullseye)
@@ -38,6 +34,6 @@ jobs:
             esac
 
           run: |
-            cmake -B build -DCMAKE_C_FLAGS="-Werror"
+            cmake -G Ninja -B build -DCMAKE_C_FLAGS="-Werror"
             cmake --build build -j --target retest
             ./build/test/retest -r -v

--- a/.github/workflows/run-on-arch.yml
+++ b/.github/workflows/run-on-arch.yml
@@ -1,0 +1,45 @@
+on: [push, pull_request]
+
+jobs:
+  build_job:
+    # The host should always be linux
+    runs-on: ubuntu-22.04
+    name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
+
+    # Run steps on Bullseye=Debian 11
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+            distro: bullseye
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: uraimo/run-on-arch-action@v2
+        name: Build artifact
+        id: build
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.distro }}
+
+          # Not required, but speeds up builds
+          githubToken: ${{ github.token }}
+
+          env: |
+            CMAKE_GENERATOR: Ninja
+
+          shell: /bin/bash
+
+          install: |
+            case "${{ matrix.distro }}" in
+              ubuntu*|jessie|stretch|buster|bullseye)
+                apt-get update -q -y
+                apt-get install -q -y cmake gcc git libssl-dev ninja-build valgrind
+                ;;
+            esac
+
+          run: |
+            cmake -B build -DCMAKE_C_FLAGS="-Werror"
+            cmake --build build -j -t retest
+            valgrind --leak-check=full --show-reachable=yes --error-exitcode=42 ./build/test/retest -r -v

--- a/.github/workflows/run-on-arch.yml
+++ b/.github/workflows/run-on-arch.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         include:
           - arch: aarch64
-            distro: ubuntu20.04
+            distro: buster
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-on-arch.yml
+++ b/.github/workflows/run-on-arch.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   build_job:
     # The host should always be linux
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
 
     # Run steps on Bullseye=Debian 11
@@ -11,7 +11,7 @@ jobs:
       matrix:
         include:
           - arch: aarch64
-            distro: bullseye
+            distro: ubuntu20.04
 
     steps:
       - uses: actions/checkout@v4
@@ -29,17 +29,15 @@ jobs:
           env: |
             CMAKE_GENERATOR: Ninja
 
-          shell: /bin/bash
-
           install: |
             case "${{ matrix.distro }}" in
               ubuntu*|jessie|stretch|buster|bullseye)
                 apt-get update -q -y
-                apt-get install -q -y cmake gcc g++ git libssl-dev ninja-build valgrind
+                apt-get install -q -y cmake gcc g++ libssl-dev ninja-build
                 ;;
             esac
 
           run: |
             cmake -B build -DCMAKE_C_FLAGS="-Werror"
             cmake --build build -j -t retest
-            valgrind --leak-check=full --show-reachable=yes --error-exitcode=42 ./build/test/retest -r -v
+            ./build/test/retest -r -v

--- a/.github/workflows/run-on-arch.yml
+++ b/.github/workflows/run-on-arch.yml
@@ -39,5 +39,5 @@ jobs:
 
           run: |
             cmake -B build -DCMAKE_C_FLAGS="-Werror"
-            cmake --build build -j -t retest
+            cmake --build build -j --target retest
             ./build/test/retest -r -v

--- a/.github/workflows/run-on-arch.yml
+++ b/.github/workflows/run-on-arch.yml
@@ -35,7 +35,7 @@ jobs:
             case "${{ matrix.distro }}" in
               ubuntu*|jessie|stretch|buster|bullseye)
                 apt-get update -q -y
-                apt-get install -q -y cmake gcc git libssl-dev ninja-build valgrind
+                apt-get install -q -y cmake gcc g++ git libssl-dev ninja-build valgrind
                 ;;
             esac
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 # Versioning
 #
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 project(re
   VERSION 3.8.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 # Versioning
 #
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.14)
 
 project(re
   VERSION 3.8.0


### PR DESCRIPTION
This job uses QEMU to run a VM with ARM64-architecture.

Please note that the job is slow, around 4 minutes to complete.