### PR TITLE
sipsess: fix termination behavior

### DIFF
--- a/src/sipsess/prack.c
+++ b/src/sipsess/prack.c
@@ -34,7 +34,6 @@ static void destructor(void *arg)
 	struct sipsess_prack *prack = arg;
 
 	mem_deref(prack->met);
-	mem_deref(prack->req);
 }
 
 
@@ -48,7 +47,7 @@ static void tmr_handler(void *arg)
 
 	err = prack_request(prack);
 	if (err)
-		mem_deref(prack);
+		mem_deref(prack->req);
 }
 
 
@@ -98,7 +97,7 @@ static void prack_resp_handler(int err, const struct sip_msg *msg, void *arg)
 		case 408:
 		case 491:
 			tmr_start(&req->tmr, req->sess->owner ? 3000 : 1000,
-				  tmr_handler, req);
+				  tmr_handler, prack);
 			return;
 		case 500:
 			hdr = sip_msg_hdr(msg, SIP_HDR_RETRY_AFTER);
@@ -106,7 +105,7 @@ static void prack_resp_handler(int err, const struct sip_msg *msg, void *arg)
 				break;
 
 			tmr_start(&req->tmr, pl_u32(&hdr->val) * 1000,
-				  tmr_handler, req);
+				  tmr_handler, prack);
 			return;
 		}
 	}
@@ -117,7 +116,7 @@ out:
 			sipsess_terminate(req->sess, err, NULL);
 	}
 
-	mem_deref(prack);
+	mem_deref(req);
 }
 
 
@@ -182,6 +181,8 @@ int sipsess_prack(struct sipsess *sess, uint32_t cseq, uint32_t rseq,
 	if (err)
 		goto out;
 
+	prack->req->priv = prack;
+
 	prack->cseq = cseq;
 	prack->rseq = rseq;
 	err = pl_strdup(&prack->met, met);
@@ -191,8 +192,12 @@ int sipsess_prack(struct sipsess *sess, uint32_t cseq, uint32_t rseq,
 	err = prack_request(prack);
 
 out:
-	if (err)
-		mem_deref(prack);
+	if (err) {
+		if (prack->req)
+			mem_deref(prack->req);
+		else
+			mem_deref(prack);
+	}
 
 	return err;
 }

--- a/src/sipsess/reply.c
+++ b/src/sipsess/reply.c
@@ -67,7 +67,6 @@ static void tmr_handler(void *arg)
 	}
 	else {
 		mem_deref(reply);
-		mem_deref(sess);
 		return;
 	}
 

--- a/src/sipsess/request.c
+++ b/src/sipsess/request.c
@@ -27,6 +27,7 @@ static void destructor(void *arg)
 	mem_deref(req->ctype);
 	mem_deref(req->body);
 	mem_deref(req->req);
+	mem_deref(req->priv);
 
 	/* wait for pending requests */
 	if (req->sess->terminated && !req->sess->requestl.head)
@@ -57,6 +58,7 @@ int sipsess_request_alloc(struct sipsess_request **reqp, struct sipsess *sess,
 	if (!req)
 		return ENOMEM;
 
+	req->sess  = sess;
 	list_append(&sess->requestl, &req->le, req);
 
 	if (ctype) {
@@ -65,7 +67,6 @@ int sipsess_request_alloc(struct sipsess_request **reqp, struct sipsess *sess,
 			goto out;
 	}
 
-	req->sess  = sess;
 	req->body  = mem_ref(body);
 	req->resph = resph ? resph : internal_resp_handler;
 	req->arg   = arg;

--- a/src/sipsess/sess.c
+++ b/src/sipsess/sess.c
@@ -94,10 +94,7 @@ static bool termwait(struct sipsess *sess)
 		}
 	}
 
