### PR TITLE
sha: use PROV_RSA_AES for CryptAcquireContext

### DIFF
--- a/src/sha/wrap.c
+++ b/src/sha/wrap.c
@@ -33,7 +33,7 @@ static void compute_hash(ALG_ID alg_id, const void *data, size_t data_size,
 	HCRYPTPROV context;
 	HCRYPTHASH hash;
 
-	CryptAcquireContext(&context, 0, 0, PROV_RSA_FULL,CRYPT_VERIFYCONTEXT);
+	CryptAcquireContext(&context, 0, 0, PROV_RSA_AES,CRYPT_VERIFYCONTEXT);
 
 	CryptCreateHash(context, alg_id, 0, 0, &hash);
 	CryptHashData(hash, (BYTE*)data, (DWORD)data_size, 0);


### PR DESCRIPTION
On windows, PROV_RSA_AES is needed to get
support for SHA-1 and SHA-2:

https://learn.microsoft.com/en-us/windows/win32/seccrypto/prov-rsa-aes