### PR TITLE
tls: refactoring SNI ctx usage for libressl support

### DIFF
--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -1997,8 +1997,10 @@ int tls_add_certf(struct tls *tls, const char *certf, const char *host)
 		goto err;
 
 	X509_STORE *ca = SSL_CTX_get_cert_store(tls->ctx);
-	X509_STORE_up_ref(ca);
-	SSL_CTX_set_cert_store(uc->ctx, ca);
+	if (ca) {
+		X509_STORE_up_ref(ca);
+		SSL_CTX_set_cert_store(uc->ctx, ca);
+	}
 
 	list_append(&tls->certs, &uc->le, uc);
 	if (list_count(&tls->certs) == 1)

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -382,6 +382,9 @@ int tls_add_cafile_path(struct tls *tls, const char *cafile,
 		return ENOTDIR;
 	}
 
+	tls->cafile = mem_deref(tls->cafile);
+	tls->capath = mem_deref(tls->capath);
+
 	str_dup(&tls->cafile, cafile);
 	str_dup(&tls->capath, capath);
 
@@ -1967,6 +1970,8 @@ static void tls_cert_destructor(void *arg)
 	struct tls_cert *uc = arg;
 
 	mem_deref(uc->host);
+	if (uc->ctx)
+		SSL_CTX_free(uc->ctx);
 }
 
 

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -247,14 +247,12 @@ static int tls_ctx_alloc(SSL_CTX **ctxp, enum tls_method method,
 
 	default:
 		DEBUG_WARNING("tls method %d not supported\n", method);
-		err = ENOSYS;
-		goto out;
+		return ENOSYS;
 	}
 
 	if (!ctx) {
 		ERR_clear_error();
-		err = ENOMEM;
-		goto out;
+		return ENOMEM;
 	}
 
 	SSL_CTX_set_min_proto_version(ctx, min_proto);

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -58,9 +58,7 @@ struct tls {
  */
 struct tls_cert {
 	struct le le;
-	X509 *x509;
-	EVP_PKEY *pkey;
-	STACK_OF(X509) *chain;
+	SSL_CTX *ctx;
 	char *host;
 };
 
@@ -164,7 +162,6 @@ static int keytype2int(enum tls_keytype type)
 }
 
 
-#if !defined(LIBRESSL_VERSION_NUMBER)
 /**
  * OpenSSL verify handler for debugging purposes. Prints only warnings in the
  * default build
@@ -207,7 +204,6 @@ int tls_verify_handler(int ok, X509_STORE_CTX *ctx)
 
 	return ok;
 }
-#endif
 
 
 static int tls_verify_idx = -1;
@@ -220,6 +216,82 @@ static void tls_init_verify_idx(void)
 
 	tls_verify_idx = SSL_get_ex_new_index(0, "tls verify ud",
 		NULL, NULL, NULL);
+}
+
+
+static int tls_ctx_alloc(SSL_CTX **ctxp, enum tls_method method,
+			 const char *certf, const char *pwd, struct tls *tls)
+{
+	int err = 0;
+	int r;
+	SSL_CTX *ctx;
+	int min_proto = 0;
+
+	switch (method) {
+
+	case TLS_METHOD_TLS:
+	case TLS_METHOD_SSLV23:
+		ctx	  = SSL_CTX_new(TLS_method());
+		min_proto = TLS1_2_VERSION;
+		break;
+
+	case TLS_METHOD_DTLS:
+	case TLS_METHOD_DTLSV1:
+	case TLS_METHOD_DTLSV1_2:
+		ctx = SSL_CTX_new(DTLS_method());
+		break;
+
+	default:
+		DEBUG_WARNING("tls method %d not supported\n", method);
+		err = ENOSYS;
+		goto out;
+	}
+
+	if (!ctx) {
+		ERR_clear_error();
+		err = ENOMEM;
+		goto out;
+	}
+
+	SSL_CTX_set_min_proto_version(ctx, min_proto);
+
+	if (!certf)
+		goto out;
+
+	/* Load our keys and certificates */
+	if (pwd && tls) {
+		err = str_dup(&tls->pass, pwd);
+		if (err)
+			goto out;
+
+		SSL_CTX_set_default_passwd_cb(ctx, password_cb);
+		SSL_CTX_set_default_passwd_cb_userdata(ctx, tls);
+	}
+
+	r = SSL_CTX_use_certificate_chain_file(ctx, certf);
+	if (r <= 0) {
+		DEBUG_WARNING("Can't read certificate file: %s (%d)\n", certf,
+			      r);
+		ERR_clear_error();
+		err = EINVAL;
+		goto out;
+	}
+
+	r = SSL_CTX_use_PrivateKey_file(ctx, certf, SSL_FILETYPE_PEM);
+	if (r <= 0) {
+		DEBUG_WARNING("Can't read key file: %s (%d)\n", certf, r);
+		ERR_clear_error();
+		err = EINVAL;
+		goto out;
+	}
+
+out:
+	if (err)
+		SSL_CTX_free(ctx);
+	else
+		*ctxp = ctx;
+
+	return err;
 }
 
 
