### PR TITLE
ice: AI_V4MAPPED macro is missing on some BSD systems

### DIFF
--- a/src/ice/icesdp.c
+++ b/src/ice/icesdp.c
@@ -209,10 +209,11 @@ static int getaddr_rcand(void *arg)
 {
 	struct rcand *rcand = arg;
 	struct addrinfo *res, *res0 = NULL;
-#ifndef OPENBSD
-	struct addrinfo hints = {.ai_flags  = AI_V4MAPPED | AI_ADDRCONFIG,
-#else
+
+#if defined(OPENBSD) || defined(__NetBSD__)
 	struct addrinfo hints = {.ai_flags  = AI_ADDRCONFIG,
+#else
+	struct addrinfo hints = {.ai_flags  = AI_ADDRCONFIG | AI_V4MAPPED,
 #endif
 				 .ai_family = rcand->ai_family};
 	int err;


### PR DESCRIPTION
AI_V4MAPPED macro is missing on some platforms, e.g. OpenBSD, NetBSD, etc.