### PR TITLE
re/main: delay freeing closed fd handlers to avoid stale poll event UAF

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -72,6 +72,7 @@ struct re_fhs {
 	int flags;           /**< Polling flags (Read, Write, etc.) */
 	fd_h* fh;            /**< Event handler                     */
 	void* arg;           /**< Handler argument                  */
+	uint32_t closed_gen; /**< poll generation when closed       */
 	struct re_fhs* next; /**< Next element in the delete list   */
 };
 
@@ -84,6 +85,7 @@ struct re {
 	int sig;                     /**< Last caught signal                */
 	struct tmrl *tmrl;           /**< List of timers                    */
 	struct re_fhs *fhsld;        /**< fhs single-linked delete list     */
+	uint32_t fhs_gen;            /**< poll generation counter           */
 #ifdef HAVE_SELECT
 	struct re_fhs **fhsl;        /**< Select fhs pointer list           */
 #endif
@@ -110,16 +112,25 @@ static once_flag flag = ONCE_FLAG_INIT;
 static void poll_close(struct re *re);
 
 
-static void fhsld_flush(struct re *re)
+static void fhsld_flush(struct re *re, bool force)
 {
 	struct re_fhs *fhs = re->fhsld;
+	struct re_fhs *keep = NULL;
 	re->fhsld = NULL;
 
 	while (fhs) {
 		struct re_fhs *next = fhs->next;
-		mem_deref(fhs);
+		if (force || (uint32_t)(re->fhs_gen - fhs->closed_gen) > 1) {
+			mem_deref(fhs);
+		}
+		else {
+			fhs->next = keep;
+			keep = fhs;
+		}
 		fhs = next;
 	}
+
+	re->fhsld = keep;
 }
 
 
@@ -128,7 +139,7 @@ static void re_destructor(void *arg)
 	struct re *re = arg;
 
 	poll_close(re);
-	fhsld_flush(re);
+	fhsld_flush(re, true);
 	mem_deref(re->mutex);
 	mem_deref(re->async);
 	mem_deref(re->tmrl);
@@ -252,6 +263,9 @@ static void fd_handler(struct re_fhs *fhs, int flags)
 {
 	const uint64_t tick = tmr_jiffies();
 	uint32_t diff;
+
+	if (!fhs || !fhs->fh)
+		return;
 
 	DEBUG_INFO("event on fd=%d (flags=0x%02x)...\n", fhs->fd, flags);
 
@@ -608,6 +622,7 @@ int fd_listen(struct re_fhs **fhsp, re_sock_t fd, int flags, fd_h *fh,
 
 		fhs->fd	   = fd;
 		fhs->index = -1;
+		fhs->closed_gen = re->fhs_gen;
 
 		DEBUG_INFO("fd_listen/new: fd=%d flags=0x%02x\n", fd, flags);
 
@@ -688,6 +703,7 @@ struct re_fhs *fd_close(struct re_fhs *fhs)
 	fhs->flags = 0;
 	fhs->fh	   = NULL;
 	fhs->arg   = NULL;
+	fhs->closed_gen = re->fhs_gen;
 
 	switch (re->method) {
 #ifdef HAVE_SELECT
@@ -933,7 +949,8 @@ static int fd_poll(struct re *re)
 
  out:
 	/* Delayed fhs deref to avoid dangling fhs pointers */
-	fhsld_flush(re);
+	++re->fhs_gen;
+	fhsld_flush(re, false);
 
 	return err;
 }
@@ -1673,5 +1690,5 @@ void re_fhs_flush(void)
 		return;
 	}
 
-	fhsld_flush(re);
+	fhsld_flush(re, true);
 }


### PR DESCRIPTION
## Summary

Delay destruction of `re_fhs` objects after `fd_close()` instead of freeing them
at the end of the current poll iteration.

Closed handlers are now placed on the deferred delete list and are only freed
after an additional poll generation, or immediately during forced cleanup.

## Motivation

`epoll`/`kqueue` may still surface events that were already returned to user space
or are still observable around the current polling cycle after a handler has been
closed.

Previously, `re_fhs` objects could be dereferenced too early from the deferred
delete list, which could lead to use-after-free when a stale backend event still
referenced the old handler pointer.

## Changes

- add `closed_gen` to `struct re_fhs`
- add `fhs_gen` to `struct re`
- record the current generation in `fd_close()`
- increment generation once per completed `fd_poll()`
- change deferred flush logic to keep recently closed handlers alive for one
  extra poll generation
- keep forced destruction behavior unchanged for shutdown paths

## Behavior

This does not change logic for valid active handlers.

The change only extends the lifetime of recently closed `re_fhs` objects long
enough to reduce the risk of stale poll backend events dereferencing freed
memory.

## Notes

This is a lifetime-management fix, not a poll backend redesign.

It mitigates UAF caused by stale event pointers around close/delivery timing,
while preserving the existing `epoll`/`kqueue` integration model.