### PR TITLE
dnsc: Fallback to getaddrinfo without any DNS servers

### DIFF
--- a/include/re_dns.h
+++ b/include/re_dns.h
@@ -224,6 +224,7 @@ void dnsc_cache_flush(struct dnsc *dnsc);
 void dnsc_cache_max(struct dnsc *dnsc, uint32_t max);
 void dnsc_getaddrinfo(struct dnsc *dnsc, bool active);
 bool dnsc_getaddrinfo_enabled(struct dnsc *dnsc);
+bool dnsc_getaddrinfo_only(const struct dnsc *dnsc);
 
 
 /* DNS System functions */

--- a/src/sip/request.c
+++ b/src/sip/request.c
@@ -727,6 +727,8 @@ static int sip_request_send(struct sip_request *req, struct sip *sip,
 {
 	struct sa dst;
 	int err;
+	bool addr_only = req->tp_selected &&
+		dnsc_getaddrinfo_only(req->sip->dnsc);
 
 	if (!sa_set_str(&dst, req->host,
 			sip_transp_port(req->tp, route->port))) {
@@ -737,7 +739,7 @@ static int sip_request_send(struct sip_request *req, struct sip *sip,
 			return err;
 		}
 	}
-	else if (route->port) {
+	else if (route->port || addr_only){
 
 		req->port = sip_transp_port(req->tp, route->port);
 		err = addr_lookup(req, req->host);


### PR DESCRIPTION
On current Android and iOS platforms, access to the system DNS server lists is restricted (e.g. https://developer.android.com/about/versions/oreo/android-8.0-changes.html#o-pri). Even when it is available, it is often broken in certain situations (e.g. https://forums.developer.apple.com/forums/thread/75449). It is therefore practically impossible to perform manual DNS queries as `re` typically does for SIP.

Currently, `re` partially supports these platforms by offering the option to use `getaddrinfo`, but even this fails when no DNS servers are known due to `/etc/resolv.conf` not being accessible. Note that manually specifying 'well-known' DNS servers like `8.8.8.8` is not an acceptable workaround for private networks. Nor is it acceptable to manually specify a fixed private DNS, IT admins will require DNS to be centrally distributed via DHCP.

This change fixes the above use case by making two changes:

1. Allow SIP A / AAAA queries to proceed without any DNS servers when `getaddrinfo` is configured. `getaddrinfo` doesn't need to know the servers so we don't need to reject it with `EINVAL`.
2. When `getaddrinfo` is configured and there are no DNS servers, if SIP transport is set but not the port (e.g. `sip:my-proxy.com;transport=tls`, use the default transport port and do a A / AAAA query instead of attempting a SRV / NAPTR that cannot possibly work.

I have tested this on Android where `dns_srv_get` always fails to return any servers. Previously Baresip would fail to even register, with this change it is able to register and make calls using a URI such as `sip:my-proxy.com;transport=tls`.