### PR TITLE
test/async: Remove unsupported AI_V4MAPPED on Android

### DIFF
--- a/test/async.c
+++ b/test/async.c
@@ -41,7 +41,9 @@ static int blocking_getaddr(void *arg)
 
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_family = AF_INET;
+#ifndef __ANDROID__
 	hints.ai_flags	= AI_V4MAPPED;
+#endif
 
 
 	/* Blocking */


### PR DESCRIPTION
This test fails on Android where `getaddrinfo` does not accept AI_V4MAPPED: https://stackoverflow.com/questions/39674147/getaddrinfo-on-android-returning-error-eai-badflags

Since this test isn't really related to socket functionality, disable use of `AI_V4MAPPED` when running on Android. Note a similar issue with this test was previously dealt with in #1164.

Extracted from #1329.