### PR TITLE
test: add test for C++ applications

### DIFF
--- a/.github/workflows/cmake_win.yml
+++ b/.github/workflows/cmake_win.yml
@@ -1,4 +1,4 @@
-name: CMake and Windows
+name: Windows
 
 on:
   push:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -18,8 +18,10 @@ jobs:
         sanitizer: [thread, address, undefined]
     env:
       CC: clang-18
+      CXX: clang++-18
       CMAKE_GENERATOR: Ninja
       CFLAGS: "-fsanitize=${{ matrix.sanitizer }} -fno-sanitize-recover=all -fno-sanitize=function"
+      CXXFLAGS: "-fsanitize=${{ matrix.sanitizer }} -fno-sanitize-recover=all -fno-sanitize=function"
       ASAN_OPTIONS: fast_unwind_on_malloc=0
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ endif()
 
 check_c_compiler_flag("-Watomic-implicit-seq-cst" COMPILER_SUPPORTS_WATOMIC)
 if(COMPILER_SUPPORTS_WATOMIC)
-  add_compile_options(-Watomic-implicit-seq-cst)
+  add_compile_options("$<$<COMPILE_LANGUAGE:C>:-Watomic-implicit-seq-cst>")
 endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,10 +83,10 @@ endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
     add_compile_options(
-      -Wshorten-64-to-32
       -Wno-gnu-zero-variadic-macro-arguments
       -Wno-c2x-extensions
     )
+    add_compile_options("$<$<COMPILE_LANGUAGE:C>:-Wshorten-64-to-32>")
 endif()
 
 check_c_compiler_flag("-Watomic-implicit-seq-cst" COMPILER_SUPPORTS_WATOMIC)

--- a/include/re_atomic.h
+++ b/include/re_atomic.h
@@ -602,13 +602,13 @@ static __forceinline unsigned __int64 _re_atomic_load(
 		v = __iso_volatile_load8((const volatile __int8*)a);
 		break;
 	case 2u:
-		v = __iso_volatile_load16((const unsigned __int16*)a);
+		v = __iso_volatile_load16((const volatile __int16*)a);
 		break;
 	case 4u:
-		v = __iso_volatile_load32((const unsigned __int32*)a);
+		v = __iso_volatile_load32((const volatile __int32*)a);
 		break;
 	default:
-		v = __iso_volatile_load64((const unsigned __int64*)a);
+		v = __iso_volatile_load64((const volatile __int64*)a);
 		break;
 	}
 

