### PR TITLE
types: use size of int as default RE_ARG_SIZE

### DIFF
--- a/include/re_types.h
+++ b/include/re_types.h
@@ -322,7 +322,7 @@ typedef int re_sock_t;
 	void const*:		sizeof(void const *),                         \
 	void*:			sizeof(void *),                               \
 	struct pl:		sizeof(struct pl),                            \
-	default: sizeof(void*)                                                \
+	default:                sizeof(int)                                   \
 )
 
 #define RE_ARG_0() 0


### PR DESCRIPTION
The default type promotion for smaller types is int