### PR TITLE
add filter_registrar option

### DIFF
--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -311,6 +311,8 @@ void sip_set_trace_handler(struct sip *sip, sip_trace_h *traceh);
 /* transport */
 int  sip_transp_add(struct sip *sip, enum sip_transp tp,
 		    const struct sa *laddr, ...);
+int  sip_transp_add_sock(struct sip *sip, enum sip_transp tp,
+			 bool listen, const struct sa *laddr, ...);
 int  sip_transp_add_websock(struct sip *sip, enum sip_transp tp,
 			    const struct sa *laddr,
 			    bool server, const char *cert, struct tls *tls);


### PR DESCRIPTION
transp.c: add sip_transp_add_sock

to add SIP transport protocol without opening a listening socket (UDP socket is always opened).

Related:
- https://github.com/baresip/baresip/pull/3080