### PR TITLE
retest: update usage message

### DIFF
--- a/test/main.c
+++ b/test/main.c
@@ -32,8 +32,7 @@ static void signal_handler(int num)
 #ifdef HAVE_GETOPT
 static void usage(void)
 {
-	(void)re_fprintf(stderr, "Usage: retest [-rotalp] [-hmv]"
-			 " <testcase>\n");
+	(void)re_fprintf(stderr, "Usage: retest [options] <testcase>\n");
 
 	(void)re_fprintf(stderr, "\ntest group options:\n");
 	(void)re_fprintf(stderr, "\t-r        Run regular tests\n");


### PR DESCRIPTION
The current options aren't reflected by the current usage message anymore, thus use same message style like in baresip's selftest.