### PR TITLE
test: udp_listen NULL

### DIFF
--- a/src/net/sockopt.c
+++ b/src/net/sockopt.c
@@ -124,7 +124,8 @@ int net_sockopt_v6only(re_sock_t fd, bool only)
 {
 	int on = only;
 
-#ifndef OPENBSD
+	DEBUG_NOTICE("net_sockopt_v6only: on=%d\n", on);
+
 #ifdef IPV6_V6ONLY
 	if (-1 == setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY,
 			     BUF_CAST &on, sizeof(on))) {
@@ -132,8 +133,10 @@ int net_sockopt_v6only(re_sock_t fd, bool only)
 		DEBUG_WARNING("IPV6_V6ONLY: %m\n", err);
 		return err;
 	}
+#else
+	DEBUG_NOTICE("net_sockopt_v6only: COMPILE-TIME DISABLED\n");
 #endif
-#endif
+
 	return 0;
 }
 

--- a/test/udp.c
+++ b/test/udp.c
@@ -164,7 +164,7 @@ int test_udp(void)
 	if (err)
 		goto out;
 
-	err  = udp_listen(&ut->usc, &ut->cli, udp_recv_client, ut);
+	err  = udp_listen(&ut->usc, NULL, udp_recv_client, ut);
 	err |= udp_listen(&ut->uss, &ut->srv, udp_recv_server, ut);
 	if (err)
 		goto out;

--- a/test/udp.c
+++ b/test/udp.c
@@ -48,6 +48,9 @@ static int send_data(struct udp_sock *us, const struct sa *peer,
 	mb->pos = 0;
 
 	err = udp_send(us, peer, mb);
+	if (err) {
+		DEBUG_WARNING("udp_send error: %m\n", err);
+	}
 
 	mem_deref(mb);
 


### PR DESCRIPTION
DRAFT

How should we handle if local address to udp_listen is NULL?
Example:

```
udp_listen(us, NULL, handler, arg);
```

For example Windows fails with:

```
Process completed with exit code 10014.
```
