### PR TITLE
atomic: fix compilation for C++ and Windows-ARM64

### DIFF
--- a/include/re_atomic.h
+++ b/include/re_atomic.h
@@ -599,16 +599,16 @@ static __forceinline unsigned __int64 _re_atomic_load(
 
 	switch (size) {
 	case 1u:
-		v = __iso_volatile_load8((const unsigned __int8*)a);
+		v = __iso_volatile_load8((const volatile __int8*)a);
 		break;
 	case 2u:
-		v = __iso_volatile_load16((const unsigned __int16*)a);
+		v = __iso_volatile_load16((const volatile __int16*)a);
 		break;
 	case 4u:
-		v = __iso_volatile_load32((const unsigned __int32*)a);
+		v = __iso_volatile_load32((const volatile __int32*)a);
 		break;
 	default:
-		v = __iso_volatile_load64((const unsigned __int64*)a);
+		v = __iso_volatile_load64((const volatile __int64*)a);
 		break;
 	}
 


### PR DESCRIPTION
original error for C++ file on Windows-ARM64:

```
C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1442~1.344\bin\Hostx64\arm64\cl.exe  /nologo /TP -DARCH=\"AMD64\" -DHAVE_ATOMIC -DHAVE_IO_H -DHAVE_PQOS_FLOWID -DHAVE_QOS_FLOWID -DHAVE_SELECT -DHAVE_UNIXSOCK=1 -DOS=\"Windows\" -DRE_VERSION=\"3.18.0\" -DVER_MAJOR=3 -DVER_MINOR=18 -DVER_PATCH=0 -DWIN32 -D_CRT_SECURE_NO_WARNINGS -D_GNU_SOURCE -D_WIN32_WINNT=0x0600 -Dretest_EXPORTS -ID:\a\re\re\test\. -ID:\a\re\re\include /DWIN32 /D_WINDOWS /EHsc /Ob0 /Od /RTC1 -MDd -Zi /W3 /showIncludes /Fotest\CMakeFiles\retest.dir\cplusplus.cpp.obj /Fdtest\CMakeFiles\retest.dir\ /FS -c D:\a\re\re\test\cplusplus.cpp D:\a\re\re\include\re_atomic.h(602): error C2664: 'char __iso_volatile_load8(volatile const char *)': cannot convert argument 1 from 'const unsigned char *' to 'volatile const char *' D:\a\re\re\include\re_atomic.h(602): note: Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or parenthesized function-style cast
```

I am not an expert on atomics, perhaps there are better solutions.