### PR TITLE
test/httpauth: fix debug warning for digest response

### DIFF
--- a/test/httpauth.c
+++ b/test/httpauth.c
@@ -635,9 +635,9 @@ int test_httpauth_digest_response(void)
 			testv[i].precalc_digest) != 0) {
 			err = EINVAL;
 			DEBUG_WARNING("[%d]"
-				" Expected response %s, got %w\n", i,
+				" Expected response %s, got %s\n", i,
 				testv[i].precalc_digest,
-				resp->response, resp->hash_length);
+				resp->response ? resp->response : "(nil)");
 			goto out;
 		}
 


### PR DESCRIPTION
fixes: https://github.com/baresip/re/issues/1330

Checked that `resp->response` is a null-terminated string because in `src/httpauth/digest.c:927` `re_snprintf()` is used.