### PR TITLE
thread: fix thrd_equal win32 handle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ else()
     -Wnested-externs
     -Wno-strict-aliasing
     -Wold-style-definition
-    -Wshadow -Waggregate-return
+    -Wshadow
     -Wstrict-prototypes
     -Wuninitialized
     -Wvla

--- a/include/re_thread.h
+++ b/include/re_thread.h
@@ -22,14 +22,18 @@
 #else
 
 #if defined(WIN32)
-
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
+
+struct thrd_win32 {
+	HANDLE hdl;
+	DWORD id;
+};
 #define ONCE_FLAG_INIT INIT_ONCE_STATIC_INIT
 typedef INIT_ONCE once_flag;
-typedef HANDLE thrd_t;
+typedef struct thrd_win32 thrd_t;
 typedef CONDITION_VARIABLE cnd_t;
 typedef CRITICAL_SECTION mtx_t;
 typedef DWORD tss_t;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,7 +44,7 @@ else()
     -Wnested-externs
     -Wno-strict-aliasing
     -Wold-style-definition
-    -Wshadow -Waggregate-return
+    -Wshadow
     -Wstrict-prototypes
     -Wuninitialized
     -Wvla


### PR DESCRIPTION
GetCurrentThread() returns only a pseudo handle and can not used
within other threads

Fixes #1202 