### PR TITLE
udp: guard udp_destructor against repeated lock teardown

### DIFF
--- a/src/udp/udp.c
+++ b/src/udp/udp.c
@@ -127,10 +127,17 @@ static bool helper_recv_handler(struct sa *src,
 static void udp_destructor(void *data)
 {
 	struct udp_sock *us = data;
+	mtx_t *lock = us->lock;
+
+	if (!lock)
+		return;
+
+	/* Avoid double-destroy in case of repeated deref */
+	us->lock = NULL;
 
 	list_flush(&us->helpers);
 
-	mem_deref(us->lock);
+	mem_deref(lock);
 
 #ifdef WIN32
 	if (us->qos && us->qos_id)


### PR DESCRIPTION
## Summary

Guard `udp_destructor()` against repeated lock teardown.

## Problem

`udp_destructor()` unconditionally dereferences `us->lock`. If the destructor
is entered more than once for the same object, the mutex can be torn down
again and trigger a double-destroy style crash.

## Fix

Take a local copy of `us->lock`, return early if it was already cleared,
and set `us->lock` to NULL before dereferencing the mutex. This ensures
the lock teardown is performed only once.

## Impact

This change is intentionally narrow:
- it only affects destructor teardown
- it does not change UDP send/recv behavior
- it does not change helper ordering or socket semantics

## Risk

Low. The change is limited to defensive teardown handling in
`udp_destructor()`.

## Testing

- build the project with CMake
- build and run `retest`
- verify normal UDP socket teardown still works
- verify repeated destructor entry no longer crashes