### PR TITLE
thread: fix gcc warnings

### DIFF
--- a/src/thread/posix.c
+++ b/src/thread/posix.c
@@ -22,7 +22,7 @@ static void *handler(void *p)
 	mem_deref(p);
 
 	ret = th.func(th.arg);
-	
+
 	return (void *)(intptr_t)ret;
 }
 

--- a/src/thread/posix.c
+++ b/src/thread/posix.c
@@ -23,7 +23,7 @@ static void *handler(void *p)
 
 	ret = th.func(th.arg);
 	
-	return (void *)(intptr_t)ret; 
+	return (void *)(intptr_t)ret;
 }
 
 

--- a/src/thread/posix.c
+++ b/src/thread/posix.c
@@ -16,11 +16,14 @@ struct thread {
 
 static void *handler(void *p)
 {
+	int ret;
 	struct thread th = *(struct thread *)p;
 
 	mem_deref(p);
 
-	return (void *)(intptr_t)th.func(th.arg);
+	ret = th.func(th.arg);
+	
+	return (void *)(intptr_t)ret; 
 }
 
 


### PR DESCRIPTION
warning: cast from function call of type ‘int’ to non-matching type ‘void *’ [-Wbad-function-cast]