### PR TITLE
sipsess: add cancel reason to cancel handler

### DIFF
--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -275,7 +275,7 @@ typedef int(sip_send_h)(enum sip_transp tp, struct sa *src,
 typedef int(sip_conn_h)(struct sa *src, const struct sa *dst, struct mbuf *mb,
 			void *arg);
 typedef void(sip_resp_h)(int err, const struct sip_msg *msg, void *arg);
-typedef void(sip_cancel_h)(void *arg, const struct sip_msg *msg);
+typedef void(sip_cancel_h)(const struct sip_msg *msg, void *arg);
 typedef void(sip_exit_h)(void *arg);
 typedef int(sip_auth_h)(char **username, char **password, const char *realm,
 			void *arg);

--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -275,7 +275,7 @@ typedef int(sip_send_h)(enum sip_transp tp, struct sa *src,
 typedef int(sip_conn_h)(struct sa *src, const struct sa *dst, struct mbuf *mb,
 			void *arg);
 typedef void(sip_resp_h)(int err, const struct sip_msg *msg, void *arg);
-typedef void(sip_cancel_h)(void *arg);
+typedef void(sip_cancel_h)(void *arg, const struct sip_msg *msg);
 typedef void(sip_exit_h)(void *arg);
 typedef int(sip_auth_h)(char **username, char **password, const char *realm,
 			void *arg);

--- a/include/re_sipsess.h
+++ b/include/re_sipsess.h
@@ -30,6 +30,7 @@ typedef void (sipsess_info_h)(struct sip *sip, const struct sip_msg *msg,
 typedef void (sipsess_refer_h)(struct sip *sip, const struct sip_msg *msg,
 			       void *arg);
 typedef void (sipsess_close_h)(int err, const struct sip_msg *msg, void *arg);
+typedef void (sipsess_cancel_h)(const struct sip_msg *msg, void *arg);
 
 typedef void (sipsess_redirect_h)(const struct sip_msg *msg,
 				  const char *uri, void *arg);
@@ -49,7 +50,7 @@ int  sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock,
 		     sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		     sipsess_progr_h *progrh, sipsess_estab_h *estabh,
 		     sipsess_info_h *infoh, sipsess_refer_h *referh,
-		     sipsess_close_h *closeh, void *arg, const char *fmt, ...);
+		     sipsess_close_h *closeh, sipsess_cancel_h *cancelh, void *arg, const char *fmt, ...);
 
 int  sipsess_accept(struct sipsess **sessp, struct sipsess_sock *sock,
 		    const struct sip_msg *msg, uint16_t scode,
@@ -59,7 +60,7 @@ int  sipsess_accept(struct sipsess **sessp, struct sipsess_sock *sock,
 		    bool aref, sipsess_offer_h *offerh,
 		    sipsess_answer_h *answerh, sipsess_estab_h *estabh,
 		    sipsess_info_h *infoh, sipsess_refer_h *referh,
-		    sipsess_close_h *closeh, void *arg,
+		    sipsess_close_h *closeh, sipsess_cancel_h *cancelh, void *arg,
 		    const char *fmt, ...);
 
 int  sipsess_set_redirect_handler(struct sipsess *sess,

--- a/include/re_sipsess.h
+++ b/include/re_sipsess.h
@@ -50,7 +50,8 @@ int  sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock,
 		     sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		     sipsess_progr_h *progrh, sipsess_estab_h *estabh,
 		     sipsess_info_h *infoh, sipsess_refer_h *referh,
-		     sipsess_close_h *closeh, sipsess_cancel_h *cancelh, void *arg, const char *fmt, ...);
+		     sipsess_close_h *closeh, sipsess_cancel_h *cancelh,
+			 void *arg, const char *fmt, ...);
 
 int  sipsess_accept(struct sipsess **sessp, struct sipsess_sock *sock,
 		    const struct sip_msg *msg, uint16_t scode,
@@ -60,8 +61,8 @@ int  sipsess_accept(struct sipsess **sessp, struct sipsess_sock *sock,
 		    bool aref, sipsess_offer_h *offerh,
 		    sipsess_answer_h *answerh, sipsess_estab_h *estabh,
 		    sipsess_info_h *infoh, sipsess_refer_h *referh,
-		    sipsess_close_h *closeh, sipsess_cancel_h *cancelh, void *arg,
-		    const char *fmt, ...);
+		    sipsess_close_h *closeh, sipsess_cancel_h *cancelh,
+			void *arg, const char *fmt, ...);
 
 int  sipsess_set_redirect_handler(struct sipsess *sess,
 				  sipsess_redirect_h *redirecth);

--- a/src/sip/strans.c
+++ b/src/sip/strans.c
@@ -139,7 +139,7 @@ static bool cmp_merge_handler(struct le *le, void *arg)
 }
 
 
