### PR TITLE
sipsess/reply: terminate session if no (PR)ACK received after 64*T1

### DIFF
--- a/src/sipsess/reply.c
+++ b/src/sipsess/reply.c
@@ -51,10 +51,6 @@ static void tmr_handler(void *arg)
 	struct sipsess_reply *reply = arg;
 	struct sipsess *sess = reply->sess;
 
-	/* wait for all pending ACKs */
-	if (sess->replyl.head)
-		goto out;
-
 	/* we want to send bye */
 
 	if (!sess->terminated) {
@@ -64,14 +60,15 @@ static void tmr_handler(void *arg)
 		}
 		else {
 			sess->established = true;
+			mem_deref(reply);
 			sipsess_terminate(sess, ETIMEDOUT, NULL);
+			return;
 		}
 	}
 	else {
 		mem_deref(sess);
 	}
 
-out:
 	mem_deref(reply);
 }
 


### PR DESCRIPTION
RFC 3261 [section 13.3.1.4](https://www.rfc-editor.org/rfc/rfc3261#section-13.3.1.4):

```
   If the server retransmits the 2xx response for 64*T1 seconds without
   receiving an ACK, the dialog is confirmed, but the session SHOULD be
   terminated.  This is accomplished with a BYE, as described in Section
   15.
```

If we never receive an ACK, the `sipsess` will never be cleaned up.