### PR TITLE
tls: allow secure TLS renegotiation

### DIFF
--- a/src/tls/openssl/tls_tcp.c
+++ b/src/tls/openssl/tls_tcp.c
@@ -230,7 +230,7 @@ static bool recv_handler(int *err, struct mbuf *mb, bool *estab, void *arg)
 
 	if (SSL_state(tc->ssl) != SSL_ST_OK) {
 
-		if (tc->up) {
+		if (tc->up && !SSL_get_secure_renegotiation_support(tc->ssl)) {
 			*err = EPROTO;
 			return true;
 		}

--- a/src/tls/openssl/tls_udp.c
+++ b/src/tls/openssl/tls_udp.c
@@ -353,7 +353,7 @@ static void conn_recv(struct tls_conn *tc, struct mbuf *mb)
 
 	if (SSL_state(tc->ssl) != SSL_ST_OK) {
 
-		if (tc->up) {
+		if (tc->up && !SSL_get_secure_renegotiation_support(tc->ssl)) {
 			conn_close(tc, EPROTO);
 			return;
 		}


### PR DESCRIPTION
With the current implementation, TLS renegotiations do not work, even if they are performed in a secure manner. With this change, TLS renegotiations are now possible if they are done in a secure manner (i.e. as described in [RFC 5746](https://www.rfc-editor.org/rfc/rfc5746)).

Read more about OpenSSL secure renegotiation [in the OpenSSL docs](https://www.openssl.org/docs/man3.2/man3/SSL_get_secure_renegotiation_support.html) (**SECURE RENEGOTIATION** section).
