### PR TITLE
sip: verify call-id, to-tag, cseq of INVITE response

### DIFF
--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -402,6 +402,7 @@ void sip_dialog_set_srcport(struct sip_dialog *dlg, uint16_t srcport);
 uint16_t sip_dialog_srcport(struct sip_dialog *dlg);
 const char *sip_dialog_uri(const struct sip_dialog *dlg);
 uint32_t sip_dialog_lseq(const struct sip_dialog *dlg);
+uint32_t sip_dialog_lseqinv(const struct sip_dialog *dlg);
 enum sip_transp sip_dialog_tp(const struct sip_dialog *dlg);
 bool sip_dialog_established(const struct sip_dialog *dlg);
 bool sip_dialog_cmp(const struct sip_dialog *dlg, const struct sip_msg *msg);

--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -91,6 +91,10 @@ static void invite_resp_handler(int err, const struct sip_msg *msg, void *arg)
 	if (!msg || err || sip_request_loops(&sess->ls, msg->scode))
 		goto out;
 
+	if (!sip_dialog_cmp_half(sess->dlg, msg)
+		|| sip_dialog_lseqinv(sess->dlg) != msg->cseq.num)
+		goto out;
+
 	sdp = mbuf_get_left(msg->mb) > 0;
 
 	if (msg->scode < 200) {


### PR DESCRIPTION
Note that `lseq` could not be used because there might be PRACKs sent which increment the CSeq and would cause a mismatch.