### PR TITLE
Handle "w" properly in the AV1 packetizer

### DIFF
--- a/include/re_av1.h
+++ b/include/re_av1.h
@@ -57,6 +57,9 @@ typedef int (av1_packet_h)(bool marker, uint64_t rtp_ts,
 			    const uint8_t *pld, size_t pld_len,
 			    void *arg);
 
+int av1_packetize_new(bool *newp, bool marker, uint64_t rtp_ts,
+		       const uint8_t *buf, size_t len, size_t maxlen,
+		       av1_packet_h *pkth, void *arg);
 int av1_packetize_high(bool *newp, bool marker, uint64_t rtp_ts,
 		       const uint8_t *buf, size_t len, size_t maxlen,
 		       av1_packet_h *pkth, void *arg);

--- a/src/av1/pkt.c
+++ b/src/av1/pkt.c
@@ -18,7 +18,28 @@
 
 
 enum {
-	MAX_OBUS = 3  /* Maximum number of OBUs for W field */
+	MAX_OBUS = 3,   /* Maximum number of OBUs for W field */
+	AV1_OBU_HEADER_SIZE = 1,
+};
+
+struct av1_context {
+	/* The current RTP packet being created */
+	struct mbuf *mb_pkt;
+	/* The current OBU being packetized. This only contains the OBU
+	 * payload, not the header or size */
+	struct mbuf *curr_obu;
+	/* The input buffer provided by the application.
+	 * The position always points to immediately after curr_obu */
+	struct mbuf *mb_buf;
+	/* The OBU header for the current OBU being packetized */
+	struct av1_obu_hdr curr_hdr;
+	/* The number of bytes which still need to be written from the
+	 * current OBU. This can be greater than the OBU size if the OBU
+	 * header hasn't been written yet.
+	 * If this is zero at the end of a packet, packetization is done */
+	size_t curr_remaining;
+	/* The max length of each RTP packet */
+	size_t maxlen;
 };
 
 
@@ -44,6 +65,8 @@ static size_t leb128_calc_size(uint64_t value)
 
 
 /*
+ * Serialize the AV1 RTP aggregation header
+ *
  * Z: MUST be set to 1 if the first OBU element is an OBU fragment that is a
  *    continuation of an OBU fragment from the previous packet, and MUST be
  *    set to 0 otherwise.
@@ -51,10 +74,387 @@ static size_t leb128_calc_size(uint64_t value)
  * Y: MUST be set to 1 if the last OBU element is an OBU fragment that will
  *    continue in the next packet, and MUST be set to 0 otherwise.
  */
