### PR TITLE
test/sys: Use writeable datapath for fs_open test

### DIFF
--- a/test/sys.c
+++ b/test/sys.c
@@ -179,7 +179,7 @@ int test_sys_fs_fopen(void)
 	 * multiple instances of test
 	 */
 	re_snprintf(filename, sizeof(filename),
-		    "retest_fs_fopen-%llu", rand_u64());
+		"%s/retest_fs_fopen-%llu", test_datapath(), rand_u64());
 
 	err = fs_fopen(&file, filename, "w+");
 	TEST_ERR(err);


### PR DESCRIPTION
On some platforms (e.g. Android), it is not possible to write to most places in the file system when running tests.

Change the sys fs test to use the configurable test data path so that it is possible to specify a custom writable directory.

Extracted from #1329