### PR TITLE
net/linux: add net_netlink_addrs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -606,6 +606,7 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   list(APPEND SRCS
     src/net/linux/rt.c
+    src/net/linux/addrs.c
   )
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Android")
   list(APPEND SRCS

--- a/include/re_net.h
+++ b/include/re_net.h
@@ -73,6 +73,7 @@ int net_if_getlinklocal(const char *ifname, int af, struct sa *ip);
 
 /* Net interface (ifaddrs.c) */
 int net_getifaddrs(net_ifaddr_h *ifh, void *arg);
+int net_netlink_addrs(net_ifaddr_h *ifh, void *arg);
 
 
 /* Net route */

--- a/src/net/linux/addrs.c
+++ b/src/net/linux/addrs.c
@@ -165,13 +165,19 @@ int net_netlink_addrs(net_ifaddr_h *ifh, void *arg)
 
 	if (send(sock, &req, req.nlh.nlmsg_len, 0) < 0) {
 		err = errno;
-		DEBUG_WARNING("sendto failed %m\n", err);
+		DEBUG_WARNING("GETLINK send failed %m\n", err);
 		goto out;
 	}
 
 	while ((len = recv(sock, buffer, sizeof(buffer), 0)) > 0) {
 		if (parse_msg_link((struct nlmsghdr *)buffer, len, iff_up))
 			break;
+	}
+
+	if (len < 0) {
+		err = errno;
+		DEBUG_WARNING("GETLINK recv failed %m\n", err);
+		goto out;
 	}
 
 	/* GETADDR */
@@ -182,7 +188,7 @@ int net_netlink_addrs(net_ifaddr_h *ifh, void *arg)
 
 	if (send(sock, &req, req.nlh.nlmsg_len, 0) < 0) {
 		err = errno;
-		DEBUG_WARNING("sendto failed %m\n", err);
+		DEBUG_WARNING("GETADDR send failed %m\n", err);
 		goto out;
 	}
 
@@ -190,6 +196,11 @@ int net_netlink_addrs(net_ifaddr_h *ifh, void *arg)
 		if (parse_msg_addr((struct nlmsghdr *)buffer, len, ifh, iff_up,
 				   arg))
 			break;
+	}
+
+	if (len < 0) {
+		err = errno;
+		DEBUG_WARNING("GETADDR recv failed %m\n", err);
 	}
 
 out:

--- a/src/net/linux/addrs.c
+++ b/src/net/linux/addrs.c
@@ -8,25 +8,11 @@
 #include <re_fmt.h>
 #include <re_sa.h>
 #include <re_net.h>
+#include "macros.h"
 
 #define DEBUG_MODULE "linuxaddrs"
 #define DEBUG_LEVEL 5
 #include <re_dbg.h>
-
-/* Override macros to avoid casting alignment warning */
-#undef RTM_RTA
-#define RTM_RTA(r) (void *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct rtmsg)))
-#undef RTA_NEXT
-#define RTA_NEXT(rta, len)                                                    \
-	((len) -= RTA_ALIGN((rta)->rta_len),                                  \
-	 (void *)(((char *)(rta)) + RTA_ALIGN((rta)->rta_len)))
-#undef NLMSG_NEXT
-#define NLMSG_NEXT(nlh, len)                                                  \
-	((len) -= NLMSG_ALIGN((nlh)->nlmsg_len),                              \
-	 (void *)(((char *)(nlh)) + NLMSG_ALIGN((nlh)->nlmsg_len)))
-#undef IFA_RTA
-#define IFA_RTA(r)                                                            \
-	((void *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct ifaddrmsg))))
 
 
 static void parse_rtattr(struct rtattr *tb[], struct rtattr *rta, int len)

