### PR TITLE
sess,request: deref request and ctrans immediately

### DIFF
--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -344,6 +344,7 @@ int sip_drequestf(struct sip_request **reqp, struct sip *sip, bool stateful,
 void sip_request_cancel(struct sip_request *req);
 bool sip_request_loops(struct sip_loopstate *ls, uint16_t scode);
 void sip_loopstate_reset(struct sip_loopstate *ls);
+bool sip_request_provrecv(const struct sip_request *req);
 
 
 /* reply */

--- a/src/sip/request.c
+++ b/src/sip/request.c
@@ -970,10 +970,25 @@ void sip_request_cancel(struct sip_request *req)
 
 	req->canceled = true;
 
-	if (!req->provrecv)
+	if (!req->provrecv) {
+		req->ct = mem_deref(req->ct);
 		return;
+	}
 
 	(void)sip_ctrans_cancel(req->ct);
+}
+
+
+/**
+ * Check if a provisional response was received for a SIP Request
+ *
+ * @param req SIP Request
+ *
+ * @return True if a provisional response was received, false otherwise
+ */
+bool sip_request_provrecv(const struct sip_request *req)
+{
+	return req ? req->provrecv : false;
 }
 
 

--- a/src/sipsess/sess.c
+++ b/src/sipsess/sess.c
@@ -85,8 +85,13 @@ static bool termwait(struct sipsess *sess)
 
 	if (sess->req) {
 		sip_request_cancel(sess->req);
-		mem_ref(sess);
-		wait = true;
+		if (!sip_request_provrecv(sess->req)) {
+			sess->req = mem_deref(sess->req);
+		}
+		else {
+			mem_ref(sess);
+			wait = true;
+		}
 	}
 
 	if (sess->replyl.head) {


### PR DESCRIPTION
... if no provisional response was received for the request.

This caused the following undesirable behavior with UDP: A user starts a call, doesn't get a response and so the user cancels it. Shortly after, the recipient of the INVITE goes online, receives a UDP retransmission of the INVITE and sends a response. The user could suddenly be in a call they thought they cancelled.

With this change, if a SIP session is terminated, the underlying `request` and `ctrans` are destroyed immediately if no response was received at all.

For reliable transports this does not happen because a transport error would occur and there are no retransmissions.