### PR TITLE
bump version to 3.21.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 cmake_minimum_required(VERSION 3.15...3.31)
 
 project(re
-  VERSION 3.20.0
+  VERSION 3.21.0
   LANGUAGES C
   HOMEPAGE_URL https://github.com/baresip/re
   DESCRIPTION "Generic library for real-time communications"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ project(re
   DESCRIPTION "Generic library for real-time communications"
 )
 
-set(PROJECT_SOVERSION 30) # bump if ABI breaks
+set(PROJECT_SOVERSION 31) # bump if ABI breaks
 
 # Pre-release identifier, comment out on a release
 # Increment for breaking changes (dev2, dev3...)

--- a/mk/Doxyfile
+++ b/mk/Doxyfile
@@ -4,7 +4,7 @@
 # Project related configuration options
 #---------------------------------------------------------------------------
 PROJECT_NAME           = libre
-PROJECT_NUMBER         = 3.20.0
+PROJECT_NUMBER         = 3.21.0
 OUTPUT_DIRECTORY       = ../re-dox
 CREATE_SUBDIRS         = NO
 OUTPUT_LANGUAGE        = English


### PR DESCRIPTION
I guess we should also bump SOVERSION because of the `struct list` change ?

There might be a problem with the abidiff job ...