### PR TITLE
sipsess/connect: set sess->established immediately on 200 receival

### DIFF
--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -148,15 +148,15 @@ static void invite_resp_handler(int err, const struct sip_msg *msg, void *arg)
 	}
 	else if (msg->scode < 300) {
 
+		sess->established = true;
+
 		sess->hdrs = mem_deref(sess->hdrs);
 
 		err = sip_dialog_established(sess->dlg) ?
 				sip_dialog_update(sess->dlg, msg) :
 				sip_dialog_create(sess->dlg, msg);
-		if (err)
-			goto out;
 
-		if (sdp) {
+		if (sdp && !err) {
 			if (sess->neg_state == SDP_NEG_LOCAL_OFFER) {
 				sess->neg_state = SDP_NEG_DONE;
 				err = sess->answerh(msg, sess->arg);
@@ -179,7 +179,6 @@ static void invite_resp_handler(int err, const struct sip_msg *msg, void *arg)
 		    && mbuf_get_left(desc))
 			sess->neg_state = SDP_NEG_DONE;
 
-		sess->established = true;
 		mem_deref(desc);
 
 		if (err || sess->terminated)


### PR DESCRIPTION
Otherwise, if something in `invite_resp_handler` fails and `sipsess_terminate` is called, no BYE will be sent.