-	if (sess->replyl.head) {
-		mem_ref(sess);
-		wait = true;
-	}
+	list_flush(&sess->replyl);
 
 	if (sess->requestl.head) {
 		mem_ref(sess);
@@ -144,6 +141,10 @@ static void destructor(void *arg)
 	hash_unlink(&sess->he);
 	tmr_cancel(&sess->tmr);
 	list_flush(&sess->replyl);
+
+	/* Prevent request destructors from calling mem_deref(sess)
+	 * during flush -- we are already inside the session destructor */
+	sess->terminated = 0;
 	list_flush(&sess->requestl);
 	mem_deref((void *)sess->msg);
 	mem_deref(sess->req);

--- a/src/sipsess/sipsess.h
+++ b/src/sipsess/sipsess.h
@@ -67,6 +67,7 @@ struct sipsess_request {
 	sip_resp_h *resph;
 	struct tmr tmr;
 	void *arg;
+	void *priv;
 };
 
 

--- a/test/sipsess.c
+++ b/test/sipsess.c
@@ -85,6 +85,7 @@ struct test {
 	bool upd_b;
 	struct mbuf *desc;
 	bool blind_transfer;
+	bool conn_b;
 	uint16_t altaddr_port;
 	int err;
 };
@@ -438,6 +439,8 @@ static void conn_handler(const struct sip_msg *msg, void *arg)
 	char *hdrs = test->rel100_b == REL100_REQUIRED ?
 		     "Require: 100rel\r\n" : "";
 
+	test->conn_b = true;
+
 	if (mbuf_get_left(msg->mb)) {
 		test->sdp_state = OFFER_RECEIVED;
 		test->offer_b = true;
@@ -468,8 +471,10 @@ static void conn_handler(const struct sip_msg *msg, void *arg)
 			goto out;
 		}
 
-		if (err)
+		if (err) {
+			test->desc = NULL;
 			mem_deref(desc);
+		}
 
 		err = sipsess_set_prack_handler(test->b, prack_handler);
 		if (err)
@@ -484,6 +489,7 @@ static void conn_handler(const struct sip_msg *msg, void *arg)
 		}
 	}
 	else if (test->conn_action & CONN_PROGR_UPD) {
+		test->desc = NULL;
 		mem_deref(desc);
 		desc = mbuf_alloc(0);
 		if (!desc) {
@@ -532,6 +538,7 @@ static void conn_handler(const struct sip_msg *msg, void *arg)
 	return;
 
 out:
+	test->desc = NULL;
 	mem_deref(desc);
 	abort_test(test, err);
 }
@@ -1134,7 +1141,7 @@ int test_sipsess_100rel_420(void)
 	ASSERT_TRUE(!test.b);
 	ASSERT_TRUE(!test.estab_a);
 	ASSERT_TRUE(!test.estab_b);
-	ASSERT_TRUE(test.desc);
+	ASSERT_TRUE(test.conn_b);
 
 out:
 	tmr_cancel(&test.ans_tmr);
@@ -1207,7 +1214,7 @@ int test_sipsess_100rel_421(void)
 	ASSERT_TRUE(!test.b);
 	ASSERT_TRUE(!test.estab_a);
 	ASSERT_TRUE(!test.estab_b);
-	ASSERT_TRUE(test.desc);
+	ASSERT_TRUE(test.conn_b);
 
 out:
 	tmr_cancel(&test.ans_tmr);


### PR DESCRIPTION
Transparency: These changes were made with the help of AI (Claude Opus).

[sipsess: fix session and prack lifecycle for OOM-safe cleanup](https://github.com/baresip/re/commit/73291df113003f9a79b15e0c54c232ab568ef261)

Three interrelated fixes that together make sipsess teardown work
correctly under OOM conditions:

1. Flush reply list directly in termwait() instead of taking an extra
   mem_ref(sess) and relying on reply timer callbacks to release it.
   During OOM cleanup no event loop iteration occurs, so the timer
   callbacks never fire, the extra ref is never released, and the
   entire session object graph leaks.
   Remove the now-unnecessary mem_deref(sess) from reply.c's
   tmr_handler terminated branch.

2. Add a void *priv field to sipsess_request and use it to give the
   request ownership of the sipsess_prack struct. Previously prack
   was only freed by prack_resp_handler, but when sip_request is
   cancelled during cleanup the response handler is not called
   (resph is set to NULL by the SIP request destructor), leaking
   the prack struct and its method string.
   The prack destructor no longer frees the request (breaking the
   circular ownership), and all cleanup paths now free req (which
   transitively frees prack via priv) instead of freeing prack
   directly.

3. Set sess->terminated = 0 before flushing requestl in the session
   destructor. The request destructor checks
   "if (req->sess->terminated && !req->sess->requestl.head)"
   and calls mem_deref(req->sess). During list_flush in the session
   destructor, the session's refcount is already 0, so this would be
   a re-entrant free of an already-dying object. Clearing terminated
   prevents request destructors from taking this path.

Also move req->sess assignment before str_dup() in
sipsess_request_alloc() so the destructor can safely access
req->sess->terminated if str_dup() fails under OOM.

[test/sipsess: fix OOM-related test errors](https://github.com/baresip/re/commit/a27e797689f47d2aeb8ec853633b4d90456b679b)

Fix test->desc double-free in conn_handler error paths: when
sipsess_accept() fails, desc has already been assigned to
test->desc. Clear test->desc before calling mem_deref(desc) to
avoid a dangling pointer that the test cleanup would free again.
Apply the same fix in the CONN_PROGR_UPD and error-exit paths.

Add a conn_b flag to track whether conn_handler was called. Use it
in 100rel_420 and 100rel_421 assertions instead of checking
test->desc, which may be NULL after failed allocations during OOM
testing.