--- a/src/net/linux/addrs.c
+++ b/src/net/linux/addrs.c
@@ -1,0 +1,148 @@
+#include <unistd.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <net/if.h>
+
+#include <re_types.h>
+#include <re_fmt.h>
+#include <re_sa.h>
+#include <re_net.h>
+
+#define DEBUG_MODULE "linuxaddrs"
+#define DEBUG_LEVEL 5
+#include <re_dbg.h>
+
+/* Override macros to avoid casting alignment warning */
+#undef RTM_RTA
+#define RTM_RTA(r) (void *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct rtmsg)))
+#undef RTA_NEXT
+#define RTA_NEXT(rta, len)                                                    \
+	((len) -= RTA_ALIGN((rta)->rta_len),                                  \
+	 (void *)(((char *)(rta)) + RTA_ALIGN((rta)->rta_len)))
+#undef NLMSG_NEXT
+#define NLMSG_NEXT(nlh, len)                                                  \
+	((len) -= NLMSG_ALIGN((nlh)->nlmsg_len),                              \
+	 (void *)(((char *)(nlh)) + NLMSG_ALIGN((nlh)->nlmsg_len)))
+#undef IFA_RTA
+#define IFA_RTA(r)                                                            \
+	((void *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct ifaddrmsg))))
+
+
+static void parse_rtattr(struct rtattr *tb[], struct rtattr *rta, int len)
+{
+	memset(tb, 0, sizeof(struct rtattr *) * (IFA_MAX + 1));
+	while (RTA_OK(rta, len)) {
+		if (rta->rta_type <= IFA_MAX) {
+			tb[rta->rta_type] = rta;
+		}
+		rta = RTA_NEXT(rta, len);
+	}
+}
+
+
+static bool is_deprecated(uint32_t flags)
+{
+	if (flags & (IFA_F_TENTATIVE | IFA_F_OPTIMISTIC | IFA_F_DADFAILED |
+		     IFA_F_DEPRECATED))
+		return true;
+
+	return false;
+}
+
+
+static int parse_msg(struct nlmsghdr *msg, size_t len, net_ifaddr_h *ifh,
+		     void *arg)
+{
+	struct nlmsghdr *nlh;
+	for (nlh = msg; NLMSG_OK(nlh, len); nlh = NLMSG_NEXT(nlh, len)) {
+		struct sa sa;
+		uint32_t flags;
+		char if_name[IF_NAMESIZE];
+
+		if (nlh->nlmsg_type == NLMSG_DONE) {
+			return 0;
+		}
+		if (nlh->nlmsg_type == NLMSG_ERROR) {
+			DEBUG_WARNING("netlink recv error\n");
+			return EBADMSG;
+		}
+
+		struct ifaddrmsg *ifa = NLMSG_DATA(nlh);
+		struct rtattr *rta_tb[IFA_MAX + 1];
+		parse_rtattr(rta_tb, IFA_RTA(ifa),
+			     nlh->nlmsg_len - NLMSG_LENGTH(sizeof(*ifa)));
+
+		if (!rta_tb[IFA_ADDRESS])
+			continue;
+
+		if (rta_tb[IFA_FLAGS]) {
+			flags = *(uint32_t *)RTA_DATA(rta_tb[IFA_FLAGS]);
+			if (is_deprecated(flags))
+				continue;
+		}
+
+		if (ifa->ifa_family == AF_INET) {
+			sa_init(&sa, AF_INET);
+			sa.u.in.sin_addr.s_addr =
+				*(uint32_t *)RTA_DATA(rta_tb[IFA_ADDRESS]);
+		}
+		else if (ifa->ifa_family == AF_INET6) {
+			sa_set_in6(&sa, RTA_DATA(rta_tb[IFA_ADDRESS]), 0);
+			sa_set_scopeid(&sa, ifa->ifa_index);
+		}
+		else
+			continue;
+
+		if (!if_indextoname(ifa->ifa_index, if_name))
+			continue;
+
+		if (ifh(if_name, &sa, arg))
+			break;
+	}
+
+	return EAGAIN;
+}
+
+
+int net_netlink_addrs(net_ifaddr_h *ifh, void *arg)
+{
+	int err = 0;
+	char buffer[8192];
+	re_sock_t sock;
+	struct {
+		struct nlmsghdr nlh;
+		struct ifaddrmsg ifa;
+	} req;
+	size_t len;
+
+	if (!ifh)
+		return EINVAL;
+
+	if ((sock = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE)) < 0) {
+		err = errno;
+		DEBUG_WARNING("socket failed %m\n", err);
+		return err;
+	}
+
+	memset(&req, 0, sizeof(req));
+	req.nlh.nlmsg_len   = NLMSG_LENGTH(sizeof(struct ifaddrmsg));
+	req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+	req.nlh.nlmsg_type  = RTM_GETADDR;
+
+	if (send(sock, &req, req.nlh.nlmsg_len, 0) < 0) {
+		err = errno;
+		DEBUG_WARNING("sendto failed %m\n", err);
+		goto out;
+	}
+
+	while ((len = recv(sock, buffer, sizeof(buffer), 0)) > 0) {
+		err = parse_msg((struct nlmsghdr *)buffer, len, ifh, arg);
+		if (!err)
+			goto out;
+	}
+
+out:
+	close(sock);
+
+	return err;
+}

