### PR TITLE
http/request: reset body mbuf pos on re-sending

### DIFF
--- a/src/http/request.c
+++ b/src/http/request.c
@@ -235,6 +235,7 @@ static void resp_handler(int err, const struct http_msg *msg, void *arg)
 	}
 
 	pl_set_mbuf(&auth, abuf);
+	mbuf_set_pos(conn->body, 0);
 	err = send_req(conn, &auth);
 	if (err)
 		goto disconnect;


### PR DESCRIPTION
This fixes the following bug:

If a HTTP request is resent (e.g. with Authentication after a 401 response), the body of the request is not sent.

This is because in `req_body_handler` `mbuf_advance(conn->body, len)` is called. Then the request is re-sent and the body size is obtained by calling `mbuf_get_left(conn->body)` which is now incorrect.

The fix is to reset the `mbuf` position of `conn->body` before re-sending a request.