### PR TITLE
tmr: make timer insertion robust against NULL list nodes

### DIFF
--- a/src/tmr/tmr.c
+++ b/src/tmr/tmr.c
@@ -88,18 +88,32 @@ int tmrl_alloc(struct tmrl **tmrl)
 
 static bool inspos_handler(struct le *le, void *arg)
 {
-	struct tmr *tmr = le->data;
+	struct tmr *tmr;
 	const uint64_t now = *(uint64_t *)arg;
 
+	if (!le || !le->data) {
+		if (le)
+			list_unlink(le);
+		return false;
+	}
+
+	tmr = le->data;
 	return tmr->jfs <= now;
 }
 
 
 static bool inspos_handler_0(struct le *le, void *arg)
 {
-	struct tmr *tmr = le->data;
+	struct tmr *tmr;
 	const uint64_t now = *(uint64_t *)arg;
 
+	if (!le || !le->data) {
+		if (le)
+			list_unlink(le);
+		return false;
+	}
+
+	tmr = le->data;
 	return tmr->jfs > now;
 }
 


### PR DESCRIPTION
Guard `inspos_handler()` and `inspos_handler_0()` against NULL list node
data by unlinking invalid nodes during insertion scan. This prevents NULL
dereference on corrupted timer-list entries without changing timer behavior
for valid nodes.