### PR TITLE
tls: upgrade usage of legacy functions

### DIFF
--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -1032,8 +1032,8 @@ int tls_peer_common_name(const struct tls_conn *tc, char *cn, size_t size)
 
 	int ix = X509_NAME_get_index_by_NID(name, NID_commonName, -1);
 	if (ix != -1) {
-		X509_NAME_ENTRY *entry = X509_NAME_get_entry(name, ix);
-		ASN1_STRING *astr = X509_NAME_ENTRY_get_data(entry);
+		const X509_NAME_ENTRY *entry = X509_NAME_get_entry(name, ix);
+		const ASN1_STRING *astr = X509_NAME_ENTRY_get_data(entry);
 
 		str_ncpy(cn, (char *)ASN1_STRING_get0_data(astr), size);
 		n = ASN1_STRING_length(astr);

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -1015,7 +1015,7 @@ int tls_peer_fingerprint(const struct tls_conn *tc, enum tls_fingerprint type,
 int tls_peer_common_name(const struct tls_conn *tc, char *cn, size_t size)
 {
 	X509 *cert;
-	int n;
+	int n = -1;
 
 	if (!tc || !cn || !size)
 		return EINVAL;
@@ -1035,11 +1035,11 @@ int tls_peer_common_name(const struct tls_conn *tc, char *cn, size_t size)
 		const X509_NAME_ENTRY *entry = X509_NAME_get_entry(name, ix);
 		const ASN1_STRING *astr = X509_NAME_ENTRY_get_data(entry);
 
-		str_ncpy(cn, (char *)ASN1_STRING_get0_data(astr), size);
-		n = ASN1_STRING_length(astr);
-	}
-	else {
-		n = -1;
+		if (astr) {
+			str_ncpy(cn, (char *)ASN1_STRING_get0_data(astr),
+				 size);
+			n = ASN1_STRING_length(astr);
+		}
 	}
 
 	X509_free(cert);

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -1028,8 +1028,19 @@ int tls_peer_common_name(const struct tls_conn *tc, char *cn, size_t size)
 	if (!cert)
 		return ENOENT;
 
-	n = X509_NAME_get_text_by_NID(X509_get_subject_name(cert),
-				      NID_commonName, cn, (int)size);
+	const X509_NAME *name = X509_get_subject_name(cert);
+
+	int ix = X509_NAME_get_index_by_NID(name, NID_commonName, -1);
+	if (ix != -1) {
+		X509_NAME_ENTRY *entry = X509_NAME_get_entry(name, ix);
+		ASN1_STRING *astr = X509_NAME_ENTRY_get_data(entry);
+
+		str_ncpy(cn, (char *)ASN1_STRING_get0_data(astr), size);
+		n = ASN1_STRING_length(astr);
+	}
+	else {
+		n = -1;
+	}
 
 	X509_free(cert);
 


### PR DESCRIPTION
Upgrade usage of legacy functions to get common name from remote peer's certificate.

https://linux.die.net/man/3/x509_name_get_text_by_nid