### PR TITLE
json: add full encode/decode odict

### DIFF
--- a/include/re_json.h
+++ b/include/re_json.h
@@ -47,4 +47,7 @@ int json_decode(const char *str, size_t len, unsigned maxdepth,
 
 int json_decode_odict(struct odict **op, uint32_t hash_size, const char *str,
 		      size_t len, unsigned maxdepth);
+int json_decode_odict_full(struct odict **op, uint32_t hash_size,
+			   const char *str, size_t len, unsigned maxdepth);
 int json_encode_odict(struct re_printf *pf, const struct odict *o);
+int json_encode_odict_full(struct re_printf *pf, const struct odict *o);


### PR DESCRIPTION
json_decode_odict and json_encode_odict assumes for easy usage, the first level is always a json object. With the new full api also the first level is encoded/decoded.