### PR TITLE
trice: update header to match filename

### DIFF
--- a/src/trice/trice.c
+++ b/src/trice/trice.c
@@ -1,5 +1,5 @@
 /**
- * @file icem.c  ICE Media stream
+ * @file trice.c  ICE Media stream
  *
  * Copyright (C) 2010 Alfred E. Heggestad
  */

--- a/src/trice/trice.h
+++ b/src/trice/trice.h
@@ -1,5 +1,5 @@
 /**
- * @file ice.h  Internal Interface to ICE
+ * @file trice.h  Internal Interface to ICE
  *
  * Copyright (C) 2010 Alfred E. Heggestad
  */


### PR DESCRIPTION
For some reason Doxygen does not give any warnings about this