### PR TITLE
test: add debug to check failure on macos

### DIFF
--- a/src/srtp/srtp.c
+++ b/src/srtp/srtp.c
@@ -210,7 +210,7 @@ int srtp_encrypt(struct srtp *srtp, struct mbuf *mb)
 
 	ix = 65536ULL * strm->roc + hdr.seq;
 
-	fprintf(stderr, ".... srtp_encrypt: ix=%llu\n", ix);
+	re_fprintf(stderr, ".... srtp_encrypt: ix=%llu\n", ix);
 
 	if (comp->aes && comp->mode == AES_MODE_CTR) {
 		union vect128 iv;
@@ -322,7 +322,7 @@ int srtp_decrypt(struct srtp *srtp, struct mbuf *mb)
 
 	ix = srtp_get_index(strm->roc, strm->s_l, hdr.seq);
 
-	fprintf(stderr, ".... srtp_decrypt: ix=%llu\n", ix);
+	re_fprintf(stderr, ".... srtp_decrypt: ix=%llu\n", ix);
 
 	if (comp->hmac) {
 		uint8_t tag_calc[SHA_DIGEST_LENGTH] = {0};

--- a/src/srtp/srtp.c
+++ b/src/srtp/srtp.c
@@ -204,6 +204,9 @@ int srtp_encrypt(struct srtp *srtp, struct mbuf *mb)
 
 	/* Roll-Over Counter (ROC) */
 	if (seq_diff(strm->s_l, hdr.seq) <= -32768) {
+
+		fprintf(stderr, ".... srtp_encrypt: ROC\n");
+
 		strm->roc++;
 		strm->s_l = 0;
 	}

--- a/src/srtp/srtp.c
+++ b/src/srtp/srtp.c
@@ -210,7 +210,8 @@ int srtp_encrypt(struct srtp *srtp, struct mbuf *mb)
 
 	ix = 65536ULL * strm->roc + hdr.seq;
 
-	re_fprintf(stderr, ".... srtp_encrypt: ix=%llu\n", ix);
+	re_fprintf(stderr, ".... srtp_encrypt:  seq=%5u  roc=%u  ix=%llu\n",
+		   hdr.seq, strm->roc, ix);
 
 	if (comp->aes && comp->mode == AES_MODE_CTR) {
 		union vect128 iv;
@@ -322,7 +323,8 @@ int srtp_decrypt(struct srtp *srtp, struct mbuf *mb)
 
 	ix = srtp_get_index(strm->roc, strm->s_l, hdr.seq);
 
-	re_fprintf(stderr, ".... srtp_decrypt: ix=%llu\n", ix);
+	re_fprintf(stderr, ".... srtp_decrypt:  seq=%5u  roc=%u  ix=%llu\n",
+		   hdr.seq, strm->roc, ix);
 
 	if (comp->hmac) {
 		uint8_t tag_calc[SHA_DIGEST_LENGTH] = {0};

--- a/src/srtp/srtp.c
+++ b/src/srtp/srtp.c
@@ -204,14 +204,13 @@ int srtp_encrypt(struct srtp *srtp, struct mbuf *mb)
 
 	/* Roll-Over Counter (ROC) */
 	if (seq_diff(strm->s_l, hdr.seq) <= -32768) {
-
-		fprintf(stderr, ".... srtp_encrypt: ROC\n");
-
 		strm->roc++;
 		strm->s_l = 0;
 	}
 
 	ix = 65536ULL * strm->roc + hdr.seq;
+
+	fprintf(stderr, ".... srtp_encrypt: ix=%llu\n", ix);
 
 	if (comp->aes && comp->mode == AES_MODE_CTR) {
 		union vect128 iv;
@@ -322,6 +321,8 @@ int srtp_decrypt(struct srtp *srtp, struct mbuf *mb)
 	}
 
 	ix = srtp_get_index(strm->roc, strm->s_l, hdr.seq);
+
+	fprintf(stderr, ".... srtp_decrypt: ix=%llu\n", ix);
 
 	if (comp->hmac) {
 		uint8_t tag_calc[SHA_DIGEST_LENGTH] = {0};

--- a/test/srtp.c
+++ b/test/srtp.c
@@ -362,9 +362,6 @@ static int test_srtp_loop(size_t offset, enum srtp_suite suite, uint16_t seq)
 		hdr.seq  = seq++;
 		hdr.ssrc = SSRC;
 
-		fprintf(stderr, ".... test_srtp_loop: i=%u seq=%u\n",
-			i, hdr.seq);
-
 		err = rtp_hdr_encode(mb, &hdr);
 		if (err)
 			break;

--- a/test/srtp.c
+++ b/test/srtp.c
@@ -362,6 +362,9 @@ static int test_srtp_loop(size_t offset, enum srtp_suite suite, uint16_t seq)
 		hdr.seq  = seq++;
 		hdr.ssrc = SSRC;
 
+		fprintf(stderr, ".... test_srtp_loop: i=%u seq=%u\n",
+			i, hdr.seq);
+
 		err = rtp_hdr_encode(mb, &hdr);
 		if (err)
 			break;

--- a/test/srtp.c
+++ b/test/srtp.c
@@ -337,6 +337,9 @@ static int test_srtp_loop(size_t offset, enum srtp_suite suite, uint16_t seq)
 		0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
 	};
 
+	fprintf(stderr, ".... test_srtp_loop: offset=%zu, suite=%d"
+		" seq=%u\n", offset, suite, seq);
+
 	mb = mbuf_alloc(offset + 32);
 	if (!mb)
 		return ENOMEM;


### PR DESCRIPTION
currently a bug with macos-latest:

```
.... test_srtp_loop: offset=0, suite=0 seq=3
.... test_srtp_loop: offset=0, suite=1 seq=3
.... test_srtp_loop: offset=0, suite=2 seq=3
.... test_srtp_loop: offset=0, suite=3 seq=3
.... test_srtp_loop: offset=4, suite=0 seq=3
.... test_srtp_loop: offset=4, suite=1 seq=3
.... test_srtp_loop: offset=0, suite=0 seq=65530

srtptest: TEST_MEMCMP: /Users/runner/work/re/re/test/srtp.c:403: test_srtp_loop(): failed

Offset:   Expected (20 bytes):       Actual (20 bytes):
0x0000    55 55 55 55 11 11 11 11     d6 0f 54 17 33 59 64 c8
0x0008    ee ee ee ee 11 11 11 11     6e 21 b5 6b 5a 6f 26 d5
0x0010    55 55 55 55                 cb a9 24 fd            
```

The index calculation is wrong:

```
.... test_srtp_loop: offset=0, suite=0 seq=65530
.... srtp_encrypt:  seq=65530  roc=0  ix=65530
.... srtp_decrypt:  seq=65530  roc=0  ix=131066
```


The calculated ix in srtp_decrypt should be the same as encrypt, i.e. 65530

relevant code:

```c
/*
 * Appendix A: Pseudocode for Index Determination
 *
 * In the following, signed arithmetic is assumed.
 */
uint64_t srtp_get_index(uint32_t roc, uint16_t s_l, uint16_t seq)
{
	int v;

	if (s_l < 32768) {

		if ((int)seq - (int)s_l > 32768)
			v = (roc-1) & 0xffffffffu;
		else
			v = roc;
	}
	else {
		if ((int)s_l - 32768 > seq)
			v = (roc+1) & 0xffffffffu;
		else
			v = roc;
	}

	return seq + v*(uint64_t)65536;
}
```
