### PR TITLE
sys/fs: fix fs_fopen return null check

### DIFF
--- a/src/sys/fs.c
+++ b/src/sys/fs.c
@@ -270,7 +270,7 @@ int fs_fread(struct mbuf **mbp, const char *path)
 		return EINVAL;
 
 	err = fs_fopen(&f, path, "r");
-	if (err) {
+	if (err || !f) {
 		DEBUG_WARNING("Could not open file '%s'\n", path);
 		return err;
 	}


### PR DESCRIPTION
Not very likely to happen (since errno must be zero) but fixes clang-analyze warnings