### PR TITLE
tls/sni: skip SNI check if we are client or server_name absent

### DIFF
--- a/src/tls/openssl/sni.c
+++ b/src/tls/openssl/sni.c
@@ -165,11 +165,12 @@ static int ssl_servername_handler(SSL *ssl, int *al, void *arg)
 	struct tls_cert *uc = NULL;
 	const char *sni;
 
+	if (!SSL_is_server(ssl))
+		return SSL_TLSEXT_ERR_OK;
+
 	sni = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
-	if (!str_isset(sni)) {
-		*al = SSL_AD_UNRECOGNIZED_NAME;
-		return SSL_TLSEXT_ERR_ALERT_FATAL;
-	}
+	if (!str_isset(sni))
+		return SSL_TLSEXT_ERR_OK;
 
 	/* find and apply matching certificate */
 	uc = tls_cert_for_sni(tls, sni);


### PR DESCRIPTION
The servername_callback is also called when the server requests a certificate in the ServerHello. However, the server will not usually send us the server_name extension. So skip the SNI check if we are client. Also continue if the server_name extension is not present.