### PR TITLE
sip: add host param to sip_send_conn

### DIFF
--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -303,7 +303,7 @@ int  sip_debug(struct re_printf *pf, const struct sip *sip);
 int  sip_send(struct sip *sip, void *sock, enum sip_transp tp,
 	      const struct sa *dst, struct mbuf *mb);
 int  sip_send_conn(struct sip *sip, void *sock, enum sip_transp tp,
-		   const struct sa *dst, struct mbuf *mb,
+		   const struct sa *dst, char *host, struct mbuf *mb,
 		   sip_conn_h *connh, void *arg);
 void sip_set_trace_handler(struct sip *sip, sip_trace_h *traceh);
 

--- a/src/sip/request.c
+++ b/src/sip/request.c
@@ -233,7 +233,7 @@ static int request(struct sip_request *req, enum sip_transp tp,
 	}
 
 	if (!req->stateful) {
-		err = sip_send_conn(req->sip, NULL, tp, dst, mb,
+		err = sip_send_conn(req->sip, NULL, tp, dst, req->host, mb,
 				    connect_handler, req);
 	}
 	else {

--- a/src/sip/sip.c
+++ b/src/sip/sip.c
@@ -210,10 +210,10 @@ void sip_close(struct sip *sip, bool force)
  * @return 0 if success, otherwise errorcode
  */
 int sip_send_conn(struct sip *sip, void *sock, enum sip_transp tp,
-		  const struct sa *dst, struct mbuf *mb,
+		  const struct sa *dst, char *host, struct mbuf *mb,
 		  sip_conn_h *connh, void *arg)
 {
-	return sip_transp_send(NULL, sip, sock, tp, dst, NULL, mb, connh, NULL,
+	return sip_transp_send(NULL, sip, sock, tp, dst, host, mb, connh, NULL,
 			       arg);
 }
 


### PR DESCRIPTION
fixes #1140 - Stateless SIP requests with TLS transport fail with EINVAL