### PR TITLE
ci/build: remove Ubuntu 20.04, add 24.04, use GCC 14 on 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,15 @@ jobs:
     strategy:
       matrix:
         build_type: [Release, Debug]
-        compiler: [gcc, clang]
-        os: [ubuntu-20.04, ubuntu-22.04, macos-latest]
+        compiler: [gcc, clang, gcc-14]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-latest]
         exclude:
           - os: macos-latest
             compiler: gcc
+          - os: macos-latest
+            compiler: gcc-14
+          - os: ubuntu-22.04
+            compiler: gcc-14
     env:
       CC: ${{ matrix.compiler }}
       CMAKE_GENERATOR: Ninja


### PR DESCRIPTION
Use same versions of Linux distributions like at https://github.com/baresip/baresip/pull/3193 and synchronize GCC version usage, too.