### PR TITLE
net: Support ifaddrs on Android API level >= 24

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,7 +563,7 @@ elseif(UNIX)
     src/mod/dl.c
     src/net/posix/pif.c
   )
-  if(NOT ANDROID)
+  if(HAVE_GETIFADDRS)
     list(APPEND SRCS
       src/net/ifaddrs.c
     )

--- a/cmake/re-config.cmake
+++ b/cmake/re-config.cmake
@@ -121,6 +121,20 @@ list(APPEND RE_DEFINITIONS
   )
 
 if(UNIX)
+  if(ANDROID)
+    string(REPLACE "android-" "" ANDROID_API_LEVEL ${ANDROID_PLATFORM})
+    if(ANDROID_API_LEVEL GREATER_EQUAL 24)
+      set(HAVE_GETIFADDRS ON CACHE BOOL "" FORCE)
+    endif()
+  else()
+    check_include_file(ifaddrs.h HAVE_GETIFADDRS)
+  endif()
+  if(HAVE_GETIFADDRS)
+    list(APPEND RE_DEFINITIONS HAVE_GETIFADDRS)
+  endif()
+endif()
+
+if(UNIX)
   list(APPEND RE_DEFINITIONS
     HAVE_PWD_H
     HAVE_SETRLIMIT
@@ -132,9 +146,6 @@ if(UNIX)
     HAVE_SIGNAL
     HAVE_FORK
     )
-  if(NOT ANDROID)
-    list(APPEND RE_DEFINITIONS HAVE_GETIFADDRS)
-  endif()
   if(NOT IOS)
     list(APPEND RE_DEFINITIONS HAVE_ROUTE_LIST)
   endif()


### PR DESCRIPTION
Baresip's default out-of-the-box networking currently doesn't work well on Android when IPv6-only due to inability to enumerate IPv6-only network interfaces. This appears to be because `ifaddrs` support is currently disabled. There are APIs to manually add interfaces to Baresip but this requires more advanced integration with the Java API in Android.

Android added `ifaddrs` support in API level 24 (Android 7) which was ages ago:
https://android.googlesource.com/platform/bionic/+/master/libc/include/ifaddrs.h#81

This PR allows `ifaddrs` to be used on Android API >= 24 so that the built-in Baresip networking works with IPv6-only networks.

I have enabled it and tested that with this change, Baresip can successfully use `getifaddrs` on a non-rooted Android 13 phone to enumerate IPv6-only interfaces without any integration with Java APIs.

Extracted from #1329 (many discussions in that PR, most of which is unrelated to this change).