### PR TITLE
tls/http: add certificate chain setters

### DIFF
--- a/include/re_http.h
+++ b/include/re_http.h
@@ -169,6 +169,9 @@ int http_client_set_cert(struct http_cli *cli, const char *path);
 int http_client_set_certpem(struct http_cli *cli, const char *pem);
 int http_client_set_key(struct http_cli *cli, const char *path);
 int http_client_set_keypem(struct http_cli *cli, const char *pem);
+int http_client_use_chain(struct http_cli *cli, const char *path);
+int http_client_use_chainpem(struct http_cli *cli, const char *chain,
+			     int len_chain);
 
 int http_client_set_session_reuse(struct http_cli *cli, bool enabled);
 int http_client_set_tls_min_version(struct http_cli *cli, int version);

--- a/include/re_tls.h
+++ b/include/re_tls.h
@@ -56,6 +56,9 @@ int tls_set_certificate_der(struct tls *tls, enum tls_keytype keytype,
 			    const uint8_t *cert, size_t len_cert,
 			    const uint8_t *key, size_t len_key);
 int tls_set_certificate(struct tls *tls, const char *cert, size_t len);
+int tls_set_certificate_chain_pem(struct tls *tls, const char *chain,
+				  size_t len_chain);
+int tls_set_certificate_chain(struct tls *tls, const char *path);
 void tls_set_verify_client(struct tls *tls);
 void tls_set_verify_client_trust_all(struct tls *tls);
 int tls_set_verify_client_handler(struct tls_conn *tc, int depth,

--- a/src/http/client.c
+++ b/src/http/client.c
@@ -1260,6 +1260,58 @@ int http_client_disable_verify_server(struct http_cli *cli)
 
 	return 0;
 }
+
+
+/**
+ * Change used certificate+key of TLS connection
+ *
+ * @param cli       HTTP Client
+ * @param chain     Cert (chain) + Key (PEM format)
+ * @param len_chain Length of certificate + key PEM string
+ *
+ * @return int 0 if success, otherwise errorcode
+ */
+int http_client_use_chainpem(struct http_cli *cli, const char *chain,
+			     int len_chain)
+{
+	if (!cli || !cli->tls)
+		return EINVAL;
+
+	int err = tls_set_certificate_chain_pem(cli->tls, chain, len_chain);
+	if (err)
+		return err;
+
+	cli->cert = mem_deref(cli->cert);
+	cli->key = mem_deref(cli->key);
+
+	return 0;
+}
+
+
+/**
+ * Change used certificate+key of TLS connection
+ *
+ * @param cli  HTTP Client
+ * @param path Path to Cert (chain) + Key file (PEM format)
+ *
+ * @return int 0 if success, otherwise errorcode
+ */
+int http_client_use_chain(struct http_cli *cli, const char *path)
+{
+	int err;
+
+	if (!cli || !cli->tls)
+		return EINVAL;
+
+	err =  tls_set_certificate_chain(cli->tls, path);
+	if (err)
+		return err;
+
+	cli->cert = mem_deref(cli->cert);
+	cli->key = mem_deref(cli->key);
+
+	return 0;
+}
 #endif /* USE_TLS */
 
 


### PR DESCRIPTION
The current setters (e.g. `tls_set_certificate`) only allow single certificates to be set. Now the whole chain can be set.