### PR TITLE
ice/icem: add icem_rcand_ready helper

### DIFF
--- a/include/re_ice.h
+++ b/include/re_ice.h
@@ -95,6 +95,7 @@ struct list *icem_lcandl(const struct icem *icem);
 struct list *icem_rcandl(const struct icem *icem);
 struct list *icem_checkl(const struct icem *icem);
 struct list *icem_validl(const struct icem *icem);
+bool icem_rcand_ready(struct icem *icem);
 const struct sa *icem_cand_default(struct icem *icem, unsigned compid);
 const struct sa *icem_selected_laddr(const struct icem *icem, unsigned compid);
 const struct ice_cand *icem_selected_lcand(const struct icem *icem,

--- a/src/ice/icem.c
+++ b/src/ice/icem.c
@@ -542,3 +542,22 @@ void icem_printf(struct icem *icem, const char *fmt, ...)
 	(void)re_printf("{%11s. } %v", icem->name, fmt, &ap);
 	va_end(ap);
 }
+
+
+/**
+ * Check if remote ICE candidates are ready
+ *
+ * @param icem ICE Media object
+ *
+ * @return true if ready otherwise false
+ */
+bool icem_rcand_ready(struct icem *icem)
+{
+	if (!icem)
+		return false;
+
+	if (icem->rcand_wait)
+		return true;
+
+	return !list_isempty(&icem->rcandl);
+}


### PR DESCRIPTION
If mDNS candidates needs to be resolved, checking `icem_rcandl` is not enough. So application never starts `icem_conncheck_start`.