### PR TITLE
release v3.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v3.13.0] - 2024-06-19
+
+## What's Changed
+* http/client: use dynamically sized buffers for PEM setters by @maximilianfridrich in https://github.com/baresip/re/pull/1117
+* tls: allow secure TLS renegotiation by @maximilianfridrich in https://github.com/baresip/re/pull/1121
+* tls: always enable USE_OPENSSL_SRTP by @alfredh in https://github.com/baresip/re/pull/1122
+* main: remove call to openssl init by @alfredh in https://github.com/baresip/re/pull/1120
+* sip/transp: Allow ACK w/o Max-Forwards header by @juha-h in https://github.com/baresip/re/pull/1124
+* net: remove NET_ADDRSTRLEN by @alfredh in https://github.com/baresip/re/pull/1123
+* ci/ios: increase min deployment target by @sreimers in https://github.com/baresip/re/pull/1126
+* tls/http: add certificate chain setters by @maximilianfridrich in https://github.com/baresip/re/pull/1125
+* sipsess/connect: set sess->established immediately on 200 receival by @maximilianfridrich in https://github.com/baresip/re/pull/1128
+* test/cmake: add crypt32 linking for WIN32 by @sreimers in https://github.com/baresip/re/pull/1130
+* ci/sanitizers: use clang-17 by @sreimers in https://github.com/baresip/re/pull/1131
+* ci/sanitizer: add undefined behavior sanitizer by @sreimers in https://github.com/baresip/re/pull/1132
+* sip: verify call-id, to-tag, cseq of INVITE response by @maximilianfridrich in https://github.com/baresip/re/pull/1129
+* ci: remove one unneeded directory change by @alfredh in https://github.com/baresip/re/pull/1134
+* test: change GENERATOR_SSRC from define to type by @alfredh in https://github.com/baresip/re/pull/1133
+* tls: refactoring SNI ctx usage for libressl support by @sreimers in https://github.com/baresip/re/pull/1136
+* test: add test_rtcp_loop() by @alfredh in https://github.com/baresip/re/pull/1137
+* ci/coverage: increase min coverage by @sreimers in https://github.com/baresip/re/pull/1138
+* ci/coverage: use json summary and upload html details by @sreimers in https://github.com/baresip/re/pull/1139
+* sip: add host param to sip_send_conn by @sreimers in https://github.com/baresip/re/pull/1141
+
+
+**Full Changelog**: https://github.com/baresip/re/compare/v3.12.0...v3.13.0
+
 ## [v3.12.0] - 2024-05-15
 
 ## What's Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,13 +14,13 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(re
-  VERSION 3.12.0
+  VERSION 3.13.0
   LANGUAGES C
   HOMEPAGE_URL https://github.com/baresip/re
   DESCRIPTION "Generic library for real-time communications"
 )
 
-set(PROJECT_SOVERSION 24) # bump if ABI breaks
+set(PROJECT_SOVERSION 25) # bump if ABI breaks
 
 # Pre-release identifier, comment out on a release
 # Increment for breaking changes (dev2, dev3...)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+libre (3.13.0) unstable; urgency=medium
+
+  * version 3.13.0
+
+ -- Christian Spielberger <c.spielberger@commend.com>  Wed, 19 Jun 2024 07:12:37 +0100
+
+libre (3.12.0) unstable; urgency=medium
+
+  * version 3.12.0
+
+ -- Alfred E. Heggestad <alfred.heggestad@gmail.com>  Wed, 15 May 2024 08:37:35 +0200
+
 libre (3.11.0) unstable; urgency=medium
 
   * version 3.11.0

--- a/mk/Doxyfile
+++ b/mk/Doxyfile
@@ -4,7 +4,7 @@
 # Project related configuration options
 #---------------------------------------------------------------------------
 PROJECT_NAME           = libre
-PROJECT_NUMBER         = 3.12.0
+PROJECT_NUMBER         = 3.13.0
 OUTPUT_DIRECTORY       = ../re-dox
 CREATE_SUBDIRS         = NO
 OUTPUT_LANGUAGE        = English


### PR DESCRIPTION
### Create/Prepare PRs for new Release (re/baresip)
- [x] Update `CHANGELOG.md`
  - Click `Draft a new release` on Release page
  - Fill a new release tag version and title (like v2.4.0)
  - Press `Generate release notes` 
  - **Save as draft** (don't publish yet)
  - Copy release notes to `CHANGELOG.md`
- [x] Update `debian/changelog`
- [x] Check/Inc version numbers
  - `CMakeLists.txt`
  - `include/baresip.h`
  - `mk/Doxyfile`
- [x] Check ABI compatibility
  - `CMakeLists.txt` (Bump PROJECT_SOVERSION)
- [x] Comment out PRE Release identifier `-dev`
  - `CMakeLists.txt`
- [x] All tests green? [re, baresip]

### Release
- [x] Merge PRs in this order
  - libre
  - baresip
- [ ] Publish draft Releases (follow the same order)
  - Maybe `Generate Release notes` is needed to update (delete last notes first)

### After Release
- [ ] Bump main branch versions with PRE Release identifier `-dev`
  - `CMakeLists.txt`
  - `include/baresip.h` (baresip only)


### Release schedule

- ~v3.12.0 15. May (@alfredh)~
- v3.13.0 19. Jun (@cspiel1)
- v3.14.0 24. Jul (@sreimers)