### PR TITLE
hash: safety check for string

### DIFF
--- a/src/hash/func.c
+++ b/src/hash/func.c
@@ -52,6 +52,8 @@ uint32_t hash_joaat_ci(const char *str, size_t len)
 {
 	uint32_t hash = 0;
 	size_t i;
+	if (!str)
+		return 0;
 
 	for (i = 0; i < len; i++) {
 		hash += tolower(str[i]);


### PR DESCRIPTION
- NULL pointer check
- ~Do not read past the null byte.~