### PR TITLE
main,httpauth: fix different from the declaration

### DIFF
--- a/include/re_httpauth.h
+++ b/include/re_httpauth.h
@@ -113,8 +113,8 @@ int httpauth_digest_response_print(struct re_printf *pf,
 	const struct httpauth_digest_enc_resp *resp);
 int httpauth_digest_response_set_cnonce(struct httpauth_digest_enc_resp *resp,
 	const struct httpauth_digest_chall *chall, const struct pl *method,
-	const char *user,	const char *passwd, const char *entitybody,
-	const uint32_t cnonce, const uint32_t nc_);
+	const char *user, const char *passwd, const char *entitybody,
+	uint32_t cnonce, uint32_t nonce_cnt);
 int httpauth_digest_response(struct httpauth_digest_enc_resp **presp,
 	const struct httpauth_digest_chall *chall, const struct pl *method,
 	const char *uri, const char *user, const char *passwd, const char *qop,

--- a/include/re_main.h
+++ b/include/re_main.h
@@ -36,8 +36,8 @@ typedef void (fd_h)(int flags, void *arg);
 typedef void (re_signal_h)(int sig);
 
 
-int   fd_listen(struct re_fhs **fhs, re_sock_t fd, int flags, fd_h *fh,
-		void *arg);
+int   fd_listen(struct re_fhs **fhsp, re_sock_t fd, int flags, fd_h fh,
+	void *arg);
 struct re_fhs *fd_close(struct re_fhs *fhs);
 int   fd_setsize(int maxfds);
 

--- a/include/re_main.h
+++ b/include/re_main.h
@@ -36,7 +36,7 @@ typedef void (fd_h)(int flags, void *arg);
 typedef void (re_signal_h)(int sig);
 
 
-int   fd_listen(struct re_fhs **fhsp, re_sock_t fd, int flags, fd_h fh,
+int   fd_listen(struct re_fhs **fhsp, re_sock_t fd, int flags, fd_h *fh,
 	void *arg);
 struct re_fhs *fd_close(struct re_fhs *fhs);
 int   fd_setsize(int maxfds);

--- a/src/httpauth/digest.c
+++ b/src/httpauth/digest.c
@@ -1000,13 +1000,13 @@ int httpauth_digest_response_print(struct re_printf *pf,
 int httpauth_digest_response_set_cnonce(struct httpauth_digest_enc_resp *resp,
 	const struct httpauth_digest_chall *chall, const struct pl *method,
 	const char *user,	const char *passwd, const char *entitybody,
-	uint32_t cnonce, uint32_t nonce_counter)
+	uint32_t cnonce, uint32_t nonce_cnt)
 {
 	if (!resp || !chall || !method || !passwd)
 		return EINVAL;
 
 	resp->cnonce = cnonce;
-	resp->nc = nonce_counter;
+	resp->nc = nonce_cnt;
 
 	return digest_response(resp, chall, method,
 		user, passwd, entitybody);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -569,7 +569,7 @@ static int poll_setup(struct re *re)
  *
  * @return 0 if success, otherwise errorcode
  */
-int fd_listen(struct re_fhs **fhsp, re_sock_t fd, int flags, fd_h fh,
+int fd_listen(struct re_fhs **fhsp, re_sock_t fd, int flags, fd_h *fh,
 	      void *arg)
 {
 	struct re *re = re_get();
@@ -581,7 +581,7 @@ int fd_listen(struct re_fhs **fhsp, re_sock_t fd, int flags, fd_h fh,
 		return EINVAL;
 	}
 
-	if (!fhsp || !flags || fh == NULL)
+	if (!fhsp || !flags || !fh)
 		return EINVAL;
 
 #ifndef RELEASE

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -581,7 +581,7 @@ int fd_listen(struct re_fhs **fhsp, re_sock_t fd, int flags, fd_h fh,
 		return EINVAL;
 	}
 
-	if (!fhsp || !flags || !fh)
+	if (!fhsp || !flags || fh == NULL)
 		return EINVAL;
 
 #ifndef RELEASE


### PR DESCRIPTION
Fix 2 Parameter is different from the declaration.
Fix 1 Warning C4550: Expression evaluated as a function with missing parameter list

fixes: https://github.com/baresip/re/issues/1094