### PR TITLE
http: Send HTTP request with explicit server address

### DIFF
--- a/include/re_http.h
+++ b/include/re_http.h
@@ -151,6 +151,10 @@ int http_client_set_config(struct http_cli *cli, struct http_conf *conf);
 int http_request(struct http_req **reqp, struct http_cli *cli, const char *met,
 		 const char *uri, http_resp_h *resph, http_data_h *datah,
 		 http_bodyh *bodyh, void *arg, const char *fmt, ...);
+int http_request_addr(struct http_req **reqp, struct http_cli *cli,
+		      const char *met, const char *uri, const struct sa *addr,
+		      http_resp_h *resph, http_data_h *datah,
+		      http_bodyh *bodyh, void *arg, const char *fmt, ...);
 void http_req_set_conn_handler(struct http_req *req, http_conn_h *connh);
 void http_client_set_laddr(struct http_cli *cli, const struct sa *addr);
 void http_client_set_laddr6(struct http_cli *cli, const struct sa *addr);
@@ -254,6 +258,8 @@ int http_reqconn_add_header(struct http_reqconn *conn,
 		const struct pl *header);
 int http_reqconn_clr_header(struct http_reqconn *conn);
 int http_reqconn_send(struct http_reqconn *conn, const struct pl *uri);
+int http_reqconn_set_peer(struct http_reqconn *conn,
+			  const struct sa *peer);
 #ifdef USE_TLS
 int http_reqconn_set_tls_hostname(struct http_reqconn *conn,
 		const struct pl *hostname);

--- a/src/http/client.c
+++ b/src/http/client.c
@@ -753,24 +753,12 @@ out:
 }
 
 
