### PR TITLE
tls: fix compiler warning with libressl 4.1.0

### DIFF
--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -495,7 +495,7 @@ int tls_set_verify_purpose(struct tls *tls, const char *purpose)
 {
 	int err;
 	int i;
-	X509_PURPOSE *xptmp;
+	const X509_PURPOSE *xptmp;
 
 	if (!tls || !purpose)
 		return EINVAL;


### PR DESCRIPTION
src/tls/openssl/tls.c:509:8: warning: assigning to 'X509_PURPOSE *' (aka 'struct x509_purpose_st *') from 'const X509_PURPOSE *' (aka 'const struct x509_purpose_st *') discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
        xptmp = X509_PURPOSE_get0(i);
              ^ ~~~~~~~~~~~~~~~~~~~~
1 warning generated.

LibreSSL from MacPorts:

  libressl @4.1.0_0 (active)