### PR TITLE
tls: drop OpenSSL 1.1.1 support

### DIFF
--- a/.github/workflows/run-on-arch.yml
+++ b/.github/workflows/run-on-arch.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
           - arch: aarch64
-            distro: bullseye
+            distro: bookworm
           - arch: armv7
             distro: ubuntu22.04
 
@@ -35,7 +35,7 @@ jobs:
 
           install: |
             case "${{ matrix.distro }}" in
-              ubuntu*|jessie|stretch|buster|bullseye)
+              ubuntu*|jessie|stretch|buster|bullseye|bookworm)
                 apt-get update -q -y
                 apt-get install -q -y cmake gcc g++ libssl-dev ninja-build
                 ;;

--- a/README.md
+++ b/README.md
@@ -267,7 +267,6 @@ legend:
 
 ### Supported versions of OpenSSL
 
-* OpenSSL version 1.1.1
 * OpenSSL version 3.x.x
 * LibreSSL version 3.x
 

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -1729,7 +1729,6 @@ static int tls_session_update_cache(const struct tls_conn *tc,
 }
 
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
 static int session_new_cb(struct ssl_st *ssl, SSL_SESSION *sess)
 {
 	BIO *wbio = NULL;
@@ -1787,7 +1786,6 @@ static void session_remove_cb(SSL_CTX *ctx, SSL_SESSION *sess)
 	/* iterate over all hash table entries and search for session */
 	(void) hash_apply(tls->reuse.ht_sessions, remove_handler, sess);
 }
-#endif
 
 
 /**
@@ -1813,14 +1811,10 @@ int tls_set_session_reuse(struct tls *tls, int enabled)
 	if (!tls->reuse.enabled)
 		return 0;
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
 	SSL_CTX_sess_set_new_cb(tls->ctx, session_new_cb);
 	SSL_CTX_sess_set_remove_cb(tls->ctx, session_remove_cb);
 
 	return 0;
-#else
-	return EOPNOTSUPP;
-#endif
 }
 
 


### PR DESCRIPTION
Since we release a major version, it's maybe a good time to drop OpenSSL 1.1.1 support.