@@ -237,8 +309,7 @@ int tls_alloc(struct tls **tlsp, enum tls_method method, const char *keyfile,
 	      const char *pwd)
 {
 	struct tls *tls;
-	int r, err;
-	int min_proto = 0;
+	int err;
 
 	if (!tlsp)
 		return EINVAL;
@@ -247,71 +318,15 @@ int tls_alloc(struct tls **tlsp, enum tls_method method, const char *keyfile,
 	if (!tls)
 		return ENOMEM;
 
-	tls->verify_server = true;
-	switch (method) {
-
-	case TLS_METHOD_TLS:
-	case TLS_METHOD_SSLV23:
-		tls->ctx = SSL_CTX_new(TLS_method());
-		min_proto = TLS1_2_VERSION;
-		break;
-
-	case TLS_METHOD_DTLS:
-	case TLS_METHOD_DTLSV1:
-	case TLS_METHOD_DTLSV1_2:
-		tls->ctx = SSL_CTX_new(DTLS_method());
-		break;
-
-	default:
-		DEBUG_WARNING("tls method %d not supported\n", method);
-		err = ENOSYS;
-		goto out;
-	}
-
-	if (!tls->ctx) {
-		ERR_clear_error();
-		err = ENOMEM;
-		goto out;
-	}
-
-	err = tls_set_min_proto_version(tls, min_proto);
+	err = tls_ctx_alloc(&tls->ctx, method, keyfile, pwd, tls);
 	if (err)
 		goto out;
+
+	tls->verify_server = true;
 
 #if defined(TRACE_SSL)
 	SSL_CTX_set_keylog_callback(tls->ctx, tls_keylogger_cb);
 #endif
-
-	/* Load our keys and certificates */
-	if (keyfile) {
-		if (pwd) {
-			err = str_dup(&tls->pass, pwd);
-			if (err)
-				goto out;
-
-			SSL_CTX_set_default_passwd_cb(tls->ctx, password_cb);
-			SSL_CTX_set_default_passwd_cb_userdata(tls->ctx, tls);
-		}
-
-		r = SSL_CTX_use_certificate_chain_file(tls->ctx, keyfile);
-		if (r <= 0) {
-			DEBUG_WARNING("Can't read certificate file: %s (%d)\n",
-				      keyfile, r);
-			ERR_clear_error();
-			err = EINVAL;
-			goto out;
-		}
-
-		r = SSL_CTX_use_PrivateKey_file(tls->ctx, keyfile,
-						SSL_FILETYPE_PEM);
-		if (r <= 0) {
-			DEBUG_WARNING("Can't read key file: %s (%d)\n",
-				      keyfile, r);
-			ERR_clear_error();
-			err = EINVAL;
-			goto out;
-		}
-	}
 
 	err = hash_alloc(&tls->reuse.ht_sessions, 256);
 	if (err)
@@ -1405,7 +1420,6 @@ int tls_set_ciphers(struct tls *tls, const char *cipherv[], size_t count)
  */
 int tls_set_verify_server(struct tls_conn *tc, const char *host)
 {
-#if !defined(LIBRESSL_VERSION_NUMBER)
 	struct sa sa;
 
 	if (!tc || !host)
@@ -1434,12 +1448,6 @@ int tls_set_verify_server(struct tls_conn *tc, const char *host)
 	SSL_set_verify(tc->ssl, SSL_VERIFY_PEER, tls_verify_handler);
 
 	return 0;
-#else
-	(void)tc;
-	(void)host;
-
-	return ENOSYS;
-#endif
 }
 
 
@@ -1947,17 +1955,12 @@ SSL_CTX *tls_ssl_ctx(const struct tls *tls)
 }
 
 
-#if !defined(LIBRESSL_VERSION_NUMBER)
 static void tls_cert_destructor(void *arg)
 {
 	struct tls_cert *uc = arg;
 
 	mem_deref(uc->host);
-	X509_free(uc->x509);
-	EVP_PKEY_free(uc->pkey);
-	sk_X509_pop_free(uc->chain, X509_free);
 }
-#endif
 
 
 /**
@@ -1973,11 +1976,8 @@ static void tls_cert_destructor(void *arg)
  */
 int tls_add_certf(struct tls *tls, const char *certf, const char *host)
 {
-#if !defined(LIBRESSL_VERSION_NUMBER)
 	struct tls_cert *uc;
-	BIO *bio = NULL;
 	int err = 0;
-	int ret;
 
 	if (!tls || !certf)
 		return EINVAL;
@@ -1989,73 +1989,24 @@ int tls_add_certf(struct tls *tls, const char *certf, const char *host)
 	if (str_isset(host)) {
 		err = str_dup(&uc->host, host);
 		if (err)
-			goto out;
+			goto err;
 	}
 
-	bio = BIO_new_file(certf, "r");
-	if (!bio) {
-		err = EIO;
-		goto out;
-	}
+	err = tls_ctx_alloc(&uc->ctx, TLS_METHOD_TLS, certf, NULL, NULL);
+	if (err)
+		goto err;
 
-	uc->x509 = PEM_read_bio_X509(bio, NULL, NULL, NULL);
-	if (!uc->x509) {
-		DEBUG_WARNING("Can't read certificate from file: %s\n", certf);
-		err = ENOTSUP;
-		goto out;
-	}
+	list_append(&tls->certs, &uc->le, uc);
+	if (list_count(&tls->certs) == 1)
+		tls_enable_sni(tls);
 
-	while (1) {
-		X509 *ca = PEM_read_bio_X509(bio, NULL, 0, NULL);
-		if (!ca)
-			break;
+	return 0;
 
-		if (!uc->chain)
-			uc->chain = sk_X509_new_null();
-
-		if (!uc->chain) {
-			err = ENOMEM;
-			goto out;
-		}
-
-		if (!sk_X509_push(uc->chain, ca)) {
-			err = ENOMEM;
-			goto out;
-		}
-	}
-
-	ret = BIO_reset(bio);
-	if (ret < 0 || !bio) {
-		err = EIO;
-		goto out;
-	}
-
-	uc->pkey = PEM_read_bio_PrivateKey(bio, NULL, NULL, NULL);
-	if (!uc->pkey) {
-		DEBUG_WARNING("Can't read private key from file: %s\n", certf);
-		err = ENOTSUP;
-		goto out;
-	}
-
-out:
-	BIO_free(bio);
-	if (err) {
-		ERR_clear_error();
-		mem_deref(uc);
-	}
-	else {
-		list_append(&tls->certs, &uc->le, uc);
-		if (list_count(&tls->certs) == 1)
-			tls_enable_sni(tls);
-	}
+err:
+	ERR_clear_error();
+	mem_deref(uc);
 
 	return err;
-#else
-	(void)tls;
-	(void)certf;
-	(void)host;
-	return ENOSYS;
-#endif
 }
 
 
@@ -2068,35 +2019,14 @@ out:
  */
 X509 *tls_cert_x509(struct tls_cert *hc)
 {
-	return hc ? hc->x509 : NULL;
+	return hc ? SSL_CTX_get0_certificate(hc->ctx) : NULL;
 }
 
 
-/**
- * Returns the private key of the TLS certificate
- *
- * @param hc  TLS certificate
- *
- * @return The OpenSSL EVP_PKEY
- */
-EVP_PKEY *tls_cert_pkey(struct tls_cert *hc)
-{
-	return hc ? hc->pkey : NULL;
+SSL_CTX *tls_cert_ctx(struct tls_cert *hc) {
+
+	return hc ? hc->ctx : NULL;
 }
-
-
-/*
- * Returns the certificate chain of the TLS certificate
- *
- * @param hc  TLS certificate
- *
- * @return The OpenSSL stack of X509
- */
-struct stack_st_X509 *tls_cert_chain(struct tls_cert *hc)
-{
-	return hc ? hc->chain : NULL;
-}
-
 
 /**
  * Returns the host name of the TLS certificate

--- a/src/tls/openssl/tls.h
+++ b/src/tls/openssl/tls.h
@@ -28,9 +28,7 @@ void tls_flush_error(void);
 SSL_CTX *tls_ssl_ctx(const struct tls *tls);
 X509 *tls_cert_x509(struct tls_cert *hc);
 SSL_CTX *tls_cert_ctx(struct tls_cert *hc);
-EVP_PKEY *tls_cert_pkey(struct tls_cert *hc);
 
-struct stack_st_X509 *tls_cert_chain(struct tls_cert *hc);
 const char *tls_cert_host(struct tls_cert *hc);
 const struct list *tls_certs(const struct tls *tls);
 

--- a/src/tls/openssl/tls.h
+++ b/src/tls/openssl/tls.h
@@ -27,6 +27,7 @@ struct tls_cert;
 void tls_flush_error(void);
 SSL_CTX *tls_ssl_ctx(const struct tls *tls);
 X509 *tls_cert_x509(struct tls_cert *hc);
+SSL_CTX *tls_cert_ctx(struct tls_cert *hc);
 EVP_PKEY *tls_cert_pkey(struct tls_cert *hc);
 
 struct stack_st_X509 *tls_cert_chain(struct tls_cert *hc);
@@ -34,7 +35,5 @@ const char *tls_cert_host(struct tls_cert *hc);
 const struct list *tls_certs(const struct tls *tls);
 
 struct tls_cert *tls_cert_for_sni(const struct tls *tls, const char *sni);
-#if !defined(LIBRESSL_VERSION_NUMBER)
 int tls_verify_handler(int ok, X509_STORE_CTX *ctx);
 void tls_enable_sni(struct tls *tls);
-#endif


### PR DESCRIPTION
Replaces unsupported (by LibreSSL) `SSL_certs_clear` with recommended `SSL_set_SSL_CTX()`:

https://www.openssl.org/docs/man3.3/man3/SSL_CTX_set_tlsext_servername_callback.html

> The servername callback should return one of the following values:
> 
> SSL_TLSEXT_ERR_OK
> This is used to indicate that the servername requested by the client has been accepted. Typically a server will call SSL_set_SSL_CTX() in the callback to set up a different configuration for the selected servername in this case.
