### PR TITLE
cmake: remove macOS include path

### DIFF
--- a/cmake/re-config.cmake
+++ b/cmake/re-config.cmake
@@ -214,7 +214,6 @@ endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   list(APPEND RE_DEFINITIONS DARWIN)
-  include_directories(/opt/local/include)
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "iOS")
   list(APPEND RE_DEFINITIONS DARWIN)
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")


### PR DESCRIPTION
This causes problems when building baresip.