### PR TITLE
tls: remove tls_set_certificate_der() -- unused

### DIFF
--- a/include/re_tls.h
+++ b/include/re_tls.h
@@ -51,9 +51,6 @@ int tls_set_selfsigned_ec(struct tls *tls, const char *cn,
 	const char *curve_n);
 int tls_set_certificate_pem(struct tls *tls, const char *cert, size_t len_cert,
 			    const char *key, size_t len_key);
-int tls_set_certificate_der(struct tls *tls, enum tls_keytype keytype,
-			    const uint8_t *cert, size_t len_cert,
-			    const uint8_t *key, size_t len_key);
 int tls_set_certificate(struct tls *tls, const char *cert, size_t len);
 int tls_set_certificate_chain_pem(struct tls *tls, const char *chain,
 				  size_t len_chain);

--- a/src/tls/stub.c
+++ b/src/tls/stub.c
@@ -77,20 +77,6 @@ int tls_set_certificate_pem(struct tls *tls, const char *cert, size_t len_cert,
 }
 
 
-int tls_set_certificate_der(struct tls *tls, enum tls_keytype keytype,
-			    const uint8_t *cert, size_t len_cert,
-			    const uint8_t *key, size_t len_key)
-{
-	(void)tls;
-	(void)keytype;
-	(void)cert;
-	(void)len_cert;
-	(void)key;
-	(void)len_key;
-	return ENOSYS;
-}
-
-
 int tls_set_certificate(struct tls *tls, const char *pem, size_t len)
 {
 	(void)tls;


### PR DESCRIPTION
Proposal to remove tls_set_certificate_der().
It is probably unused. Use PEM certificates instead.