### PR TITLE
h265: add H265_NAL_RSV_IRAP_VCL{22,23}

### DIFF
--- a/include/re_h265.h
+++ b/include/re_h265.h
@@ -32,6 +32,8 @@ enum h265_naltype {
 	H265_NAL_IDR_W_RADL      = 19,
 	H265_NAL_IDR_N_LP        = 20,
 	H265_NAL_CRA_NUT         = 21,
+	H265_NAL_RSV_IRAP_VCL22  = 22,
+	H265_NAL_RSV_IRAP_VCL23  = 23,
 
 	/* non-VCL class */
 	H265_NAL_VPS_NUT         = 32,

--- a/src/h265/nal.c
+++ b/src/h265/nal.c
@@ -94,6 +94,8 @@ const char *h265_nalunit_name(enum h265_naltype type)
 	case H265_NAL_IDR_W_RADL:      return "IDR_W_RADL";
 	case H265_NAL_IDR_N_LP:        return "IDR_N_LP";
 	case H265_NAL_CRA_NUT:         return "CRA_NUT";
+	case H265_NAL_RSV_IRAP_VCL22:  return "H265_NAL_RSV_IRAP_VCL22";
+	case H265_NAL_RSV_IRAP_VCL23:  return "H265_NAL_RSV_IRAP_VCL23";
 
 	/* non-VCL class */
 	case H265_NAL_VPS_NUT:         return "VPS_NUT";
@@ -117,7 +119,7 @@ const char *h265_nalunit_name(enum h265_naltype type)
 
 bool h265_is_keyframe(enum h265_naltype type)
 {
-	/* between 16 and 21 (inclusive) */
+	/* between 16 and 23 (inclusive) */
 	switch (type) {
 
 	case H265_NAL_BLA_W_LP:
@@ -126,6 +128,8 @@ bool h265_is_keyframe(enum h265_naltype type)
 	case H265_NAL_IDR_W_RADL:
 	case H265_NAL_IDR_N_LP:
 	case H265_NAL_CRA_NUT:
+	case H265_NAL_RSV_IRAP_VCL22:
+	case H265_NAL_RSV_IRAP_VCL23:
 		return true;
 	default:
 		return false;

--- a/test/h265.c
+++ b/test/h265.c
@@ -32,6 +32,9 @@ int test_h265(void)
 	ASSERT_EQ(32, hdr.nal_unit_type);
 	ASSERT_EQ(TID, hdr.nuh_temporal_id_plus1);
 
+	ASSERT_TRUE(!h265_is_keyframe(H265_NAL_VPS_NUT));
+	ASSERT_TRUE( h265_is_keyframe(H265_NAL_IDR_W_RADL));
+
  out:
 	return err;
 }


### PR DESCRIPTION
- update h265_is_keyframe() to include H265_NAL_RSV_IRAP_VCL{22,23}
- IRAP = Intra Random Access Pictures

See:
https://www.ffmpeg.org/doxygen/2.2/libavcodec_2hevc_8h.html#aef033ac1a8e8b14e8bceb15e9c4f2df3