### PR TITLE
types: fix RE_ARG_SIZE gcc bit fields

### DIFF
--- a/include/re_types.h
+++ b/include/re_types.h
@@ -303,7 +303,7 @@ typedef int re_sock_t;
 #define HAVE_RE_ARG 1
 
 #define RE_ARG_SIZE(type)                                                     \
-	_Generic((type),                                                      \
+	_Generic((0)?(type):(type),                                           \
 	bool:			sizeof(int),                                  \
 	char:			sizeof(int),                                  \
 	unsigned char:		sizeof(unsigned int),                         \


### PR DESCRIPTION
GCC workaround for bit fields (always default otherwise).

Ref: https://gcc.gnu.org/legacy-ml/gcc/2016-02/msg00266.html