### PR TITLE
test/sipsess: cast rel100_mode

### DIFF
--- a/test/sipsess.c
+++ b/test/sipsess.c
@@ -327,10 +327,10 @@ static int answer_handler_a(const struct sip_msg *msg, void *arg)
 		test->sdp_state = ANSWER_RECEIVED;
 
 	if (sip_msg_hdr_has_value(msg, SIP_HDR_SUPPORTED, "100rel"))
-		test->rel100_a |= REL100_SUPPORTED;
+		test->rel100_a |= (enum rel100_mode)REL100_SUPPORTED;
 
 	if (sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE, "100rel"))
-		test->rel100_a |= REL100_REQUIRE;
+		test->rel100_a |= (enum rel100_mode)REL100_REQUIRE;
 
 	if (!pl_strcmp(&msg->cseq.met, "UPDATE")) {
 		if (msg->scode < 200 || msg->scode > 299) {


### PR DESCRIPTION
Fixes:

```
D:\a\re\re\test\sipsess.c(330): error C2220: the following warning is treated as an error
D:\a\re\re\test\sipsess.c(330): warning C5286: implicit conversion from enum type 'rel100_state' to enum type 'rel100_mode'; use an explicit cast to silence this warning
D:\a\re\re\test\sipsess.c(330): note: to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings
D:\a\re\re\test\sipsess.c(333): warning C5286: implicit conversion from enum type 'rel100_state' to enum type 'rel100_mode'; use an explicit cast to silence this warning
D:\a\re\re\test\sipsess.c(333): note: to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings
```