### PR TITLE
udp/mcast: use group scopeid as interface for IPv6

### DIFF
--- a/src/udp/mcast.c
+++ b/src/udp/mcast.c
@@ -37,7 +37,7 @@ static int multicast_update(struct udp_sock *us, const struct sa *group,
 #ifdef HAVE_INET6
 	case AF_INET6:
 		mreq6.ipv6mr_multiaddr = group->u.in6.sin6_addr;
-		mreq6.ipv6mr_interface = 0;
+		mreq6.ipv6mr_interface = sa_scopeid(group);
 
 		err = udp_setsockopt(us, IPPROTO_IPV6,
 				     join


### PR DESCRIPTION
For IPv6 (link-local) the interface must be selected when sending packets. Otherwise, `udp_setsockopt()` results in an ICMPv6 packet being sent with the source IP being `::` which results in IPv6 multicast not working.