### PR TITLE
thread/posix: optimize handler and fix gcc arm32 warning

### DIFF
--- a/src/thread/posix.c
+++ b/src/thread/posix.c
@@ -16,11 +16,12 @@ struct thread {
 
 static void *handler(void *p)
 {
-	struct thread th = *(struct thread *)p;
+	struct thread *th = p;
 
-	mem_deref(p);
+	int ret = th->func(th->arg);
+	mem_deref(th);
 
-	return (void *)(intptr_t)th.func(th.arg);
+	return (void *)(intptr_t)ret;
 }
 
 


### PR DESCRIPTION
Fixes (on arm32 gcc):
warning: cast from function call of type ‘int’ to non-matching type ‘void *’ [-Wbad-function-cast]