### PR TITLE
mem/mem_pool: use pointer-pointer to prevent heap-use-after-free

### DIFF
--- a/src/mem/mem_pool.c
+++ b/src/mem/mem_pool.c
@@ -161,6 +161,7 @@ int mem_pool_extend(struct mem_pool *pool, size_t num)
 		}
 		objs[i]->member = mem_zalloc(pool->membsize, pool->membdh);
 		if (!objs[i]->member) {
+			mem_deref(objs[i]);
 			mem_deref(objs);
 			mtx_unlock(pool->lock);
 			return ENOMEM;


### PR DESCRIPTION
If `mem_pool_entry` pointer is stored by application a `mem_pool_extend` derefs this pointer. This PR uses a pointer-pointer list to keep old `mem_pool_entry` pointers intact.

Fixes https://github.com/baresip/baresip/issues/3338