--- a/include/re_atomic.h
+++ b/include/re_atomic.h
@@ -599,7 +599,7 @@ static __forceinline unsigned __int64 _re_atomic_load(
 
 	switch (size) {
 	case 1u:
-		v = __iso_volatile_load8((const unsigned __int8*)a);
+		v = __iso_volatile_load8((const volatile __int8*)a);
 		break;
 	case 2u:
 		v = __iso_volatile_load16((const unsigned __int16*)a);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,7 +35,8 @@ set(CMAKE_CXX_STANDARD 11)
 if(MSVC)
   add_compile_options("/W3")
 else()
-  add_compile_options(
+
+ set(c_flags
     -Wall
     -Wbad-function-cast
     -Wcast-align
@@ -49,6 +50,10 @@ else()
     -Wstrict-prototypes
     -Wuninitialized
     -Wvla
+  )
+
+  add_compile_options(
+    "$<$<COMPILE_LANGUAGE:C>:${c_flags}>"
   )
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,7 +36,7 @@ if(MSVC)
   add_compile_options("/W3")
 else()
 
- set(c_flags
+  set(c_flags
     -Wall
     -Wbad-function-cast
     -Wcast-align

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ include(sanitizer)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_CXX_STANDARD 11)
 
 if(MSVC)
   add_compile_options("/W3")
@@ -152,6 +153,8 @@ if(USE_OPENSSL)
     mock/cert.c
   )
 endif()
+
+list(APPEND SRCS cplusplus.cpp)
 
 
 ##############################################################################

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,7 +53,7 @@ else()
 endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wshorten-64-to-32)
+  add_compile_options("$<$<COMPILE_LANGUAGE:C>:-Wshorten-64-to-32>")
 endif()
 
 include_directories(

--- a/test/cplusplus.cpp
+++ b/test/cplusplus.cpp
@@ -1,0 +1,25 @@
+/**
+ * @file cplusplus.cpp Emulate C++ applications
+ *
+ * Copyright (C) 2025 Alfred E. Heggestad
+ */
+
+#include <iostream>
+#include <re_atomic.h>
+#include <re.h>
+#include "test.h"
+
+
+#define DEBUG_MODULE "cplusplus"
+#define DEBUG_LEVEL 5
+#include <re_dbg.h>
+
+
+int test_cplusplus(void)
+{
+	std::cout << "test\n";
+
+	DEBUG_NOTICE("%H\n", sys_kernel_get, nullptr);
+
+	return 0;
+}

--- a/test/test.c
+++ b/test/test.c
@@ -279,6 +279,7 @@ static const struct test tests_integration[] = {
 	TEST(test_tmr_jiffies_usec),
 	TEST(test_turn_thread),
 	TEST(test_thread_cnd_timedwait),
+	TEST(test_cplusplus),
 };
 
 

--- a/test/test.h
+++ b/test/test.h
@@ -388,6 +388,16 @@ int  test_integration(const char *name, bool verbose);
 int  test_sipevent_network(void);
 int  test_sip_drequestf_network(void);
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int  test_cplusplus(void);
+
+#ifdef __cplusplus
+}
+#endif
+
 /* High-level API */
 int  test_reg(const char *name, bool verbose);
 int  test_oom(const char *name, bool verbose);


### PR DESCRIPTION
Proposal to compile a C++ application to test libre api.

There are some build errors for ARM64-Windows:

```
FAILED: test/CMakeFiles/retest.dir/cplusplus.cpp.obj 
C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1442~1.344\bin\Hostx64\arm64\cl.exe  /nologo /TP -DARCH=\"AMD64\" -DHAVE_ATOMIC -DHAVE_IO_H -DHAVE_PQOS_FLOWID -DHAVE_QOS_FLOWID -DHAVE_SELECT -DHAVE_UNIXSOCK=1 -DOS=\"Windows\" -DRE_VERSION=\"3.18.0\" -DVER_MAJOR=3 -DVER_MINOR=18 -DVER_PATCH=0 -DWIN32 -D_CRT_SECURE_NO_WARNINGS -D_GNU_SOURCE -D_WIN32_WINNT=0x0600 -Dretest_EXPORTS -ID:\a\re\re\test\. -ID:\a\re\re\include /DWIN32 /D_WINDOWS /EHsc /Ob0 /Od /RTC1 -MDd -Zi /W3 /showIncludes /Fotest\CMakeFiles\retest.dir\cplusplus.cpp.obj /Fdtest\CMakeFiles\retest.dir\ /FS -c D:\a\re\re\test\cplusplus.cpp
D:\a\re\re\include\re_atomic.h(602): error C2664: 'char __iso_volatile_load8(volatile const char *)': cannot convert argument 1 from 'const unsigned char *' to 'volatile const char *'
D:\a\re\re\include\re_atomic.h(602): note: Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or parenthesized function-style cast
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\include\intrin0.inl.h(273): note: see declaration of '__iso_volatile_load8'
D:\a\re\re\include\re_atomic.h(602): note: while trying to match the argument list '(const unsigned char *)'
D:\a\re\re\include\re_atomic.h(605): error C2664: 'short __iso_volatile_load16(volatile const short *)': cannot convert argument 1 from 'const unsigned short *' to 'volatile const short *'
D:\a\re\re\include\re_atomic.h(605): note: Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or parenthesized function-style cast
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\include\intrin0.inl.h(270): note: see declaration of '__iso_volatile_load16'
D:\a\re\re\include\re_atomic.h(605): note: while trying to match the argument list '(const unsigned short *)'
D:\a\re\re\include\re_atomic.h(608): error C2664: 'int __iso_volatile_load32(volatile const int *)': cannot convert argument 1 from 'const unsigned int *' to 'volatile const int *'
D:\a\re\re\include\re_atomic.h(608): note: Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or parenthesized function-style cast
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\include\intrin0.inl.h(271): note: see declaration of '__iso_volatile_load32'
D:\a\re\re\include\re_atomic.h(608): note: while trying to match the argument list '(const unsigned int *)'
D:\a\re\re\include\re_atomic.h(611): error C2664: '__int64 __iso_volatile_load64(volatile const __int64 *)': cannot convert argument 1 from 'const unsigned __int64 *' to 'volatile const __int64 *'
D:\a\re\re\include\re_atomic.h(611): note: Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or parenthesized function-style cast
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\include\intrin0.inl.h(272): note: see declaration of '__iso_volatile_load64'
D:\a\re\re\include\re_atomic.h(611): note: while trying to match the argument list '(const unsigned __int64 *)'
ninja: build stopped: subcommand failed.
```


