### PR TITLE
dns: fix AAAA address comparison in getaddr_dup()

### DIFF
--- a/src/dns/client.c
+++ b/src/dns/client.c
@@ -788,7 +788,7 @@ static bool getaddr_dup(struct le *le, void *arg)
 	}
 
 	if (r1->type == DNS_TYPE_AAAA && r2->type == DNS_TYPE_AAAA) {
-		if (r1->rdata.aaaa.addr == r2->rdata.aaaa.addr)
+		if (0 == memcmp(r1->rdata.aaaa.addr, r2->rdata.aaaa.addr, 16))
 			return true;
 	}
 


### PR DESCRIPTION
I think this is a bug.

Could you please double-check @sreimers ?