### PR TITLE
tls: fix SSL_SESSION_is_resumable LibreSSL

### DIFF
--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -1706,10 +1706,7 @@ static int tls_session_update_cache(const struct tls_conn *tc,
 					     session_cmp_handler, &peer));
 	mem_deref(e);
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10101000L) && \
-	(!defined(LIBRESSL_VERSION_NUMBER) || \
-	  defined(LIBRESSL_HAS_TLS1_3) || \
-	  defined(LIBRESSL_INTERNAL) )
+#if !defined(LIBRESSL_VERSION_NUMBER)
 	if (!SSL_SESSION_is_resumable(sess)) {
 		return EINVAL;
 	}


### PR DESCRIPTION
SSL_SESSION_is_resumable() returns 1 if the session is resumable or 0 otherwise.

It always returns 0 with LibreSSL.