### PR TITLE
turn: guard chan_destructor against NULL turnc lock

### DIFF
--- a/src/turn/chan.c
+++ b/src/turn/chan.c
@@ -67,10 +67,12 @@ static void chan_destructor(void *data)
 
 	tmr_cancel(&chan->tmr);
 	mem_deref(chan->ct);
-	mtx_lock(chan->turnc->lock);
-	hash_unlink(&chan->he_numb);
-	hash_unlink(&chan->he_peer);
-	mtx_unlock(chan->turnc->lock);
+	if (chan->turnc && chan->turnc->lock) {
+		mtx_lock(chan->turnc->lock);
+		hash_unlink(&chan->he_numb);
+		hash_unlink(&chan->he_peer);
+		mtx_unlock(chan->turnc->lock);
+	}
 }
 
 


### PR DESCRIPTION
## Summary

Guard `chan_destructor()` against missing `turnc`/lock during channel teardown.

## Problem

`chan_destructor()` unconditionally accesses `chan->turnc->lock` when unlinking
channel entries from the TURN channel hash tables. If teardown reaches the
destructor after `turnc` or its lock is no longer available, this may crash.

## Fix

Add a defensive check before taking the lock and unlinking the channel from
the hash tables.

## Impact

This change is intentionally narrow:
- it only affects channel teardown
- it does not change channel bind/refresh behavior
- it does not change normal lookup or channel allocation logic

## Risk

Low. The change is limited to a destructor-side NULL guard.

## Testing

- build the project with CMake
- build and run `retest`
- verify normal TURN channel setup/teardown still works
- verify teardown no longer crashes when `turnc` or its lock is unavailable