-/**
- * Send an HTTP request
- *
- * @param reqp      Pointer to allocated HTTP request object
- * @param cli       HTTP Client
- * @param met       Request method
- * @param uri       Request URI
- * @param resph     Response handler
- * @param datah     Content handler (optional)
- * @param bodyh     Body handler (optional)
- * @param arg       Handler argument
- * @param fmt       Formatted HTTP headers and body (optional)
- *
- * @return 0 if success, otherwise errorcode
- */
-int http_request(struct http_req **reqp, struct http_cli *cli, const char *met,
-		 const char *uri, http_resp_h *resph, http_data_h *datah,
-		 http_bodyh *bodyh, void *arg, const char *fmt, ...)
+static int http_request_addr_v(struct http_req **reqp, struct http_cli *cli,
+			       const char *met, const char *uri,
+			       const struct sa *addr,
+			       http_resp_h *resph, http_data_h *datah,
+			       http_bodyh *bodyh, void *arg,
+			       const char *fmt, va_list ap)
 {
 	struct http_uri http_uri;
 	struct pl pl;
@@ -779,7 +767,6 @@ int http_request(struct http_req **reqp, struct http_cli *cli, const char *met,
 	struct sa sa;
 	bool ipv6;
 	bool secure;
-	va_list ap;
 	int err;
 
 	if (!cli || !met || !uri)
@@ -812,8 +799,9 @@ int http_request(struct http_req **reqp, struct http_cli *cli, const char *met,
 
 	req->cli    = cli;
 	req->secure = secure;
-	req->port   = pl_isset(&http_uri.port) ? pl_u32(&http_uri.port) :
-			defport;
+	req->port   = (addr && sa_port(addr)) ? sa_port(addr) :
+			(pl_isset(&http_uri.port) ? pl_u32(&http_uri.port) :
+			  defport);
 	req->resph  = resph;
 	req->datah  = datah;
 	req->bodyh  = bodyh;
@@ -836,14 +824,10 @@ int http_request(struct http_req **reqp, struct http_cli *cli, const char *met,
 			  met, &http_uri.path,
 			  ipv6 ? "[" : "", &http_uri.host, ipv6 ? "]" : "");
 
-	if (fmt) {
-		va_start(ap, fmt);
+	if (fmt)
 		err |= mbuf_vprintf(req->mbreq, fmt, ap);
-		va_end(ap);
-	}
-	else {
+	else
 		err |= mbuf_write_str(req->mbreq, "\r\n");
-	}
 
 	if (err)
 		goto out;
@@ -868,8 +852,14 @@ int http_request(struct http_req **reqp, struct http_cli *cli, const char *met,
 		goto out;
 #endif
 
-	if (!sa_set_str(&req->srvv[0], req->host, req->port)) {
-
+	if (addr) {
+		/* Use explicit addr instead of DNS resolution */
+		req->srvv[0] = *addr;
+		sa_set_port(&req->srvv[0], req->port);
+		req->srvc = 1;
+		err = req_connect(req);
+	}
+	else if (!sa_set_str(&req->srvv[0], req->host, req->port)) {
 		req->srvc = 1;
 
 		err = req_connect(req);
@@ -901,6 +891,74 @@ int http_request(struct http_req **reqp, struct http_cli *cli, const char *met,
 		req->reqp = reqp;
 		*reqp = req;
 	}
+
+	return err;
+}
+
+
+/**
+ * Send an HTTP request
+ *
+ * @param reqp   Pointer to allocated HTTP request object
+ * @param cli    HTTP Client
+ * @param met    Request method
+ * @param uri    Request URI
+ * @param resph  Response handler
+ * @param datah  Content handler (optional)
+ * @param bodyh  Body handler (optional)
+ * @param arg    Handler argument
+ * @param fmt    Formatted HTTP headers and body (optional)
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int http_request(struct http_req **reqp, struct http_cli *cli, const char *met,
+		 const char *uri, http_resp_h *resph, http_data_h *datah,
+		 http_bodyh *bodyh, void *arg, const char *fmt, ...)
+{
+	va_list ap;
+	int err;
+
+	va_start(ap, fmt);
+	err = http_request_addr_v(reqp, cli, met, uri, NULL,
+				  resph, datah, bodyh, arg, fmt, ap);
+	va_end(ap);
+
+	return err;
+}
+
+
+/**
+ * Send an HTTP request with explicit server address (bypasses DNS)
+ *
+ * Like http_request but connects to addr instead of resolving the URI
+ * host via DNS. The Host header still uses the hostname from uri.
+ * If addr is NULL, falls back to DNS resolution like http_request().
+ *
+ * @param reqp   Pointer to allocated HTTP request object
+ * @param cli    HTTP Client
+ * @param met    Request method
+ * @param uri    Request URI (host used for Host header only)
+ * @param addr   Explicit server address for TCP connect, or NULL
+ * @param resph  Response handler
+ * @param datah  Content handler (optional)
+ * @param bodyh  Body handler (optional)
+ * @param arg    Handler argument
+ * @param fmt    Formatted HTTP headers and body (optional)
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int http_request_addr(struct http_req **reqp, struct http_cli *cli,
+		      const char *met, const char *uri, const struct sa *addr,
+		      http_resp_h *resph, http_data_h *datah,
+		      http_bodyh *bodyh, void *arg, const char *fmt, ...)
+{
+	va_list ap;
+	int err;
+
+	va_start(ap, fmt);
+	err = http_request_addr_v(reqp, cli, met, uri, addr,
+				  resph, datah, bodyh, arg, fmt, ap);
+	va_end(ap);
 
 	return err;
 }

--- a/src/http/request.c
+++ b/src/http/request.c
@@ -350,21 +350,25 @@ static int send_req(struct http_reqconn *conn, const struct pl *auth)
 	if (conn->custhdr)
 		pl_set_mbuf(&custh, conn->custhdr);
 
-	err = http_request(&conn->req, conn->client,
-			conn->met, conn->uri,
-			resp_handler, conn->datah ? data_handler : NULL,
-			(conn->bodyh || conn->body) ? req_body_handler : NULL,
-			conn,
-			"%r%s"
-			"User-Agent: re " RE_VERSION "\r\n"
-			"%r"
-			"%r"
-			"%r"
-			"\r\n",
-			auth, auth ? "\r\n" : "",
-			&ct,
-			&custh,
-			&cl);
+	err = http_request_addr(&conn->req, conn->client,
+				conn->met, conn->uri,
+				sa_isset(&conn->peer, SA_ADDR) ?
+					 &conn->peer : NULL,
+				resp_handler,
+				conn->datah ? data_handler : NULL,
+				(conn->bodyh || conn->body) ?
+					req_body_handler : NULL,
+				conn,
+				"%r%s"
+				"User-Agent: re " RE_VERSION "\r\n"
+				"%r"
+				"%r"
+				"%r"
+				"\r\n",
+				auth, auth ? "\r\n" : "",
+				&ct,
+				&custh,
+				&cl);
 
 	mem_deref(clbuf);
 	mem_deref(ctbuf);
@@ -590,6 +594,33 @@ int http_reqconn_set_tls_hostname(struct http_reqconn *conn,
 	return pl_strdup(&conn->tlshn, hostname);
 }
 #endif
+
+
+/**
+ * Set explicit peer address for next request (bypasses DNS)
+ *
+ * If set, the TCP connection goes to this address while
+ * the URI's hostname is still used for the Host header and
+ * TLS SNI. Useful for routing through a local proxy.
+ *
+ * @param conn HTTP request connection
+ * @param peer Peer address (NULL to clear)
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int http_reqconn_set_peer(struct http_reqconn *conn,
+			  const struct sa *peer)
+{
+	if (!conn)
+		return EINVAL;
+
+	if (peer)
+		conn->peer = *peer;
+	else
+		memset(&conn->peer, 0, sizeof(conn->peer));
+
+	return 0;
+}
 
 
 int http_reqconn_send(struct http_reqconn *conn, const struct pl *uri)

--- a/test/http.c
+++ b/test/http.c
@@ -820,3 +820,143 @@ int test_https_conn_post_handshake(void)
 	return test_http_loop_base(true, "GET", true, false, false, true);
 }
 #endif
+
+
+static void http_req_addr_handler(struct http_conn *conn,
+				   const struct http_msg *msg, void *arg)
+{
+	struct test *t = arg;
+	(void)msg;
+
+	++t->n_request;
+	http_reply(conn, 200, "OK", "Content-Length: 0\r\n\r\n");
+}
+
+
+static void http_resp_addr_handler(int err, const struct http_msg *msg,
+				   void *arg)
+{
+	struct test *t = arg;
+
+	if (err)
+		goto out;
+
+	++t->n_response;
+	TEST_EQUALS(200, msg->scode);
+	re_cancel();
+
+ out:
+	if (err)
+		abort_test(t, err);
+}
+
+
+static int test_http_request_addr_base(bool secure)
+{
+	struct http_sock *sock = NULL;
+	struct http_cli *cli = NULL;
+	struct http_req *req = NULL;
+	struct dnsc *dnsc = NULL;
+	struct dns_server *dns_srv = NULL;
+	struct sa srv;
+	struct test t;
+	char url[256];
+	int err = 0;
+#ifdef USE_TLS
+	char path[256];
+#endif
+	memset(&t, 0, sizeof(t));
+	t.secure = secure;
+
+	err = sa_set_str(&srv, "127.0.0.1", 0);
+	TEST_ERR(err);
+
+	/* Mock DNS server with no records */
+	err = dns_server_alloc(&dns_srv, "127.0.0.1");
+	TEST_ERR(err);
+
+#ifdef USE_TLS
+	if (secure) {
+		re_snprintf(path, sizeof(path), "%s/server-ecdsa.pem",
+			    test_datapath());
+		err = https_listen(&sock, &srv, path, http_req_addr_handler,
+				   &t);
+	}
+	else
+#endif
+	{
+		err = http_listen(&sock, &srv, http_req_addr_handler, &t);
+	}
+	if (err)
+		goto out;
+
+	err = tcp_sock_local_get(http_sock_tcp(sock), &srv);
+	if (err)
+		goto out;
+
+	err = dnsc_alloc(&dnsc, NULL, &dns_srv->addr, 1);
+	if (err)
+		goto out;
+
+	err = http_client_alloc(&cli, dnsc);
+	if (err)
+		goto out;
+
+#ifdef USE_TLS
+	if (secure) {
+		re_snprintf(path, sizeof(path), "%s/server-ecdsa.pem",
+			    test_datapath());
+		err = http_client_add_ca(cli, path);
+		if (err)
+			goto out;
+	}
+#endif
+
+	/* Port 1 in URL — without explicit addr the connect goes to port 1
+	 * (nothing listens), proving http_request_addr bypasses ip and port
+	 * in the URL and uses the given ip and port */
+	re_snprintf(url, sizeof(url), "http%s://127.0.0.1:1/index.html",
+		    secure ? "s" : "");
+
+	err = http_request_addr(&req, cli, "GET", url, &srv,
+				http_resp_addr_handler, NULL, NULL, &t,
+				"\r\n");
+	if (err)
+		goto out;
+
+	err = re_main_timeout(secure ? 1800 : 900);
+	if (err)
+		goto out;
+
+	if (t.err) {
+		err = t.err;
+		goto out;
+	}
+
+	TEST_EQUALS(1, t.n_request);
+	TEST_EQUALS(1, t.n_response);
+
+ out:
+	mem_deref(t.mb_body);
+	mem_deref(req);
+	mem_deref(cli);
+	mem_deref(dnsc);
+	mem_deref(sock);
+	mem_deref(dns_srv);
+
+	return err;
+}
+
+
+int test_http_request_addr(void)
+{
+	return test_http_request_addr_base(false);
+}
+
+
+#ifdef USE_TLS
+int test_https_request_addr(void)
+{
+	return test_http_request_addr_base(true);
+}
+#endif

--- a/test/test.c
+++ b/test/test.c
@@ -122,6 +122,10 @@ static const struct test tests[] = {
 	TEST(test_http_conn_large_body),
 	TEST(test_http_large_body),
 	TEST(test_http_loop),
+	TEST(test_http_request_addr),
+#ifdef USE_TLS
+	TEST(test_https_request_addr),
+#endif
 #ifdef USE_TLS
 	TEST(test_https_loop),
 	TEST(test_http_client_set_tls),

--- a/test/test.h
+++ b/test/test.h
@@ -228,6 +228,10 @@ int test_http_conn(void);
 int test_http_conn_large_body(void);
 int test_dns_http_integration(void);
 int test_dns_cache_http_integration(void);
+int test_http_request_addr(void);
+#ifdef USE_TLS
+int test_https_request_addr(void);
+#endif
 #ifdef USE_TLS
 int test_https_loop(void);
 int test_http_client_set_tls(void);


### PR DESCRIPTION
Http(s) requests with explicit server ip address and port.

This allows external dns resolvement for hostname and use the standard tls verify handler with hostname check for https requests.