### PR TITLE
release v3.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v3.10.0] - 2024-03-06
+
+## What's Changed
+* transp: deref qent only if qentp is not set by @maximilianfridrich in https://github.com/baresip/re/pull/1061
+* sipsess: fix doxygen comments by @alfredh in https://github.com/baresip/re/pull/1062
+* aufile: fix doxygen comment by @alfredh in https://github.com/baresip/re/pull/1063
+* ci/codeql: bump action v3 by @sreimers in https://github.com/baresip/re/pull/1064
+* misc: text2pcap helpers (RTP/RTCP capturing) by @sreimers in https://github.com/baresip/re/pull/1065
+* ci/mingw: bump upload/download-artifact and cache versions by @sreimers in https://github.com/baresip/re/pull/1066
+* transp,tls: add TLS client verification by @maximilianfridrich in https://github.com/baresip/re/pull/1059
+* fmt/text2pcap: cleanup by @sreimers in https://github.com/baresip/re/pull/1067
+* ci/android: cache openssl build by @sreimers in https://github.com/baresip/re/pull/1068
+* ci/misc: fix double push/pull runs by @sreimers in https://github.com/baresip/re/pull/1069
+* fmt/text2pcap: fix coverity return value warning by @sreimers in https://github.com/baresip/re/pull/1070
+* sipsess/listen: improve glare handling by @maximilianfridrich in https://github.com/baresip/re/pull/1071
+* conf: add conf_get_i32 by @sreimers in https://github.com/baresip/re/pull/1072
+
+
+**Full Changelog**: https://github.com/baresip/re/compare/v3.9.0...v3.10.0
+
+
 ## [v3.9.0] - 2024-01-31
 
 ## What's Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,13 +14,13 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(re
-  VERSION 3.9.0
+  VERSION 3.10.0
   LANGUAGES C
   HOMEPAGE_URL https://github.com/baresip/re
   DESCRIPTION "Generic library for real-time communications"
 )
 
-set(PROJECT_SOVERSION 21) # bump if ABI breaks
+set(PROJECT_SOVERSION 22) # bump if ABI breaks
 
 # Pre-release identifier, comment out on a release
 # Increment for breaking changes (dev2, dev3...)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libre (3.10.0) unstable; urgency=medium
+
+  * version 3.10.0
+
+ -- Christian Spielberger <c.spielberger@commend.com>  Wed, 6 Mar 2024 11:40:00 +0100
+
 libre (3.9.0) unstable; urgency=medium
 
   * version 3.9.0

--- a/mk/Doxyfile
+++ b/mk/Doxyfile
@@ -4,7 +4,7 @@
 # Project related configuration options
 #---------------------------------------------------------------------------
 PROJECT_NAME           = libre
-PROJECT_NUMBER         = 3.9.0
+PROJECT_NUMBER         = 3.10.0
 OUTPUT_DIRECTORY       = ../re-dox
 CREATE_SUBDIRS         = NO
 OUTPUT_LANGUAGE        = English


### PR DESCRIPTION
### Create/Prepare PRs for new Release (re/baresip)
- [x] Update `CHANGELOG.md`
  - Click `Draft a new release` on Release page
  - Fill a new release tag version and title (like v2.4.0)
  - Press `Generate release notes` 
  - **Save as draft** (don't publish yet)
  - Copy release notes to `CHANGELOG.md`
- [x] Update `debian/changelog`
- [x] Check/Inc version numbers
  - `CMakeLists.txt`
  - `include/baresip.h`
  - `mk/Doxyfile`
- [x] Check ABI compatibility
  - `CMakeLists.txt` (Bump PROJECT_SOVERSION)
- [x] Comment out PRE Release identifier `-dev`
  - `CMakeLists.txt`
- [x] All tests green? [re, baresip]

### Release
- [ ] Merge PRs in this order
  - libre
  - baresip
- [ ] Publish draft Releases (follow the same order)
  - Maybe `Generate Release notes` is needed to update (delete last notes first)

### After Release
- [ ] Bump main branch versions with PRE Release identifier `-dev`
  - `CMakeLists.txt`
  - `include/baresip.h` (baresip only)


### Release schedule


- ~v3.6.0 18. Oct (@alfredh)~
- ~v3.7.0 22. Nov (@cspiel1)~
- ~v3.8.0 27. Dec (@sreimers)~
- ~v3.9.0 31. Jan (@alfredh)~
- v3.10.0 6. Mar (@cspiel1)
- v3.11.0 10. Apr (@sreimers)
