### PR TITLE
sip: exposed ltag and rtag in sip dialog

### DIFF
--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -403,6 +403,8 @@ int  sip_dialog_set_callid(struct sip_dialog *dlg, const char *callid);
 void sip_dialog_set_srcport(struct sip_dialog *dlg, uint16_t srcport);
 uint16_t sip_dialog_srcport(struct sip_dialog *dlg);
 const char *sip_dialog_uri(const struct sip_dialog *dlg);
+const char *sip_dialog_ltag(const struct sip_dialog *dlg);
+const char *sip_dialog_rtag(const struct sip_dialog *dlg);
 uint32_t sip_dialog_lseq(const struct sip_dialog *dlg);
 uint32_t sip_dialog_lseqinv(const struct sip_dialog *dlg);
 enum sip_transp sip_dialog_tp(const struct sip_dialog *dlg);

--- a/src/sip/dialog.c
+++ b/src/sip/dialog.c
@@ -590,6 +590,18 @@ const char *sip_dialog_uri(const struct sip_dialog *dlg)
 }
 
 
+const char *sip_dialog_ltag(const struct sip_dialog *dlg)
+{
+	return dlg ? dlg->ltag : NULL;
+}
+
+
+const char *sip_dialog_rtag(const struct sip_dialog *dlg)
+{
+	return dlg ? dlg->rtag : NULL;
+}
+
+
 const struct uri *sip_dialog_route(const struct sip_dialog *dlg)
 {
 	return dlg ? &dlg->route : NULL;


### PR DESCRIPTION
Hello this relates to baresip issue [#3367](https://github.com/baresip/baresip/issues/3367).

Exposing ltag and rtag is the approach I took to retrieve tags in baresip's call_replace_transfer. I plan to go ahead with the PR for baresip once this is done. Is that ok? 

This is my first experience with contributing to an open source project. Please let me know should anything else be needed. 