### PR TITLE
ci/sanitizers: add mmap rnd_bits workaround

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -30,6 +30,10 @@ jobs:
       run: |
         sudo sed -i 's/azure\./de\./' /etc/apt/sources.list
 
+    - name: mmap rnd_bits workaround
+      run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28
+
     - name: install packages
       run: |
         sudo apt-get update && sudo apt-get install -y ninja-build


### PR DESCRIPTION
`vm.mmap_rnd_bits` has been recently changed to 32 on GHA, which triggers issues in ASAN builds that spuriously fail on startup.