### PR TITLE
rtp: send all RTCP packets as compound packets

### DIFF
--- a/src/rtp/rtcp.c
+++ b/src/rtp/rtcp.c
@@ -27,6 +27,11 @@ static int rtcp_quick_send(struct rtp_sock *rs, enum rtcp_type type,
 
 	mb->pos = RTCP_HEADROOM;
 
+	err  = rtcp_make_sr(rs, mb);
+	err |= rtcp_make_sdes_cname(rs, mb);
+	if (err)
+		goto out;
+
 	va_start(ap, count);
 	err = rtcp_vencode(mb, type, count, ap);
 	va_end(ap);
@@ -36,6 +41,10 @@ static int rtcp_quick_send(struct rtp_sock *rs, enum rtcp_type type,
 	if (!err)
 		err = rtcp_send(rs, mb);
 
+	if (!err)
+		rtcp_schedule_report(rs);
+
+out:
 	mem_deref(mb);
 
 	return err;

--- a/src/rtp/rtcp.h
+++ b/src/rtp/rtcp.h
@@ -44,8 +44,12 @@ int rtcp_rr_alloc(struct rtcp_rr **rrp, size_t count);
 int rtcp_rr_encode(struct mbuf *mb, const struct rtcp_rr *rr);
 int rtcp_rr_decode(struct mbuf *mb, struct rtcp_rr *rr);
 
+/* SR (Sender report) */
+int rtcp_make_sr(const struct rtp_sock *rs, struct mbuf *mb);
+
 /* SDES (Source Description) */
 int rtcp_sdes_decode(struct mbuf *mb, struct rtcp_sdes *sdes);
+int rtcp_make_sdes_cname(const struct rtp_sock *rs, struct mbuf *mb);
 
 /* RTCP Feedback */
 int rtcp_rtpfb_gnack_encode(struct mbuf *mb, uint16_t pid, uint16_t blp);
@@ -86,3 +90,4 @@ void rtcp_sess_tx_rtp(struct rtcp_sess *sess, uint32_t ts, uint64_t jfs_rt,
 		      size_t payload_size);
 void rtcp_sess_rx_rtp(struct rtcp_sess *sess, struct rtp_header *hdr,
 		      size_t payload_size, const struct sa *peer);
+void rtcp_schedule_report(const struct rtp_sock *rs);

--- a/src/rtp/sess.c
+++ b/src/rtp/sess.c
@@ -459,6 +459,16 @@ static int mk_sr(struct rtcp_sess *sess, struct mbuf *mb)
 }
 
 
+int rtcp_make_sr(const struct rtp_sock *rs, struct mbuf *mb)
+{
+	struct rtcp_sess *sess = rtp_rtcp_sess(rs);
+	if (!sess)
+		return EINVAL;
+
+	return mk_sr(sess, mb);
+}
+
+
 static int sdes_encode_handler(struct mbuf *mb, void *arg)
 {
 	struct rtcp_sess *sess = arg;
@@ -476,6 +486,16 @@ static int sdes_encode_handler(struct mbuf *mb, void *arg)
 static int mk_sdes(struct rtcp_sess *sess, struct mbuf *mb)
 {
 	return rtcp_encode(mb, RTCP_SDES, 1, sdes_encode_handler, sess);
+}
+
+
+int rtcp_make_sdes_cname(const struct rtp_sock *rs, struct mbuf *mb)
+{
+	struct rtcp_sess *sess = rtp_rtcp_sess(rs);
+	if (!sess)
+		return EINVAL;
+
+	return mk_sdes(sess, mb);
 }
 
 
@@ -552,6 +572,16 @@ static void timeout(void *arg)
 
 static void schedule(struct rtcp_sess *sess)
 {
+	tmr_start(&sess->tmr, sess->interval, timeout, sess);
+}
+
+
+void rtcp_schedule_report(const struct rtp_sock *rs)
+{
+	struct rtcp_sess *sess = rtp_rtcp_sess(rs);
+	if (!sess)
+		return;
+
 	tmr_start(&sess->tmr, sess->interval, timeout, sess);
 }
 


### PR DESCRIPTION
According to [RFC 3550 section 6.1](https://www.rfc-editor.org/rfc/rfc3550#section-6.1) all RTCP packets MUST be sent as compound packets:

```
   Thus, all RTCP packets MUST be sent in a compound packet of at least
   two individual packets, with the following format:
   ...
   SR or RR:  The first RTCP packet in the compound packet MUST
      always be a report packet to facilitate header validation as
      described in Appendix A.2.  This is true even if no data has been
      sent or received, in which case an empty RR MUST be sent, and even
      if the only other RTCP packet in the compound packet is a BYE.
   ...
   SDES:  An SDES packet containing a CNAME item MUST be included
      in each compound RTCP packet, except as noted in Section 9.1.
```

With this change, RTCP packets sent with `rtcp_quick_send` are now sent as compound packets and thereby RFC compliant.