-static void hdr_encode(uint8_t hdr[AV1_AGGR_HDR_SIZE],
+static void aggr_hdr_encode(uint8_t hdr[AV1_AGGR_HDR_SIZE],
 		       bool z, bool y, uint8_t w, bool n)
 {
 	hdr[0] = z<<7 | y<<6 | w<<4 | n<<3;
+}
+
+
+/**
+ * @returns the size the given OBU will be once we packetize it.
+ * We force has_size to false in the OBU header, so this is the size of the OBU
+ * and the one-byte OBU header.
+ */
+static size_t packetized_obu_size(const struct av1_obu_hdr* hdr) {
+	return AV1_OBU_HEADER_SIZE + hdr->size;
+}
+
+
+/**
+ * Searches through mb_buf until it finds an OBU which should be packetized,
+ * and updates the current OBU when one is found.
+ * If there are no more OBUs, curr_remaining will be set to 0
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+static int update_curr_obu(struct av1_context* context) {
+	int err = 0;
+	do {
+		size_t remaining = mbuf_get_left(context->mb_buf);
+		/* OBUs must be at least 2 bytes */
+		if (remaining < 2) {
+			if (remaining > 0) {
+				DEBUG_WARNING(
+					"av1: encode: leftover data "
+					"(%zu bytes)\n",
+					remaining);
+				mbuf_advance(context->mb_buf, remaining);
+			}
+			context->curr_obu->pos = context->curr_obu->end;
+			context->curr_remaining = 0;
+			break;
+		}
+		err = av1_obu_decode(&context->curr_hdr, context->mb_buf);
+		if (err) {
+			break;
+		}
+		context->curr_obu->buf = mbuf_buf(context->mb_buf);
+		context->curr_obu->size = context->curr_hdr.size;
+		context->curr_obu->pos = 0;
+		context->curr_obu->end = context->curr_hdr.size;
+		context->curr_remaining =
+			packetized_obu_size(&context->curr_hdr);
+		mbuf_advance(context->mb_buf, context->curr_hdr.size);
+	} while (!obu_allowed_rtp(context->curr_hdr.type));
+
+	return err;
+}
+
+
+/**
+ * Copies len_to_copy of the current OBU to the RTP packet, taking the OBU
+ * header into account. The caller is responsible for ensuring there is
+ * enough space left in the packet for this many bytes:
+ *     len_to_copy +
+ *         include_prefix ? leb128_calc_size(len_to_copy) : 0
+ *
+ * @param context        Packetization context
+ * @param include_prefix Whether to include the size prefix before the fragment
+ * @param len_to_copy    The length of the OBU fragment to write. This is the
+ *                       number of bytes to copy from the OBU
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+static int copy_fragment(struct av1_context* context, bool include_prefix,
+		size_t len_to_copy) {
+	int err = 0;
+	if (include_prefix) {
+		err = av1_leb128_encode(context->mb_pkt, len_to_copy);
+		if (err) {
+			goto out;
+		}
+	}
+	/*
+	 * If this is the first time we're writing this OBU, we need to take
+	 * the OBU header into account. The header can't be copied normally
+	 * because we might need to modify it to remove the size information.
+	 */
+	if (context->curr_remaining == packetized_obu_size(&context->curr_hdr))
+	{
+		uint8_t obu_hdr = (context->curr_hdr.type & 0xf) << 3;
+		err |= mbuf_write_u8(context->mb_pkt, obu_hdr);
+		if (err) {
+			goto out;
+		}
+		--len_to_copy;
+		--context->curr_remaining;
+	}
+
+	err = mbuf_write_mem(context->mb_pkt,
+		mbuf_buf(context->curr_obu), len_to_copy);
+	if (err) {
+		goto out;
+	}
+	mbuf_advance(context->curr_obu, len_to_copy);
+	context->curr_remaining -= len_to_copy;
+out:
+	return err;
+}
+
+
+/**
+ * Calculates the length of a fragment and the length of the leb128-encoded
+ * size prefix for it.
+ *
+ * @param context         Packetization context
+ * @param remaining_pkt   The number of bytes remaining in the current packet.
+ *                        Must be greater than zero
+ * @param len_to_copy_out Pointer to receive the length of the fragment to be
+ *                        written
+ * @param prefix_len_out  Pointer to receive the length of the size prefix to
+ *                        be written
+ */
+static void calc_fragment_len_with_prefix(
+		struct av1_context* context,
+		size_t remaining_pkt,
+		size_t* len_to_copy_out,
+		size_t* prefix_len_out) {
+	/* The size always uses at least 1 byte, so subtract one from the
+	 * remaining packet space */
+	size_t len_to_copy = min(context->curr_remaining, remaining_pkt - 1);
+	size_t prefix_len = leb128_calc_size(len_to_copy);
+
+	if (len_to_copy + prefix_len > remaining_pkt) {
+		/* If there's not enough room in the packet for the initial
+		 * estimate, reserve space in the packet for the length of the
+		 * prefix and try again. Note that prefix_len can change here
+		 * if len_to_copy changes from, say, 128 to 127, but the new
+		 * prefix_len will always be <= the old one. */
+		len_to_copy = remaining_pkt - prefix_len;
+		prefix_len = leb128_calc_size(len_to_copy);
+	}
+
+	*len_to_copy_out = len_to_copy;
+	*prefix_len_out = prefix_len;
+}
+
+
+/**
+ * Calculates the length of the next fragment to write to the RTP packet and
+ * whether it needs a size prefix.
+ *
+ * @param context            Packetization context
+ * @param count              The number of fragments already written to the RTP
+ *                           packet
+ * @param include_prefix_out Pointer to receive whether the size prefix should
+ *                           be written before this fragment
+ * @param len_to_copy_out    Pointer to receive the length of the fragment to
+ *                           be written. If set to zero, there was not enough
+ *                           room in the packet for another fragment
+ *
+ * @returns 0 on success and non-zero otherwise. On success, check
+ *          len_to_copy_out to determine if there was room in the packet for
+ *          another fragment
+ */
+static int calc_fragment_len(
+		struct av1_context* context,
+		size_t count,
+		bool* include_prefix_out,
+		size_t* len_to_copy_out) {
+	/* Note: This checks for space left in the entire buffer,
+	 * not the current OBU */
+	bool is_last_obu = mbuf_get_left(context->mb_buf) == 0;
+	size_t pkt_len = mbuf_pos(context->mb_pkt);
+	size_t remaining_pkt = 0;
+	size_t len_to_copy = 0;
+	size_t fragment_size_len = 0;
+	bool include_prefix = false;
+
+	*include_prefix_out = 0;
+	*len_to_copy_out = 0;
+
+	if (pkt_len > context->maxlen) {
+		DEBUG_WARNING("av1: encode: packet too large (%zu > %zu)\n",
+				pkt_len, context->maxlen);
+		return ERANGE;
+	}
+	remaining_pkt = context->maxlen - pkt_len;
+	if (remaining_pkt < 1) {
+		return 0;
+	}
+
+	/* The size prefix can be elided for the last fragment only when there
+	 * are 3 or fewer fragments in the packet. */
+	if (count > MAX_OBUS) {
+		include_prefix = true;
+	}
+	else if (!is_last_obu && remaining_pkt > context->curr_remaining) {
+		/* If the next fragment would need a prefix, we need a minimum
+		 * of 2 bytes for it. */
+		size_t next_fragment = count > 2 ? 2 : 1;
+		calc_fragment_len_with_prefix(context,
+			remaining_pkt,
+			&len_to_copy,
+			&fragment_size_len);
+
+		/* Only include a prefix if there
+		 * is room for another fragment. */
+		include_prefix = len_to_copy + fragment_size_len <=
+				remaining_pkt - next_fragment;
+	}
+
+	if (include_prefix) {
+		/* A prefixed fragment needs a minimum of 2 bytes:
+		 * 1 for the prefix itself and at least 1 for the data. */
+		if (remaining_pkt < 2) {
+			return 0;
+		}
+		/* Only calculate this if it wasn't calculated above when
+		 * count <= 3 */
+		if (len_to_copy == 0) {
+			calc_fragment_len_with_prefix(context,
+				remaining_pkt,
+				&len_to_copy,
+				&fragment_size_len);
+		}
+	}
+	else {
+		/* No prefix is needed, fill as much
+		 * of the packet as possible. */
+		len_to_copy = min(context->curr_remaining, remaining_pkt);
+	}
+
+	*include_prefix_out = include_prefix;
+	*len_to_copy_out = len_to_copy;
+	return 0;
+}
+
+
+/**
+ * Copy as many OBU fragments as possible to the current RTP packet.
+ *
+ * @param context Packetization context
+ * @param w       The value of w for this packet (whether each fragment is
+ *                prefixed or the last one is elided)
+ * @param y       The value of y for this packet (whether the last fragment
+ *                will continue to the next packet)
+ */
+static int copy_obus_to_packet(struct av1_context* context, uint8_t* w,
+		bool *y) {
+	unsigned count = 0;
+	int err = 0;
+	bool include_prefix = true;
+
+	/* Stop copying OBUs when:
+	 * 1. There are no more OBUs left (curr_remaining == 0), or
+	 * 2. The last fragment didn't include a prefix. We aren't allowed to
+	 *    copy another fragment even if there's space in the packet, or
+	 * 3. calc_fragment_len determines there isn't enough room for another
+	 *    fragment */
+	while (context->curr_remaining > 0 && include_prefix) {
+		size_t len_to_copy = 0;
+		err = calc_fragment_len(context, count + 1, &include_prefix,
+			&len_to_copy);
+		if (err) {
+			goto out;
+		}
+		/* Not enough room for another fragment */
+		if (len_to_copy == 0) {
+			break;
+		}
+		err = copy_fragment(context, include_prefix, len_to_copy);
+		if (err) {
+			goto out;
+		}
+		++count;
+
+		if (context->curr_remaining == 0) {
+			/* We finished packetizing the current OBU,
+			 * move onto the next one. */
+			*y = false;
+			err = update_curr_obu(context);
+			if (err) {
+				goto out;
+			}
+		}
+		else {
+			/* The current OBU still has data left to packetize. */
+			*y = true;
+		}
+	}
+	/* It's possible for copy_obu_to_packet to accidentally include the
+	 * size prefix before the last OBU in the packet if the last OBU in
+	 * the buffer is skipped. We need to set w = 0 in that case even if
+	 * there are <= 3 OBU fragments */
+	*w = count > MAX_OBUS || include_prefix ? 0 : count;
+
+out:
+	return err;
+}
+
+
+/**
+ * Packetize an AV1 bitstream with one or more OBUs
+ *
+ * @param newp    Pointer to new stream flag
+ * @param marker  Set marker bit
+ * @param rtp_ts  RTP timestamp
+ * @param buf     Input buffer
+ * @param len     Buffer length
+ * @param maxlen  Maximum RTP packet size
+ * @param pkth    Packet handler
+ * @param arg     Handler argument
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int av1_packetize_new(bool *newp, bool marker, uint64_t rtp_ts,
+		       const uint8_t *buf, size_t len, size_t maxlen,
+		       av1_packet_h *pkth, void *arg)
+{
+	struct mbuf *mb_pkt;
+	uint8_t w;
+	int err;
+	bool continuing_to_next_packet = false;
+	bool continued_from_previous_packet = false;
+	struct mbuf mb_buf = {
+		.buf  = (uint8_t *)buf,
+		.size = len,
+		.pos  = 0,
+		.end  = len
+	};
+	struct mbuf curr_obu;
+	uint8_t aggr_hdr[AV1_AGGR_HDR_SIZE];
+
+	if (!newp || !buf || !len || maxlen < (AV1_AGGR_HDR_SIZE + 1) || !pkth)
+		return EINVAL;
+
+	maxlen -= sizeof(aggr_hdr);
+	mb_pkt = mbuf_alloc(maxlen);
+	if (!mb_pkt)
+		return ENOMEM;
+	mbuf_init(&curr_obu);
+
+	struct av1_context context = {
+		.mb_pkt = mb_pkt,
+		.mb_buf = &mb_buf,
+		.curr_obu = &curr_obu,
+		.curr_remaining = 0,
+		.maxlen = maxlen
+	};
+	err = update_curr_obu(&context);
+	if (err) {
+		goto out;
+	}
+
+	while (context.curr_remaining > 0) {
+		continued_from_previous_packet = continuing_to_next_packet;
+		err = copy_obus_to_packet(&context, &w,
+			&continuing_to_next_packet);
+		if (err) {
+			goto out;
+		}
+		aggr_hdr_encode(aggr_hdr, continued_from_previous_packet,
+			continuing_to_next_packet, w, *newp);
+		*newp = false;
+
+		mbuf_set_pos(context.mb_pkt, 0);
+		err = pkth(marker && context.curr_remaining == 0,
+			rtp_ts,
+			aggr_hdr,
+			sizeof(aggr_hdr),
+			mbuf_buf(context.mb_pkt),
+			mbuf_get_left(context.mb_pkt),
+			arg);
+		if (err) {
+			goto out;
+		}
+		mbuf_rewind(context.mb_pkt);
+	}
+
+ out:
+	mem_deref(mb_pkt);
+	return err;
 }
 
 
@@ -197,7 +597,7 @@ static int av1_packetize_internal(bool *newp, bool marker, uint64_t rtp_ts,
 
 	while (len > maxlen) {
 
-		hdr_encode(hdr, z_cont, true, w, *newp);
+		aggr_hdr_encode(hdr, z_cont, true, w, *newp);
 		*newp = false;
 
 		err |= pkth(false, rtp_ts, hdr, sizeof(hdr), buf, maxlen, arg);
@@ -215,7 +615,7 @@ static int av1_packetize_internal(bool *newp, bool marker, uint64_t rtp_ts,
 		}
 	}
 
-	hdr_encode(hdr, z_cont, false, w, *newp);
+	aggr_hdr_encode(hdr, z_cont, false, w, *newp);
 	*newp = false;
 
 	err |= pkth(marker, rtp_ts, hdr, sizeof(hdr), buf, len, arg);
@@ -225,7 +625,9 @@ static int av1_packetize_internal(bool *newp, bool marker, uint64_t rtp_ts,
 
 
 /**
- * Packetize an AV1 bitstream with one or more OBUs
+ * Packetize an AV1 bitstream using a deprecated algorithm. This algorithm
+ * has known issues when too many OBUs are present. Prefer av1_packetize_new
+ * whenever possible.
  *
  * @param newp    Pointer to new stream flag
  * @param marker  Set marker bit

--- a/test/av1.c
+++ b/test/av1.c
@@ -157,15 +157,17 @@ static int test_av1_obu(void)
 
 static const uint64_t dummy_ts = 0x0102030405060708ULL;
 
+#define MAX_OBUS 10
+
 struct test {
 	/* input: */
 	size_t pktsize;
 
 	/* output: */
