### PR TITLE
.clangd: suppress -Wgnu-zero-variadic-macro-arguments

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -3,3 +3,6 @@ If:
 CompileFlags:
   Add: [-Wall, -DHAVE_INTTYPES_H, -include re.h]
   Remove: [-xobjective-c++-header]
+---
+Diagnostics:
+  Suppress: "-Wgnu-zero-variadic-macro-arguments"


### PR DESCRIPTION
Necessary if the chosen compiler is not clang but clangd is used as a language server.