### PR TITLE
[WIP] Fix problems with Android Emulator CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,7 +11,7 @@ on:
 env:
   openssl: 3.2.1
   toolchain: toolchains/llvm/prebuilt/linux-x86_64
-  api: 26
+  api: 29
   abi: x86_64
 
 jobs:


### PR DESCRIPTION
There is currently a problem with retest running on the Android emulator.

* Files in test data can be opened
* Test data files cannot be read (EOF)
* Problem present with host Ubuntu 22.04 and 24.04
* Files in test data are all zero bytes
* adb push copies files to the sub-directory, the old files are all zero bytes 



Here is the log:

```
a/: 13 files pushed, 0 skipped. 0.4 MB/s (24082 bytes in 0.059s)
/usr/bin/sh -c adb shell chmod 775 /data/local/tmp/retest-data
/usr/bin/sh -c adb push $ANDROID_NDK_LATEST_HOME/$toolchain/sysroot/usr/lib/$abi-linux-android/libc++_shared.so /data/local/tmp/libc++_shared.so
/usr/local/lib/android/sdk/ndk/28.2.13676358/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/x86_64-linux-android/libc++_shared.so: 1 file pushed, 0 skipped. 33.5 MB/s (8808664 bytes in 0.251s)
/usr/bin/sh -c adb shell HOME=/data/local/tmp LD_LIBRARY_PATH=/data/local/tmp /data/local/tmp/retest -r -v -d /data/local/tmp/retest-data
regular tests:       aufile_open: filename='/data/local/tmp/retest-data/beep.wav'
END-OF-FILE
aulength: TEST_ERR: /home/runner/work/re/re/test/aulength.c:26: (No data available [61])
test: test_aulength: test failed (No data available [61])

retest: TEST_ERR: /home/runner/work/re/re/test/main.c:237: (No data available [61])
retest: libre version 4.1.0 (x86_64/Android)
using async polling method 'epoll'
using datapath '/data/local/tmp/retest-data'
test 0 -- test_aac
test 1 -- test_aes
test 2 -- test_aes_gcm
test 3 -- test_au
test 4 -- test_aubuf
test 5 -- test_aulength
Error: The process '/usr/bin/sh' failed with exit code 61
```

https://github.com/ReactiveCircus/android-emulator-runner/issues/381
