### PR TITLE
list: add macro LIST_FOREACH_SAFE

### DIFF
--- a/include/re_list.h
+++ b/include/re_list.h
@@ -97,6 +97,7 @@ static inline bool list_isempty(const struct list *list)
 #define LIST_FOREACH(list, le)					\
 	for ((le) = list_head((list)); (le); (le) = (le)->next)
 
+#undef LIST_FOREACH_SAFE
 #define LIST_FOREACH_SAFE(list, le, n)			\
 	for ((le) = list_head((list)), (n) = (le) ? (le)->next : NULL; (le); \
 		(le) = (n), (n) = (le) ? (le)->next : NULL)

--- a/include/re_list.h
+++ b/include/re_list.h
@@ -97,6 +97,9 @@ static inline bool list_isempty(const struct list *list)
 #define LIST_FOREACH(list, le)					\
 	for ((le) = list_head((list)); (le); (le) = (le)->next)
 
+#define LIST_FOREACH_SAFE(list, le, n)			\
+	for ((le) = list_head((list)), (n) = (le) ? (le)->next : NULL; (le); \
+		(le) = (n), (n) = (le) ? (le)->next : NULL)
 
 /**
  * Move element to another linked list


### PR DESCRIPTION
support modification during linked list traversal.
referring to the implementation of the Linux kernel "list_for_each_safe(pos, n, head)"