### PR TITLE
test: vertical alignment of integration test names

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -1110,7 +1110,7 @@ int test_integration(const char *name, bool verbose)
 		if (str_isset(name) && test->name)
 			continue;
 
-		(void)re_fprintf(stderr, "  %-28s: ", test->name);
+		(void)re_fprintf(stderr, "  %-32s: ", test->name);
 
 		if (test->exec)
 			err = test->exec();


### PR DESCRIPTION
```
alfredh@debian:~/git/re$ ./test/retest -v -i
retest: libre version 3.17.0 (x86_64/Linux)
using async polling method 'epoll'
using datapath './test/data'
integration tests
  test_dns_cache_http_integration : OK	
  test_dns_http_integration       : OK	
  test_dns_integration            : OK	
  test_net_dst_source_addr_get    : OK	
  test_rtp_listen                 : OK	
  test_sip_drequestf_network      : OK	
  test_sipevent_network           : OK	
  test_sipreg_tcp                 : OK	
  test_sipreg_tls                 : OK	
  test_sipreg_udp                 : OK	
  test_tmr_jiffies                : OK	
  test_tmr_jiffies_usec           : OK	
  test_turn_thread                : main: fd_close err: fd=4 (No such file or directory [2])
OK	
  test_thread_cnd_timedwait       : OK	
```
