### PR TITLE
ci: Enable testing on Android

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,6 +10,9 @@ on:
 
 env:
   openssl: 3.2.1
+  toolchain: toolchains/llvm/prebuilt/linux-x86_64
+  api: 21
+  abi: x86_64
 
 jobs:
   android:
@@ -18,11 +21,17 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Enable KVM
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+
     - uses: actions/cache@v4
       id: openssl
       with:
         path: openssl
-        key: ${{ runner.os }}-android-openssl-${{ env.openssl }}
+        key: ${{ runner.os }}-android-${{ env.abi }}-openssl-${{ env.openssl }}
 
     - name: "build openssl"
       if: steps.openssl.outputs.cache-hit != 'true'
@@ -30,9 +39,49 @@ jobs:
         wget -q https://www.openssl.org/source/openssl-$openssl.tar.gz
         tar -xzf openssl-$openssl.tar.gz
         mv openssl-$openssl openssl
-        cd openssl && ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME PATH=$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH ./Configure android-arm64 no-shared no-tests -U__ANDROID_API__ -D__ANDROID_API__=21 && PATH=$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH make build_libs && cd ..
+        cd openssl && ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME PATH=$ANDROID_NDK_LATEST_HOME/$toolchain/bin:$PATH ./Configure android-$abi no-shared no-tests -U__ANDROID_API__ -D__ANDROID_API__=$api && PATH=$ANDROID_NDK_LATEST_HOME/$toolchain/bin:$PATH make build_libs && cd ..
 
     - name: build
+      # unixsock is not currently supported on Android as only abstract (not pathname) addresses are allowed
       run: |
-        cmake -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_LATEST_HOME/build/cmake/android.toolchain.cmake -DANDROID_ABI="arm64-v8a" -DANDROID_PLATFORM=android-21 -DOPENSSL_ROOT_DIR=openssl -DOPENSSL_INCLUDE_DIR=openssl/include -DOPENSSL_CRYPTO_LIBRARY=openssl/libcrypto.a -DOPENSSL_SSL_LIBRARY=openssl/libssl.a .
+        cmake -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_LATEST_HOME/build/cmake/android.toolchain.cmake -DANDROID_ABI="$abi" -DANDROID_PLATFORM=android-$api -DOPENSSL_ROOT_DIR=openssl -DOPENSSL_INCLUDE_DIR=openssl/include -DOPENSSL_CRYPTO_LIBRARY=openssl/libcrypto.a -DOPENSSL_SSL_LIBRARY=openssl/libssl.a -DUSE_UNIXSOCK=OFF .
         cmake --build . -j 4 -t retest
+
+    - name: AVD cache
+      uses: actions/cache@v4
+      id: avd-cache
+      with:
+        path: |
+          ~/.android/avd/*
+          ~/.android/adb*
+        key: avd-${{ env.abi }}-${{ env.api }}
+
+    - name: create AVD and generate snapshot for caching
+      if: steps.avd-cache.outputs.cache-hit != 'true'
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: ${{ env.api }}
+        arch: ${{ env.abi }}
+        target: google_apis
+        force-avd-creation: false
+        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
+        disable-animations: false
+        script: echo "Generated AVD snapshot for caching."
+
+    - name: run
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: ${{ env.api }}
+        arch: ${{ env.abi }}
+        target: google_apis
+        force-avd-creation: false
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
+        disable-animations: true
+        # Use test data directory as a writeable directory for I/O tests as the emulator file system is not generally writeable
+        script: |
+          adb push test/retest /data/local/tmp/retest
+          adb shell chmod 775 /data/local/tmp/retest
+          adb push test/data /data/local/tmp/retest-data
+          adb shell chmod 775 /data/local/tmp/retest-data
+          adb push $ANDROID_NDK_LATEST_HOME/$toolchain/sysroot/usr/lib/$abi-linux-android/libc++_shared.so /data/local/tmp/libc++_shared.so
+          adb shell HOME=/data/local/tmp LD_LIBRARY_PATH=/data/local/tmp /data/local/tmp/retest -r -v -d /data/local/tmp/retest-data


### PR DESCRIPTION
Enable running CI tests on Android using an emulator.

I was unable to get the ARM emulator running so this changes the CI to build for Android x86_64. There is still general ARM ABI coverage on other platforms.

Unix socket tests are currently skipped as Android does not support pathname socket addresses, which is the only variant `re` currently supports. If abstract socket address support is added, then tests for those can be enabled on Android.

Extracted from #1329.