### PR TITLE
ci: remove step to install ninja on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,11 +46,6 @@ jobs:
       run: |
         sudo apt-get update && sudo apt-get install -y ninja-build
 
-    - name: install packages
-      if: ${{ runner.os == 'macOS' }}
-      run: |
-        brew install ninja
-
     - name: make info
       run: |
         echo "OS: ${{ matrix.os }}"


### PR DESCRIPTION
Annotations
2 warnings:

ninja 1.12.1 is already installed and up-to-date. To reinstall 1.12.1, run: brew reinstall ninja