### PR TITLE
thread: use __APPLE__ macro for pthread_setname_np()

### DIFF
--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -13,6 +13,9 @@
 #include <windows.h>
 #include <processthreadsapi.h>
 #endif
+#ifdef __APPLE__
+#include "TargetConditionals.h"
+#endif
 #ifdef HAVE_PTHREAD
 #include <pthread.h>
 #ifdef OPENBSD
@@ -89,8 +92,10 @@ static int handler(void *p)
 	(void)prctl(PR_SET_NAME, th.name);
 #elif defined(WIN32)
 	/* Not implemented */
-#elif defined(DARWIN)
+#elif __APPLE__
+#if defined(TARGET_OS_MAC) || defined(TARGET_OS_IPHONE)
 	(void)pthread_setname_np(th.name);
+#endif
 #elif defined(HAVE_PTHREAD)
 #if defined(OPENBSD)
 	(void)pthread_set_name_np(*th.thr, th.name);


### PR DESCRIPTION
not sure if this patch is needed, since we already define `DARWIN` in re-config.cmake:

```
if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
  list(APPEND RE_DEFINITIONS DARWIN)
  include_directories(/opt/local/include)
elseif(${CMAKE_SYSTEM_NAME} MATCHES "iOS")
  list(APPEND RE_DEFINITIONS DARWIN)
elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
  list(APPEND RE_DEFINITIONS FREEBSD)
elseif(${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
  list(APPEND RE_DEFINITIONS OPENBSD)
elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
  list(APPEND RE_DEFINITIONS LINUX)
endif()
```
