### PR TITLE
test: init err in test_sip_auth_encode()

### DIFF
--- a/test/sipauth.c
+++ b/test/sipauth.c
@@ -74,7 +74,7 @@ static int auth_handler(char **user, char **pass, const char *rlm, void *arg)
 
 static int test_sip_auth_encode(void)
 {
-	int err;
+	int err = 0;
 	struct mbuf *mb, *mb_enc;
 	struct sip_auth *auth = NULL;
 	char buf[1024] = {0};


### PR DESCRIPTION
cppcheck warning:

```
test/sipauth.c:129:6: warning: Uninitialized variable: err [uninitvar]
 if (err) {
     ^
test/sipauth.c:95:23: note: Assuming condition is false
 for (size_t i = 0; i < RE_ARRAY_SIZE(testv); i++) {
                      ^
test/sipauth.c:129:6: note: Uninitialized variable: err
 if (err) {
     ^
```
