### PR TITLE
ci/android: Upgrade to API-level 29 (Android 10.0)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,7 +11,7 @@ on:
 env:
   openssl: 3.2.1
   toolchain: toolchains/llvm/prebuilt/linux-x86_64
-  api: 26
+  api: 29
   abi: x86_64
 
 jobs:


### PR DESCRIPTION
This seems to fix the issue with CI and Android Emulator.