### PR TITLE
h265: Fix NAL Decode nuh_layer_id

### DIFF
--- a/include/re_h265.h
+++ b/include/re_h265.h
@@ -53,6 +53,7 @@ enum h265_naltype {
 
 struct h265_nal {
 	unsigned nal_unit_type:6;          /* NAL unit type (0-40)       */
+	unsigned nuh_layer_id:6;           /* layer identifier           */
 	unsigned nuh_temporal_id_plus1:3;  /* temporal identifier plus 1 */
 };
 

--- a/src/h265/nal.c
+++ b/src/h265/nal.c
@@ -40,6 +40,7 @@ int h265_nal_decode(struct h265_nal *nal, const uint8_t *p)
 
 	forbidden_zero_bit         = p[0] >> 7;
 	nal->nal_unit_type         = (p[0] >> 1) & 0x3f;
+	nal->nuh_layer_id          = (p[0]&1)<<5 | p[1] >> 3;
 	nal->nuh_temporal_id_plus1 = p[1] & 0x07;
 
 	if (forbidden_zero_bit) {


### PR DESCRIPTION
The h265_nal_decode method for H.265 has an issue: the nuh_layer_id in WebRTC H.265 RTP streams is not 0, which can cause the loss of VPS, SPS, and PPS data.