### PR TITLE
ci: enable Windows testing when OpenSSL is disabled

### DIFF
--- a/.github/workflows/cmake_win.yml
+++ b/.github/workflows/cmake_win.yml
@@ -45,7 +45,7 @@ jobs:
             openssl: false,
             disable_openssl: "ON",
             choco: "--x86",
-            testing: false
+            testing: true
           }
         - {
             name: "Windows Debug ARM64",


### PR DESCRIPTION
Run retest also when compiled without OpenSSL support