### PR TITLE
sip/transp: allow requests w/o Max-Forwards header

### DIFF
--- a/src/sip/transp.c
+++ b/src/sip/transp.c
@@ -345,8 +345,6 @@ static bool have_essential_fields(const struct sip_msg *msg)
 		pl_isset(&(msg->from.auri)) &&
 		pl_isset(&(msg->cseq.met)) &&
 		pl_isset(&(msg->callid)) &&
-		(pl_isset(&(msg->maxfwd)) ||
-		 !pl_strncmp(&msg->met, "ACK", 3)) &&
 		pl_isset(&(msg->via.branch)))
 		return true;
 


### PR DESCRIPTION
A customer reports problems with their SIP proxy that misses the Max-Forwards header for SIP MESSAGE. Our devices reject these SIP requests.

In RFC 3261 couldn't find anything about what a UAC should do with a SIP request without a Max-Forwards header.

Found this about SIP Proxy:

```
16 Proxy Behavior

16.3 Request Validation

3. Max-Forwards check

If the request does not contain a Max-Forwards header field, this
check is passed.
```

Which is the opposite of the current behavior.

@juha-h @alfredh @sreimers Do you agree with removing the check?