### PR TITLE
audio: cleanup start/stop redundancy part 1

### DIFF
--- a/src/sdp/media.c
+++ b/src/sdp/media.c
@@ -764,6 +764,9 @@ const struct sdp_format *sdp_media_rformat(const struct sdp_media *m,
 		if (!fmt->sup)
 			continue;
 
+		if (!fmt->data)
+			continue;
+
 		if (name && str_casecmp(name, fmt->name))
 			continue;
 


### PR DESCRIPTION
- sdp: null pointer check for sdp_format data

Helps to remove redundancy in baresip: https://github.com/baresip/baresip/pull/2943