### PR TITLE
ci/clang-analyze: bump clang version and fix status-bugs

### DIFF
--- a/.github/workflows/clang-analyze.yml
+++ b/.github/workflows/clang-analyze.yml
@@ -29,4 +29,4 @@ jobs:
     - name: analyze
       run: | 
         cmake -B build -DCMAKE_C_COMPILER=clang-17
-        analyze-build-17 --cdb build/compile_commands.json --status-bugs
+        analyze-build-17 --cdb build/compile_commands.json --status-bugs -v

--- a/.github/workflows/clang-analyze.yml
+++ b/.github/workflows/clang-analyze.yml
@@ -23,10 +23,10 @@ jobs:
     - name: Install clang-tools
       run: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
-        sudo apt-get update && sudo apt-get install -y clang-tools-15
+        sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main"
+        sudo apt-get update && sudo apt-get install -y clang-tools-17
 
     - name: analyze
       run: | 
-        cmake -B build -DCMAKE_C_COMPILER=clang-15
-        analyze-build-15 --cdb build/compile_commands.json
+        cmake -B build -DCMAKE_C_COMPILER=clang-17
+        analyze-build-17 --cdb build/compile_commands.json --status-bugs

--- a/src/fmt/time.c
+++ b/src/fmt/time.c
@@ -148,7 +148,7 @@ int fmt_timestamp_us(struct re_printf *pf, void *arg)
 	int h, m, s;
 	uint64_t us;
 	struct timespec tspec;
-	struct tm tm;
+	struct tm tm = {0};
 
 #if defined(WIN32) && !defined(__MINGW32__)
 	timespec_get(&tspec, TIME_UTC);

--- a/test/httpauth.c
+++ b/test/httpauth.c
@@ -651,13 +651,13 @@ int test_httpauth_digest_response(void)
 			goto out;
 		}
 
-		mb_printed = mem_deref (mb_printed);
-		resp = mem_deref(resp);
+		mem_deref(mb_printed);
+		mem_deref(resp);
 		continue;
 
 out:
-		mb_printed = mem_deref (mb_printed);
-		resp = mem_deref(resp);
+		mem_deref(mb_printed);
+		mem_deref(resp);
 		break;
 	}
 

--- a/test/sipsess.c
+++ b/test/sipsess.c
@@ -203,7 +203,7 @@ out:
 static void send_update_a(void *arg)
 {
 	struct test *test = arg;
-	struct mbuf *desc;
+	struct mbuf *desc = NULL;
 	int err;
 
 	err = make_sdp(&desc, sdp_a);
@@ -223,7 +223,7 @@ out:
 static void send_update_b(void *arg)
 {
 	struct test *test = arg;
-	struct mbuf *desc;
+	struct mbuf *desc = NULL;
 	int err;
 
 	err = make_sdp(&desc, sdp_b);
@@ -433,7 +433,7 @@ static void close_handler(int err, const struct sip_msg *msg, void *arg)
 static void conn_handler(const struct sip_msg *msg, void *arg)
 {
 	struct test *test = arg;
-	struct mbuf *desc;
+	struct mbuf *desc = NULL;
 	int err;
 	char *hdrs = test->rel100_b == REL100_REQUIRED ?
 		     "Require: 100rel\r\n" : "";


### PR DESCRIPTION
Fixes:

```c
test/httpauth.c:654:3: warning: Value stored to 'mb_printed' is never read
test/sipsess.c:216:2: warning: 1st function call argument is an uninitialized Value
test/sipsess.c:236:2: warning: 1st function call argument is an uninitialized Value
test/sipsess.c:535:2: warning: 1st function call argument is an uninitialized value
```