### PR TITLE
misc: text2pcap helpers (RTP/RTCP capturing)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,7 @@ set(SRCS
   src/fmt/regex.c
   src/fmt/str.c
   src/fmt/str_error.c
+  src/fmt/text2pcap.c
   src/fmt/time.c
   src/fmt/unicode.c
 

--- a/include/re_fmt.h
+++ b/include/re_fmt.h
@@ -203,3 +203,13 @@ void fmt_param_apply(const struct pl *pl, fmt_param_h *ph, void *arg);
 int utf8_encode(struct re_printf *pf, const char *str);
 int utf8_decode(struct re_printf *pf, const struct pl *pl);
 size_t utf8_byteseq(char u[4], unsigned cp);
+
+
+/* text2pcap */
+struct re_text2pcap {
+	bool in;
+	const struct mbuf *mb;
+	char *id;
+};
+
+int re_text2pcap(struct re_printf *pf, struct re_text2pcap *pcap);

--- a/include/re_fmt.h
+++ b/include/re_fmt.h
@@ -209,7 +209,9 @@ size_t utf8_byteseq(char u[4], unsigned cp);
 struct re_text2pcap {
 	bool in;
 	const struct mbuf *mb;
-	char *id;
+	const char *id;
 };
 
 int re_text2pcap(struct re_printf *pf, struct re_text2pcap *pcap);
+void re_text2pcap_trace(const char *name, const char *id, bool in,
+			const struct mbuf *mb);

--- a/include/re_fmt.h
+++ b/include/re_fmt.h
@@ -179,9 +179,10 @@ static inline bool str_isset(const char *s)
 
 
 /* time */
-int  fmt_gmtime(struct re_printf *pf, void *ts);
-int  fmt_timestamp(struct re_printf *pf, void *ts);
-int  fmt_human_time(struct re_printf *pf, const uint32_t *seconds);
+int fmt_gmtime(struct re_printf *pf, void *ts);
+int fmt_timestamp(struct re_printf *pf, void *ts);
+int fmt_timestamp_us(struct re_printf *pf, void *arg);
+int fmt_human_time(struct re_printf *pf, const uint32_t *seconds);
 
 
 void hexdump(FILE *f, const void *p, size_t len);

--- a/src/fmt/text2pcap.c
+++ b/src/fmt/text2pcap.c
@@ -1,0 +1,31 @@
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
+#include <time.h>
+
+#include <re_types.h>
+#include <re_fmt.h>
+#include <re_mbuf.h>
+
+
+int re_text2pcap(struct re_printf *pf, struct re_text2pcap *pcap)
+{
+	if (!pcap)
+		return EINVAL;
+
+	uint8_t *buf = mbuf_buf(pcap->mb);
+	if (!buf)
+		return EINVAL;
+
+	re_hprintf(pf, "%s %H 000000", pcap->in ? "I" : "O", fmt_timestamp_us,
+		   NULL);
+
+	size_t sz = mbuf_get_left(pcap->mb);
+	for (size_t i = 0; i < sz; i++) {
+		re_hprintf(pf, " %02x", buf[i]);
+	}
+
+	re_hprintf(pf, " %s", pcap->id);
+
+	return 0;
+}

--- a/test/fmt.c
+++ b/test/fmt.c
@@ -1158,3 +1158,30 @@ int test_fmt_hexdump(void)
 
 	return 0;
 }
+
+
+int test_text2pcap(void)
+{
+	char test[64];
+	struct mbuf *mb;
+	int err = 0;
+
+	mb = mbuf_alloc(2);
+	if (!mb)
+		return ENOMEM;
+
+	mbuf_write_u8(mb, 42);
+	mbuf_write_u8(mb, 23);
+
+	mbuf_set_pos(mb, 0);
+
+	struct re_text2pcap pcap = {.id = "test", .in = true, .mb = mb};
+
+	int ret = re_snprintf(test, sizeof(test), "%H", re_text2pcap, &pcap);
+
+	TEST_EQUALS(35, ret);
+
+out:
+	mem_deref(mb);
+	return err;
+}

--- a/test/test.c
+++ b/test/test.c
@@ -214,6 +214,7 @@ static const struct test tests[] = {
 	TEST(test_sys_getenv),
 	TEST(test_tcp),
 	TEST(test_telev),
+	TEST(test_text2pcap),
 #ifdef USE_TLS
 	TEST(test_tls),
 	TEST(test_tls_ec),

--- a/test/test.h
+++ b/test/test.h
@@ -330,6 +330,7 @@ int test_sys_fs_fopen(void);
 int test_sys_getenv(void);
 int test_tcp(void);
 int test_telev(void);
+int test_text2pcap(void);
 int test_thread(void);
 int test_thread_cnd_timedwait(void);
 int test_tmr_jiffies(void);

--- a/test/trace.c
+++ b/test/trace.c
@@ -67,5 +67,7 @@ int test_trace(void)
 #endif
 
 out:
+	if (err)
+		re_trace_close();
 	return err;
 }


### PR DESCRIPTION
text2pcap is useful for debugging encrypted connections like DTLS_SRTP from application context.

See: https://blog.mozilla.org/webrtc/debugging-encrypted-rtp-is-more-fun-than-it-used-to-be/

```bash
jq -r ".traceEvents[] | select (.cat == \"pcap\") | .args.pcap" re_trace.json | text2pcap -D -n -l1 -i17 -u 1000,2000 -t '%H:%M:%S.%f' - dump.pcapng
```

Documentation: https://github.com/baresip/baresip/wiki/Text2pcap-RTP-and-RTCP-capturing