### PR TITLE
rtp/rtcp: add RTCP Generic NACK packet send (RFC 4585 6.2.1)

### DIFF
--- a/include/re_rtp.h
+++ b/include/re_rtp.h
@@ -268,6 +268,8 @@ int   rtcp_send_app(struct rtp_sock *rs, const char name[4],
 		    const uint8_t *data, size_t len);
 int   rtcp_send_fir(struct rtp_sock *rs, uint32_t ssrc);
 int   rtcp_send_nack(struct rtp_sock *rs, uint16_t fsn, uint16_t blp);
+int   rtcp_send_gnack(struct rtp_sock *rs, uint32_t ssrc, uint16_t fsn,
+		    uint16_t blp);
 int   rtcp_send_pli(struct rtp_sock *rs, uint32_t fb_ssrc);
 int   rtcp_send_fir_rfc5104(struct rtp_sock *rs, uint32_t ssrc,
 			    uint8_t fir_seqn);

--- a/src/rtp/rtcp.c
+++ b/src/rtp/rtcp.c
@@ -89,6 +89,36 @@ int rtcp_send_nack(struct rtp_sock *rs, uint16_t fsn, uint16_t blp)
 }
 
 
+static int encode_gnack(struct mbuf *mb, void *arg)
+{
+	struct gnack *fci = arg;
+
+	int err = mbuf_write_u16(mb, htons(fci->pid));
+	err |= mbuf_write_u16(mb, htons(fci->blp));
+	return err;
+}
+
+
+/**
+ * Send an RTCP Generic NACK packet (RFC 4585 6.2.1)
+ *
+ * @param rs   RTP Socket
+ * @param ssrc SSRC of the target encoder
+ * @param fsn  First Sequence Number lost
+ * @param blp  Bitmask of lost packets
+ *
+ * @return 0 for success, otherwise errorcode
+ */
+int rtcp_send_gnack(struct rtp_sock *rs, uint32_t ssrc, uint16_t fsn,
+		    uint16_t blp)
+{
+	struct gnack fci = {fsn, blp};
+	return rtcp_quick_send(rs, RTCP_RTPFB, RTCP_RTPFB_GNACK,
+			       rtp_sess_ssrc(rs), ssrc, &encode_gnack,
+			       &fci);
+}
+
+
 /**
  * Send an RTCP Picture Loss Indication (PLI) packet
  *


### PR DESCRIPTION
Needed for WebRTC