-static void dummy_handler(void *arg, const struct sip_msg *msg)
+static void dummy_handler(const struct sip_msg *msg, void *arg)
 {
 	(void)arg;
 	(void)msg;

--- a/src/sip/strans.c
+++ b/src/sip/strans.c
@@ -139,9 +139,10 @@ static bool cmp_merge_handler(struct le *le, void *arg)
 }
 
 
-static void dummy_handler(void *arg)
+static void dummy_handler(void *arg, const struct sip_msg *msg)
 {
 	(void)arg;
+	(void)msg;
 }
 
 

--- a/src/sip/strans.c
+++ b/src/sip/strans.c
@@ -219,7 +219,7 @@ static bool cancel_handler(struct sip *sip, const struct sip_msg *msg)
 
 	case TRYING:
 	case PROCEEDING:
-		st->cancelh(st->arg);
+		st->cancelh(st->arg, msg);
 		break;
 
 	default:

--- a/src/sip/strans.c
+++ b/src/sip/strans.c
@@ -220,7 +220,7 @@ static bool cancel_handler(struct sip *sip, const struct sip_msg *msg)
 
 	case TRYING:
 	case PROCEEDING:
-		st->cancelh(st->arg, msg);
+		st->cancelh(msg, st->arg);
 		break;
 
 	default:

--- a/src/sipsess/accept.c
+++ b/src/sipsess/accept.c
@@ -18,7 +18,7 @@
 #include "sipsess.h"
 
 
-static void cancel_handler(void *arg, const struct sip_msg *msg)
+static void cancel_handler(const struct sip_msg *msg, void *arg)
 {
 	struct sipsess *sess = arg;
 	sipsess_cancel_h *cancelh;

--- a/src/sipsess/accept.c
+++ b/src/sipsess/accept.c
@@ -31,10 +31,9 @@ static void cancel_handler(void *arg, const struct sip_msg *msg)
 	if (sess->terminated)
 		return;
 	cancelh = sess->cancelh;
-	arg = sess->arg;
 
 	if (cancelh)
-		cancelh(msg, arg);
+		cancelh(msg, sess->arg);
 
 	sipsess_terminate(sess, ECONNRESET, NULL);
 }

--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -319,7 +319,7 @@ int sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock,
 		    sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		    sipsess_progr_h *progrh, sipsess_estab_h *estabh,
 		    sipsess_info_h *infoh, sipsess_refer_h *referh,
-		    sipsess_close_h *closeh, void *arg, const char *fmt, ...)
+		    sipsess_close_h *closeh, sipsess_cancel_h *cancelh, void *arg, const char *fmt, ...)
 {
 	struct sipsess *sess;
 	struct pl hdrs;
@@ -331,7 +331,7 @@ int sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock,
 	err = sipsess_alloc(&sess, sock, cuser, ctype, NULL, authh, aarg, aref,
 			    desch,
 			    offerh, answerh, progrh, estabh, infoh, referh,
-			    closeh, arg);
+			    closeh, cancelh, arg);
 	if (err)
 		return err;
 

--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -319,7 +319,8 @@ int sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock,
 		    sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		    sipsess_progr_h *progrh, sipsess_estab_h *estabh,
 		    sipsess_info_h *infoh, sipsess_refer_h *referh,
