### PR TITLE
tmr: prevent race condition on cancel

### DIFF
--- a/include/re_tmr.h
+++ b/include/re_tmr.h
@@ -6,6 +6,7 @@
 
 
 #include "re_thread.h"
+#include "re_atomic.h"
 
 /**
  * Defines the timeout handler
@@ -19,6 +20,7 @@ struct tmrl;
 /** Defines a timer */
 struct tmr {
 	struct le le;       /**< Linked list element */
+	RE_ATOMIC bool active; /**< Timer is active  */
 	mtx_t *lock;        /**< Mutex lock          */
 	tmr_h *th;          /**< Timeout handler     */
 	void *arg;          /**< Handler argument    */

--- a/include/re_tmr.h
+++ b/include/re_tmr.h
@@ -21,7 +21,7 @@ struct tmrl;
 struct tmr {
 	struct le le;       /**< Linked list element */
 	RE_ATOMIC bool active; /**< Timer is active  */
-	mtx_t *lock;        /**< Mutex lock          */
+	mtx_t *llock;       /**< List Mutex lock     */
 	tmr_h *th;          /**< Timeout handler     */
 	void *arg;          /**< Handler argument    */
 	uint64_t jfs;       /**< Jiffies for timeout */

--- a/src/tmr/tmr.c
+++ b/src/tmr/tmr.c
@@ -393,15 +393,16 @@ static void tmr_startcont_dbg(struct tmr *tmr, uint64_t delay, bool syncnow,
 	if (!tmr || !tmrl)
 		return;
 
+	/* Prevent multiple cancel race conditions */
 	if (!re_atomic_acq(&tmr->active) && !th)
 		return;
 
 	re_atomic_rls_set(&tmr->active, false);
 
-	if (!tmr->lock || !tmr->le.list)
-		lock = tmrl->lock;
+	if (!tmr->llock || !tmr->le.list)
+		lock = tmrl->lock; /* use current list lock */
 	else
-		lock = tmr->lock; /* use old lock for unlinking */
+		lock = tmr->llock; /* use old list lock for unlinking */
 
 	mtx_lock(lock);
 
@@ -418,10 +419,10 @@ static void tmr_startcont_dbg(struct tmr *tmr, uint64_t delay, bool syncnow,
 	tmr->arg  = arg;
 	tmr->file = file;
 	tmr->line = line;
-	tmr->lock = tmrl->lock;
+	tmr->llock = tmrl->lock;
 
 	if (!th) {
-		tmr->lock = NULL;
+		tmr->llock = NULL;
 		mtx_unlock(lock);
 		return;
 	}


### PR DESCRIPTION
If `tmr_cancel` is called from multiple threads it's enough to cancel once. The behavior remains undefined if `tmr_start` is called from multiple threads in parallel and should prevented by the caller.