### PR TITLE
dns/rr: fix dns_rr_print underflow

### DIFF
--- a/src/dns/rr.c
+++ b/src/dns/rr.c
@@ -615,8 +615,10 @@ int dns_rr_print(struct re_printf *pf, const struct dnsrr *rr)
 	n = (w > l) ? w - l : 0;
 
 	err = re_hprintf(pf, "%s.", rr->name);
-	while (n--)
+	while (n) {
 		err |= pf->vph(" ", 1, pf->arg);
+		--n;
+	}
 
 	err |= re_hprintf(pf, " %10lld %-4s %-7s ",
 			  rr->ttl,


### PR DESCRIPTION
found by coverity:

```
CID 400048: (#1 of 1): Overflowed constant (INTEGER_OVERFLOW)
6. overflow_const: Expression n--, which is equal to 18446744073709551615, where n is known to be equal to 0, underflows the type that receives it, an unsigned integer 64 bits wide.
```