-		    sipsess_close_h *closeh, sipsess_cancel_h *cancelh, void *arg, const char *fmt, ...)
+		    sipsess_close_h *closeh, sipsess_cancel_h *cancelh,
+			void *arg, const char *fmt, ...)
 {
 	struct sipsess *sess;
 	struct pl hdrs;

--- a/src/sipsess/sess.c
+++ b/src/sipsess/sess.c
@@ -167,7 +167,7 @@ int sipsess_alloc(struct sipsess **sessp, struct sipsess_sock *sock,
 		  sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		  sipsess_progr_h *progrh, sipsess_estab_h *estabh,
 		  sipsess_info_h *infoh, sipsess_refer_h *referh,
-		  sipsess_close_h *closeh, void *arg)
+		  sipsess_close_h *closeh, sipsess_cancel_h *cancelh, void *arg)
 {
 	struct sipsess *sess;
 	int err;
@@ -199,6 +199,7 @@ int sipsess_alloc(struct sipsess **sessp, struct sipsess_sock *sock,
 	sess->infoh   = infoh;
 	sess->referh  = referh;
 	sess->closeh  = closeh  ? closeh  : internal_close_handler;
+	sess->cancelh = cancelh;
 	sess->arg     = arg;
 
  out:

--- a/src/sipsess/sess.c
+++ b/src/sipsess/sess.c
@@ -167,7 +167,8 @@ int sipsess_alloc(struct sipsess **sessp, struct sipsess_sock *sock,
 		  sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		  sipsess_progr_h *progrh, sipsess_estab_h *estabh,
 		  sipsess_info_h *infoh, sipsess_refer_h *referh,
-		  sipsess_close_h *closeh, sipsess_cancel_h *cancelh, void *arg)
+		  sipsess_close_h *closeh, sipsess_cancel_h *cancelh,
+		  void *arg)
 {
 	struct sipsess *sess;
 	int err;

--- a/src/sipsess/sipsess.h
+++ b/src/sipsess/sipsess.h
@@ -31,6 +31,7 @@ struct sipsess {
 	sipsess_info_h *infoh;
 	sipsess_refer_h *referh;
 	sipsess_close_h *closeh;
+	sipsess_cancel_h *cancelh;
 	sipsess_redirect_h *redirecth;
 	sipsess_prack_h *prackh;
 	void *arg;
@@ -77,7 +78,7 @@ int  sipsess_alloc(struct sipsess **sessp, struct sipsess_sock *sock,
 		   sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		   sipsess_progr_h *progrh, sipsess_estab_h *estabh,
 		   sipsess_info_h *infoh, sipsess_refer_h *referh,
-		   sipsess_close_h *closeh, void *arg);
+		   sipsess_close_h *closeh, sipsess_cancel_h *cancelh, void *arg);
 void sipsess_terminate(struct sipsess *sess, int err,
 		       const struct sip_msg *msg);
 int  sipsess_ack(struct sipsess_sock *sock, struct sip_dialog *dlg,

--- a/src/sipsess/sipsess.h
+++ b/src/sipsess/sipsess.h
@@ -78,7 +78,8 @@ int  sipsess_alloc(struct sipsess **sessp, struct sipsess_sock *sock,
 		   sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		   sipsess_progr_h *progrh, sipsess_estab_h *estabh,
 		   sipsess_info_h *infoh, sipsess_refer_h *referh,
-		   sipsess_close_h *closeh, sipsess_cancel_h *cancelh, void *arg);
+		   sipsess_close_h *closeh, sipsess_cancel_h *cancelh,
+		   void *arg);
 void sipsess_terminate(struct sipsess *sess, int err,
 		       const struct sip_msg *msg);
 int  sipsess_ack(struct sipsess_sock *sock, struct sip_dialog *dlg,

--- a/test/sipsess.c
+++ b/test/sipsess.c
@@ -462,7 +462,7 @@ static void conn_handler(const struct sip_msg *msg, void *arg)
 				"application/sdp", desc, NULL, NULL, false,
 				offer_handler_b, answer_handler_b,
 				estab_handler_b, NULL, NULL, close_handler,
-				test, hdrs);
+				NULL, test, hdrs);
 		if (err != test->progr_ret_code) {
 			test->progr_ret_code = err;
 			goto out;
@@ -502,7 +502,7 @@ static void conn_handler(const struct sip_msg *msg, void *arg)
 				test->rel100_b, "b", "application/sdp",
 				desc, NULL, NULL, false, offer_handler_b,
 				answer_handler_b, estab_handler_b, NULL, NULL,
-				close_handler, test, hdrs);
+				close_handler, NULL, test, hdrs);
 		if (err != test->answ_ret_code) {
 			test->answ_ret_code = err;
 			goto out;
@@ -514,7 +514,7 @@ static void conn_handler(const struct sip_msg *msg, void *arg)
 				"application/sdp", NULL, NULL, NULL, false,
 				offer_handler_b, answer_handler_b,
 				estab_handler_b, NULL, NULL, close_handler,
-				test, hdrs);
+				NULL, test, hdrs);
 		if (err != test->answ_ret_code) {
 			test->answ_ret_code = err;
 			goto out;
@@ -605,7 +605,7 @@ int test_sipsess(void)
 			      callid, desc_handler_a,
 			      offer_handler_a, answer_handler_a, NULL,
 			      estab_handler_a, NULL, NULL,
-			      close_handler, &test, NULL);
+			      close_handler, NULL, &test, NULL);
 	mem_deref(callid);
 	TEST_ERR(err);
 
