### PR TITLE
sipreg/reg.c: stop retrying registers early after 401/407

### DIFF
--- a/src/sipreg/reg.c
+++ b/src/sipreg/reg.c
@@ -193,6 +193,7 @@ static void response_handler(int err, const struct sip_msg *msg, void *arg)
 {
 	const struct sip_hdr *minexp;
 	struct sipreg *reg = arg;
+	uint16_t last_scode = reg->ls.last_scode;
 
 	reg->wait = failwait(reg->failc + 1);
 	if (err || !msg || sip_request_loops(&reg->ls, msg->scode)) {
@@ -223,6 +224,11 @@ static void response_handler(int err, const struct sip_msg *msg, void *arg)
 
 		case 401:
 		case 407:
+			if (reg->ls.failc > 1 && last_scode == msg->scode) {
+				reg->failc++;
+				goto out;
+			}
+
 			sip_auth_reset(reg->auth);
 			err = sip_auth_authenticate(reg->auth, msg);
 			if (err) {


### PR DESCRIPTION
Currently, REGISTERs are retried until the loop detection mechanism kicks in, which results in 16 unsuccessful REGISTERs being sent in very quick succession if the REGISTER can't be authorized (401 or 407 responses).

Now, on 401 and 407 responses, the REGISTER is only retried once (instead of 16 times). Re-trying the same request 16 times with the same auth credentials doesn't make much sense.