-	struct mbuf *mb;
+	struct mbuf *obus[MAX_OBUS];
+	size_t obu_index;
 	unsigned marker_count;
 	unsigned new_count;
-	uint8_t w_saved;
 };
 
 
@@ -178,6 +180,11 @@ static int av1_packet_handler(bool marker, uint64_t rtp_ts,
 	struct mbuf *mb = mbuf_alloc(hdr_len + pld_len);
 	struct av1_aggr_hdr aggr_hdr;
 	int err = 0;
+	unsigned count = 0;
+	size_t size = 0;
+
+	if (!mb)
+		return ENOMEM;
 
 	ASSERT_EQ(dummy_ts, rtp_ts);
 	ASSERT_TRUE((hdr_len + pld_len) <= test->pktsize);
@@ -193,22 +200,50 @@ static int av1_packet_handler(bool marker, uint64_t rtp_ts,
 	if (err)
 		goto out;
 
-	/* XXX: check Z and Y flags */
-
-	/* Save the first W field */
-	if (test->w_saved == 255)
-		test->w_saved = aggr_hdr.w;
-
 	if (aggr_hdr.n)
 		++test->new_count;
 
-	err = mbuf_write_mem(test->mb, mbuf_buf(mb), mbuf_get_left(mb));
-	if (err)
-		goto out;
+	if (aggr_hdr.z) {
+		ASSERT_TRUE(test->obus[test->obu_index]->pos > 0);
+	}
+	else {
+		ASSERT_EQ(0, test->obus[test->obu_index]->pos);
+	}
+
+	while (mbuf_get_left(mb) > 0) {
+		++count;
+		if (aggr_hdr.w == 0 || count < aggr_hdr.w) {
+			uint64_t decoded_size = 0;
+			err = av1_leb128_decode(mb, &decoded_size);
+			if (err) {
+				goto out;
+			}
+			/* Note: av1_leb128_decode always uses uint64_t,
+			 * but mbuf uses size_t, which can be 32 bits */
+			ASSERT_TRUE(decoded_size <= SIZE_MAX);
+			size = (size_t)decoded_size;
+			ASSERT_TRUE(size <= mbuf_get_left(mb));
+		}
+		else {
+			size = mbuf_get_left(mb);
+		}
+		err = mbuf_write_mem(test->obus[test->obu_index],
+			mbuf_buf(mb), size);
+		if (err) {
+			goto out;
+		}
+		mbuf_advance(mb, size);
+
+		if (mbuf_get_left(mb) > 0 || !aggr_hdr.y) {
+			mbuf_set_pos(test->obus[test->obu_index], 0);
+			++test->obu_index;
+		}
+	}
+
+	ASSERT_TRUE(aggr_hdr.w == 0 || count == aggr_hdr.w);
 
 	if (marker) {
 		++test->marker_count;
-		test->mb->pos = 0;
 	}
 
  out:
@@ -272,83 +307,10 @@ static int copy_obu(struct mbuf *mb_bs, const uint8_t *buf, size_t size)
 }
 
 
-/* Convert RTP OBUs to AV1 bitstream */
-static int convert_rtp_to_bs(struct mbuf *mb_bs, const uint8_t *buf,
-			     size_t buf_size, uint8_t w)
-{
-	struct mbuf mb_rtp = {
-		.buf = (uint8_t *)buf,
-		.size = buf_size,
-		.pos = 0,
-		.end = buf_size
-	};
-	size_t size;
-	int err;
-
-	/* prepend Temporal Delimiter */
-	err = av1_obu_encode(mb_bs, AV1_OBU_TEMPORAL_DELIMITER, true, 0, NULL);
-	if (err)
-		return err;
-
-	if (w) {
-		for (unsigned i=0; i<w; i++) {
-			bool last = (i+1 == w);
-
-			if (last) {
-				/* last OBU element MUST NOT be preceded
-				 * by a length field */
-				size = mbuf_get_left(&mb_rtp);
-			}
-			else {
-				uint64_t val;
-
-				err = av1_leb128_decode(&mb_rtp, &val);
-				if (err)
-					return err;
-
-				if (val > mbuf_get_left(&mb_rtp))
-					return EBADMSG;
-
-				size = (size_t)val;
-			}
-
-			err = copy_obu(mb_bs, mbuf_buf(&mb_rtp), size);
-			if (err)
-				return err;
-
-			mbuf_advance(&mb_rtp, size);
-		}
-	}
-	else {
-		while (mbuf_get_left(&mb_rtp) >= 2) {
-
-			uint64_t val;
-
-			/* each OBU element MUST be preceded by length field */
-			err = av1_leb128_decode(&mb_rtp, &val);
-			if (err)
-				return err;
-
-			if (val > mbuf_get_left(&mb_rtp))
-				return EBADMSG;
-
-			size = (size_t)val;
-
-			err = copy_obu(mb_bs, mbuf_buf(&mb_rtp), size);
-			if (err)
-				return err;
-
-			mbuf_advance(&mb_rtp, size);
-		}
-	}
-
-	return 0;
-}
-
-
 static int test_av1_packetize_base(unsigned count_bs, unsigned count_rtp,
-				   unsigned exp_w_first, size_t pktsize,
-				   const uint8_t *buf, size_t size)
+				   size_t pktsize, const uint8_t *buf,
+				   size_t size, const uint8_t *expected_buf,
+				   size_t expected_size)
 {
 	struct test test;
 	struct mbuf *mb_bs = mbuf_alloc(1024);
@@ -364,15 +326,16 @@ static int test_av1_packetize_base(unsigned count_bs, unsigned count_rtp,
 	ASSERT_EQ(count_rtp, av1_obu_count_rtp(buf, size));
 
 	test.pktsize = pktsize;
-	test.w_saved = 255;
 
-	test.mb = mbuf_alloc(1024);
-	if (!test.mb) {
-		err = ENOMEM;
-		goto out;
+	for (size_t i = 0; i < MAX_OBUS; ++i) {
+		test.obus[i] = mbuf_alloc(1024);
+		if (!test.obus[i]) {
+			err = ENOMEM;
+			goto out;
+		}
 	}
 
-	err = av1_packetize_high(&new_flag, true, dummy_ts,
+	err = av1_packetize_new(&new_flag, true, dummy_ts,
 			    buf, size, test.pktsize,
 			    av1_packet_handler, &test);
 	if (err)
@@ -380,17 +343,24 @@ static int test_av1_packetize_base(unsigned count_bs, unsigned count_rtp,
 
 	ASSERT_EQ(1, test.marker_count);
 	ASSERT_EQ(1, test.new_count);
-	ASSERT_EQ(exp_w_first, test.w_saved);
 
-	err = convert_rtp_to_bs(mb_bs, test.mb->buf, test.mb->end,
-				test.w_saved);
+	/* prepend Temporal Delimiter */
+	err = av1_obu_encode(mb_bs, AV1_OBU_TEMPORAL_DELIMITER, true, 0, NULL);
 	TEST_ERR(err);
 
+	for (size_t i = 0; i < test.obu_index; ++i) {
+		err = copy_obu(mb_bs,
+			mbuf_buf(test.obus[i]), mbuf_get_left(test.obus[i]));
+		TEST_ERR(err);
+	}
+
 	/* compare bitstream with test-vector */
-	TEST_MEMCMP(buf, size, mb_bs->buf, mb_bs->end);
+	TEST_MEMCMP(expected_buf, expected_size, mb_bs->buf, mb_bs->end);
 
  out:
-	mem_deref(test.mb);
+	for (size_t i = 0; i < MAX_OBUS; ++i) {
+		mem_deref(test.obus[i]);
+	}
 	mem_deref(mb_bs);
 
 	return err;
@@ -435,6 +405,90 @@ static const uint8_t pkt_aom5[] = {
 	0x3b, 0xe3, 0xe1, 0x31, 0xeb, 0x4f, 0x36,
 };
 
+static const uint8_t pkt_aom_metadata[] = {
+
+	/* Temporal Delimiter */
+	0x12, 0x00,
+
+	/* Sequence header */
+	0x0a, 0x0a,
+	0x00, 0x00,  0x00, 0x01, 0x9f, 0xfb, 0xff, 0xf3, 0x00, 0x80,
+
+	/* OBU frame header */
+	0x1a, 0x1b,
+	0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
+	0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13,
+	0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x80,
+
+	/* OBU metadata */
+	0x2a, 0x1a,
+	0x02, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
+	0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13,
+	0x14, 0x15, 0x16, 0x17, 0x18, 0x80,
+
+	/* OBU metadata */
+	0x2a, 0x06,
+	0x01, 0x01, 0x02, 0x03, 0x04, 0x80,
+
+	/* Frame */
+	0x32, 0x17,
+	0x10, 0x01, 0x92, 0x80, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x57, 0xb6, 0xd3, 0xfb,
+	0x3b, 0xe3, 0xe1, 0x31, 0xeb, 0x4f, 0x36,
+};
+
+static const uint8_t pkt_multi_seq[] = {
+
+	/* Temporal Delimiter */
+	0x12, 0x00,
+
+	/* Padding */
+	0x7a, 0x04,
+	0x01, 0x02, 0x03, 0x04,
+
+	/* Sequence header */
+	0x0a, 0x0a,
+	0x00, 0x00,  0x00, 0x01, 0x9f, 0xfb, 0xff, 0xf3, 0x00, 0x80,
+
+	/* Padding */
+	0x7a, 0x04,
+	0x05, 0x06, 0x07, 0x08,
+
+	/* Padding */
+	0x7a, 0x08,
+	0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+
+	/* Duplicate sequence header */
+	0x0a, 0x0a,
+	0x00, 0x00,  0x00, 0x01, 0x9f, 0xfb, 0xff, 0xf3, 0x00, 0x80,
+
+	/* Frame */
+	0x32, 0x17,
+	0x10, 0x01, 0x92, 0x80, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x57, 0xb6, 0xd3, 0xfb,
+	0x3b, 0xe3, 0xe1, 0x31, 0xeb, 0x4f, 0x36,
+};
+
+static const uint8_t pkt_multi_seq_expected[] = {
+
+	/* Temporal Delimiter */
+	0x12, 0x00,
+
+	/* Sequence header */
+	0x0a, 0x0a,
+	0x00, 0x00,  0x00, 0x01, 0x9f, 0xfb, 0xff, 0xf3, 0x00, 0x80,
+
+	/* Duplicate sequence header */
+	0x0a, 0x0a,
+	0x00, 0x00,  0x00, 0x01, 0x9f, 0xfb, 0xff, 0xf3, 0x00, 0x80,
+
+	/* Frame */
+	0x32, 0x17,
+	0x10, 0x01, 0x92, 0x80, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x57, 0xb6, 0xd3, 0xfb,
+	0x3b, 0xe3, 0xe1, 0x31, 0xeb, 0x4f, 0x36,
+};
+
 
 /*
  * https://dl8.webmfiles.org/BeachDrone-AV1.webm
@@ -469,16 +523,48 @@ static const char pkt_beach[] =
 	;
 
 
+static int test_av1_packetize_range(
+		unsigned count_bs, unsigned count_rtp,
+		const uint8_t *buf, size_t size,
+		const uint8_t *expected_buf, size_t expected_size) {
+	int err = 0;
+	for (size_t i = 10; i <= 120; ++i) {
+		err = test_av1_packetize_base(count_bs, count_rtp, i,
+			buf, size, expected_buf, expected_size);
+		if (err) {
+			return err;
+		}
+	}
+	return err;
+}
+
+
 static int test_av1_packetize(void)
 {
 	uint8_t buf[320];
 	int err;
 
-	err = test_av1_packetize_base(2, 1, 1, 1200, pkt_aom, sizeof(pkt_aom));
+	err = test_av1_packetize_range(2, 1,
+		pkt_aom, sizeof(pkt_aom),
+		pkt_aom, sizeof(pkt_aom));
 	if (err)
 		return err;
 
-	err = test_av1_packetize_base(5, 4, 0, 10, pkt_aom5, sizeof(pkt_aom5));
+	err = test_av1_packetize_range(5, 4,
+		pkt_aom5, sizeof(pkt_aom5),
+		pkt_aom5, sizeof(pkt_aom5));
+	if (err)
+		return err;
+
+	err = test_av1_packetize_range(6, 5,
+		pkt_aom_metadata, sizeof(pkt_aom_metadata),
+		pkt_aom_metadata, sizeof(pkt_aom_metadata));
+	if (err)
+		return err;
+
+	err = test_av1_packetize_range(7, 3,
+		pkt_multi_seq, sizeof(pkt_multi_seq),
+		pkt_multi_seq_expected, sizeof(pkt_multi_seq_expected));
 	if (err)
 		return err;
 
@@ -486,7 +572,9 @@ static int test_av1_packetize(void)
 	if (err)
 		return err;
 
-	err = test_av1_packetize_base(3, 2, 2, 100, buf, sizeof(buf));
+	err = test_av1_packetize_range(3, 2,
+		buf, sizeof(buf),
+		buf, sizeof(buf));
 	if (err)
 		return err;
 
@@ -772,7 +860,7 @@ static int test_av1_interop(void)
 	err = str_hex(state.buf_packet2, sizeof(state.buf_packet2), packet2);
 	TEST_ERR(err);
 
-	err = av1_packetize_high(&new_flag, true, dummy_ts,
+	err = av1_packetize_new(&new_flag, true, dummy_ts,
 				 buf, sizeof(buf), 1188,
 				 interop_packet_handler, &state);
 	if (err)


### PR DESCRIPTION
The AV1 packetizer did not properly packetize all AV1 bitstreams. It incorrectly calculated the "w" field from the AV1 RTP spec once and applied it to all RTP packets. This field needs to be determined on a per-packet basis. In practice, this meant the packetizer generated invalid RTP packets if w = 0 for the first packet (i.e. 4 or more OBUs).

Rewrite the packetizer to accurately determine how many OBU fragments are present in each RTP packet. The general idea is:
1. Start with the first OBU in the user buffer
2. Fill the RTP packet with data from the current OBU
3. If there is space left over in the packet, move to the next OBU and repeat #2
4. Once the RTP packet is full, report it to the handler and clear it and repeat #2

Update the tests to get wider coverage of this new algorithm. Add another stream with more OBUs and test each stream with varying packet sizes. Also, fix the frame re-assembly code in the test to conform to the spec.

Name this new algorithm av1_packetize_new and keep the old av1_packetize_high around for now. Library users can switch to the new implementation for testing until it replaces av1_packetize_high.

AV1 RTP spec: https://aomediacodec.github.io/av1-rtp-spec/