--- a/src/net/linux/addrs.c
+++ b/src/net/linux/addrs.c
@@ -1,3 +1,9 @@
+/**
+ * @file linux/addrs.c Get interface addresses (See rtnetlink(7))
+ *
+ * Copyright (C) 2024 Sebastian Reimers
+ */
+
 #include <string.h>
 #include <unistd.h>
 #include <linux/netlink.h>

--- a/src/net/linux/addrs.c
+++ b/src/net/linux/addrs.c
@@ -45,7 +45,7 @@ static bool is_ipv6_deprecated(uint32_t flags)
 }
 
 
-static bool parse_msg_link(struct nlmsghdr *msg, size_t len, int *iff_up)
+static bool parse_msg_link(struct nlmsghdr *msg, ssize_t len, int *iff_up)
 {
 	struct nlmsghdr *nlh;
 	struct ifinfomsg *ifi;
@@ -74,8 +74,8 @@ static bool parse_msg_link(struct nlmsghdr *msg, size_t len, int *iff_up)
 }
 
 
-static bool parse_msg_addr(struct nlmsghdr *msg, size_t len, net_ifaddr_h *ifh,
-			   int *iff_up, void *arg)
+static bool parse_msg_addr(struct nlmsghdr *msg, ssize_t len,
+			   net_ifaddr_h *ifh, int *iff_up, void *arg)
 {
 	struct nlmsghdr *nlh;
 	for (nlh = msg; NLMSG_OK(nlh, len); nlh = NLMSG_NEXT(nlh, len)) {
@@ -137,7 +137,7 @@ int net_netlink_addrs(net_ifaddr_h *ifh, void *arg)
 	int err = 0;
 	char buffer[BUFSZ];
 	re_sock_t sock;
-	int len;
+	ssize_t len;
 	int iff_up[MAXIF] = {0};
 
 	struct {
@@ -169,9 +169,8 @@ int net_netlink_addrs(net_ifaddr_h *ifh, void *arg)
 		goto out;
 	}
 
-	while ((len = (int)recv(sock, buffer, sizeof(buffer), 0)) > 0) {
-		if (parse_msg_link((struct nlmsghdr *)buffer, (size_t)len,
-				   iff_up))
+	while ((len = recv(sock, buffer, sizeof(buffer), 0)) > 0) {
+		if (parse_msg_link((struct nlmsghdr *)buffer, len, iff_up))
 			break;
 	}
 
@@ -187,9 +186,9 @@ int net_netlink_addrs(net_ifaddr_h *ifh, void *arg)
 		goto out;
 	}
 
-	while ((len = (int)recv(sock, buffer, sizeof(buffer), 0)) > 0) {
-		if (parse_msg_addr((struct nlmsghdr *)buffer, (size_t)len, ifh,
-				   iff_up, arg))
+	while ((len = recv(sock, buffer, sizeof(buffer), 0)) > 0) {
+		if (parse_msg_addr((struct nlmsghdr *)buffer, len, ifh, iff_up,
+				   arg))
 			break;
 	}
 

--- a/src/net/linux/addrs.c
+++ b/src/net/linux/addrs.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include <unistd.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>

--- a/src/net/linux/macros.h
+++ b/src/net/linux/macros.h
@@ -1,0 +1,14 @@
+/* Override macros to avoid casting alignment warning */
+#undef RTM_RTA
+#define RTM_RTA(r) (void *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct rtmsg)))
+#undef RTA_NEXT
+#define RTA_NEXT(rta, len)                                                    \
+	((len) -= RTA_ALIGN((rta)->rta_len),                                  \
+	 (void *)(((char *)(rta)) + RTA_ALIGN((rta)->rta_len)))
+#undef NLMSG_NEXT
+#define NLMSG_NEXT(nlh, len)                                                  \
+	((len) -= NLMSG_ALIGN((nlh)->nlmsg_len),                              \
+	 (void *)(((char *)(nlh)) + NLMSG_ALIGN((nlh)->nlmsg_len)))
+#undef IFA_RTA
+#define IFA_RTA(r)                                                            \
+	((void *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct ifaddrmsg))))

--- a/src/net/linux/rt.c
+++ b/src/net/linux/rt.c
@@ -15,23 +15,12 @@
 #include <re_fmt.h>
 #include <re_sa.h>
 #include <re_net.h>
+#include "macros.h"
 
 
 #define DEBUG_MODULE "linuxrt"
 #define DEBUG_LEVEL 5
 #include <re_dbg.h>
-
-
-/* Override macros to avoid casting alignment warning */
-#undef RTM_RTA
-#define RTM_RTA(r) (void *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct rtmsg)))
-#undef RTA_NEXT
-#define RTA_NEXT(rta, len) ((len) -= RTA_ALIGN((rta)->rta_len), \
-		(void *)(((char *)(rta)) + RTA_ALIGN((rta)->rta_len)))
-#undef NLMSG_NEXT
-#define NLMSG_NEXT(nlh,len)	 ((len) -= NLMSG_ALIGN((nlh)->nlmsg_len), \
-		  (void*)(((char*)(nlh)) + NLMSG_ALIGN((nlh)->nlmsg_len)))
-
 
 enum {BUFSIZE = 8192};
 

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -131,8 +131,7 @@ int net_if_apply(net_ifaddr_h *ifh, void *arg)
 {
 #ifdef LINUX
 	return net_netlink_addrs(ifh, arg);
-#endif
-#ifdef HAVE_GETIFADDRS
+#elif HAVE_GETIFADDRS
 	return net_getifaddrs(ifh, arg);
 #else
 	return net_if_list(ifh, arg);

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -129,7 +129,10 @@ int net_default_source_addr_get(int af, struct sa *ip)
  */
 int net_if_apply(net_ifaddr_h *ifh, void *arg)
 {
-#ifdef HAVE_GETIFADDRS
+#ifdef LINUX
+	return net_netlink_addrs(ifh, arg);
+#endif
+#if HAVE_GETIFADDRS
 	return net_getifaddrs(ifh, arg);
 #else
 	return net_if_list(ifh, arg);

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -132,7 +132,7 @@ int net_if_apply(net_ifaddr_h *ifh, void *arg)
 #ifdef LINUX
 	return net_netlink_addrs(ifh, arg);
 #endif
-#if HAVE_GETIFADDRS
+#ifdef HAVE_GETIFADDRS
 	return net_getifaddrs(ifh, arg);
 #else
 	return net_if_list(ifh, arg);


### PR DESCRIPTION
This pull request adds support for obtaining network interface addresses using the RTNETLINK API on Linux systems.

fixes https://github.com/baresip/baresip/issues/3245