### PR TITLE
sip/auth: relax repeated challenge handling for existing realms

### DIFF
--- a/src/sip/auth.c
+++ b/src/sip/auth.c
@@ -214,7 +214,8 @@ static bool auth_handler(const struct sip_hdr *hdr, const struct sip_msg *msg,
 			goto out;
 	}
 	else {
-		if (!pl_isset(&ch.stale) || pl_strcasecmp(&ch.stale, "true")) {
+		if ((!pl_isset(&ch.stale) ||
+				pl_strcasecmp(&ch.stale, "true")) && (realm->nc == 2)) {
 			err = EAUTH;
 			goto out;
 		}


### PR DESCRIPTION
## Summary

Allow an existing SIP auth realm to accept later digest challenges without
requiring `stale=true` in every repeated challenge.

## Problem

`sip/auth.c` currently returns `EAUTH` for any challenge received for an
already known realm unless the server explicitly marks it as `stale=true`.

This is too strict for realms that have already been used successfully,
because later valid re-challenges for the same realm are rejected instead of
refreshing nonce-related state.

## Fix

Keep the existing protection for the first failed authenticated retry, but
only return `EAUTH` for a non-stale repeated challenge when `realm->nc == 2`.

For later uses of the same realm, refresh nonce/qop/opaque/algorithm from the
new challenge and continue.

## Impact

This change is intentionally narrow:
- it does not change initial digest authentication setup
- it preserves the first failed auth attempt behavior
- it only relaxes handling for later challenges on an existing realm

## Risk

Low. The change is limited to repeated challenge handling in `auth_handler()`.

## Testing

- build the project with CMake
- build and run `retest`
- verify initial auth success/failure behavior is unchanged
- verify later challenges for an existing realm no longer fail immediately
  when `stale=true` is not present