### PR TITLE
sipsess/reply: fix heap-use-after-free bug

### DIFF
--- a/src/sipsess/reply.c
+++ b/src/sipsess/reply.c
@@ -66,7 +66,8 @@ static void tmr_handler(void *arg)
 		}
 	}
 	else {
-		mem_deref(sess); /* list_flush derefs reply */
+		mem_deref(reply);
+		mem_deref(sess);
 		return;
 	}
 

--- a/src/sipsess/reply.c
+++ b/src/sipsess/reply.c
@@ -66,7 +66,8 @@ static void tmr_handler(void *arg)
 		}
 	}
 	else {
-		mem_deref(sess);
+		mem_deref(sess); /* list_flush derefs reply */
+		return;
 	}
 
 	mem_deref(reply);


### PR DESCRIPTION
fixes #1178 - `mem_deref(sess)` calls maybe `list_flush(&sess->replyl)` within destructor and reply is a dangling pointer after this.