@@ -705,7 +705,7 @@ int test_sipsess_reject(void)
 			      callid, desc_handler,
 			      offer_handler_a, answer_handler_a, NULL,
 			      estab_handler_a, NULL, NULL,
-			      close_handler, &test, NULL);
+			      close_handler, NULL, &test, NULL);
 	mem_deref(callid);
 	TEST_ERR(err);
 
@@ -787,7 +787,7 @@ int test_sipsess_blind_transfer(void)
 			      callid, desc_handler_a,
 			      offer_handler_a, answer_handler_a, NULL,
 			      estab_handler_a, NULL, NULL,
-			      close_handler, &test, NULL);
+			      close_handler, NULL, &test, NULL);
 	mem_deref(callid);
 	TEST_ERR(err);
 
@@ -868,7 +868,7 @@ int test_sipsess_100rel_caller_require(void)
 			      callid, desc_handler_a,
 			      offer_handler_a, answer_handler_a,
 			      progr_handler_a, estab_handler_a, NULL,
-			      NULL, close_handler, &test,
+			      NULL, close_handler, NULL, &test,
 			      "Require: 100rel\r\n");
 	mem_deref(callid);
 	TEST_ERR(err);
@@ -953,7 +953,7 @@ int test_sipsess_100rel_supported(void)
 			      callid, desc_handler_a,
 			      offer_handler_a, answer_handler_a,
 			      progr_handler_a, estab_handler_a, NULL,
-			      NULL, close_handler, &test,
+			      NULL, close_handler, NULL, &test,
 			      "Supported: 100rel\r\n");
 	mem_deref(callid);
 	TEST_ERR(err);
@@ -1040,7 +1040,7 @@ int test_sipsess_100rel_answer_not_allowed(void)
 			      callid, desc_handler_a,
 			      offer_handler_a, answer_handler_a,
 			      progr_handler_a, estab_handler_a, NULL,
-			      NULL, close_handler, &test,
+			      NULL, close_handler, NULL, &test,
 			      "Supported: 100rel\r\n");
 	mem_deref(callid);
 	TEST_ERR(err);
@@ -1118,7 +1118,7 @@ int test_sipsess_100rel_420(void)
 			      callid, desc_handler,
 			      offer_handler_a, answer_handler_a, NULL,
 			      estab_handler_a, NULL, NULL,
-			      close_handler, &test,
+			      close_handler, NULL, &test,
 			      "Require: 100rel\r\n");
 	mem_deref(callid);
 	TEST_ERR(err);
@@ -1192,7 +1192,7 @@ int test_sipsess_100rel_421(void)
 			      callid, desc_handler,
 			      offer_handler_a, answer_handler_a, NULL,
 			      estab_handler_a, NULL, NULL,
-			      close_handler, &test, NULL);
+			      close_handler, NULL, &test, NULL);
 	mem_deref(callid);
 	TEST_ERR(err);
 
@@ -1266,7 +1266,7 @@ int test_sipsess_update_uac(void)
 			      callid, desc_handler_a,
 			      offer_handler_a, answer_handler_a,
 			      progr_handler_a, estab_handler_a, NULL,
-			      NULL, close_handler, &test,
+			      NULL, close_handler, NULL, &test,
 			      "Supported: 100rel\r\n");
 	mem_deref(callid);
 	TEST_ERR(err);
@@ -1353,7 +1353,7 @@ int test_sipsess_update_uas(void)
 			      callid, desc_handler_a,
 			      offer_handler_a, answer_handler_a,
 			      progr_handler_a, estab_handler_a, NULL,
-			      NULL, close_handler, &test,
+			      NULL, close_handler, NULL, &test,
 			      "Supported: 100rel\r\n");
 	mem_deref(callid);
 	TEST_ERR(err);
@@ -1439,7 +1439,7 @@ int test_sipsess_update_no_sdp(void)
 			      callid, desc_handler_a,
 			      offer_handler_a, answer_handler_a,
 			      progr_handler_a, estab_handler_a, NULL,
-			      NULL, close_handler, &test, NULL);
+			      NULL, close_handler, NULL, &test, NULL);
 	mem_deref(callid);
 	TEST_ERR(err);
 


### PR DESCRIPTION
I want to display the provided reason in Cancel messages to the user of baresip, but as far as I could tell the Cancel messages are not communicated outside of libre. So I added a cancel handler, very similar to all the other handlers.

This is a breaking API change though, so I am not sure if this is the best way to go about this.

Related to this feature request: https://github.com/baresip/baresip/issues/3363