### PR TITLE
rtp: remove rtcp_psfb_sli_encode() (unused)

### DIFF
--- a/src/rtp/fb.c
+++ b/src/rtp/fb.c
@@ -48,24 +48,6 @@ int rtcp_rtpfb_gnack_encode(struct mbuf *mb, uint16_t pid, uint16_t blp)
 }
 
 
-/**
- * Encode an RTCP Slice Loss Indication (SLI) message
- *
- * @param mb     Buffer to encode into
- * @param first  Macroblock (MB) address of the first lost macroblock
- * @param number Number of lost macroblocks
- * @param picid  Picture ID
- *
- * @return 0 for success, otherwise errorcode
- */
-int rtcp_psfb_sli_encode(struct mbuf *mb, uint16_t first, uint16_t number,
-			 uint8_t picid)
-{
-	const uint32_t v = first<<19 | number<<6 | picid;
-	return mbuf_write_u32(mb, htonl(v));
-}
-
-
 /* Decode functions */
 
 

--- a/src/rtp/rtcp.h
+++ b/src/rtp/rtcp.h
@@ -53,8 +53,6 @@ int rtcp_make_sdes_cname(const struct rtp_sock *rs, struct mbuf *mb);
 
 /* RTCP Feedback */
 int rtcp_rtpfb_gnack_encode(struct mbuf *mb, uint16_t pid, uint16_t blp);
-int rtcp_psfb_sli_encode(struct mbuf *mb, uint16_t first, uint16_t number,
-			 uint8_t picid);
 int rtcp_rtpfb_twcc_decode(struct mbuf *mb, struct twcc *msg, int n);
 int rtcp_rtpfb_decode(struct mbuf *mb, struct rtcp_msg *msg);
 int rtcp_psfb_decode(struct mbuf *mb, struct rtcp_msg *msg);


### PR DESCRIPTION
SLI is not used in our stack.
Also contributes to increased code coverage.