### PR TITLE
http: uri decode and encode

### DIFF
--- a/include/re_http.h
+++ b/include/re_http.h
@@ -92,12 +92,15 @@ struct http_msg {
 
 struct http_uri {
 	struct pl scheme;
-	struct pl host;
+	struct pl user;      /**< Optional username            */
+	struct pl host;      /**< Hostname or IP-address       */
+	int af;              /**< Address family of host IP-address */
 	struct pl port;
 	struct pl path;
 };
 
 int http_uri_decode(struct http_uri *hu, const struct pl *uri);
+int http_uri_encode(struct re_printf *pf, const struct http_uri *hu);
 
 
 /** Http Client configuration */

--- a/include/re_http.h
+++ b/include/re_http.h
@@ -95,7 +95,7 @@ struct http_uri {
 	struct pl user;      /**< Optional username            */
 	struct pl host;      /**< Hostname or IP-address       */
 	int af;              /**< Address family of host IP-address */
-	struct pl port;
+	uint16_t port;
 	struct pl path;
 };
 

--- a/src/http/client.c
+++ b/src/http/client.c
@@ -729,6 +729,7 @@ static void query_handler(int err, const struct dnshdr *hdr, struct list *ansl,
 int http_uri_decode(struct http_uri *hu, const struct pl *uri)
 {
 	struct pl hostport = PL_INIT;
+	struct pl port = PL_INIT;
 	int err;
 
 	if (!hu || !uri)
@@ -741,8 +742,6 @@ int http_uri_decode(struct http_uri *hu, const struct pl *uri)
 		       "[a-z]+://[^:@/]+[:]*[^@/]*@[^/]+[^]*",
 		       &hu->scheme, &hu->user, NULL, NULL,
 		       &hostport, &hu->path);
-	err |= (hu->scheme.p == uri->p ? 0 : EINVAL);
-	err |= uri_decode_hostport(&hostport, &hu->host, &hu->port);
 	if (!err)
 		goto out;
 
@@ -750,23 +749,24 @@ int http_uri_decode(struct http_uri *hu, const struct pl *uri)
 	memset(hu, 0, sizeof(*hu));
 	err = re_regex(uri->p, uri->l, "[a-z]+://[^/]+[^]*",
 		       &hu->scheme, &hostport, &hu->path);
-	err |= (hu->scheme.p == uri->p ? 0 : EINVAL);
-	err |= uri_decode_hostport(&hostport, &hu->host, &hu->port);
 
 out:
-	if (err)
-		return err;
+	err |= (hu->scheme.p == uri->p ? 0 : EINVAL);
+	err |= uri_decode_hostport(&hostport, &hu->host, &port);
+	if (!err) {
+		if (!pl_isset(&hu->path))
+			pl_set_str(&hu->path, "/");
 
-	if (!pl_isset(&hu->path))
-		pl_set_str(&hu->path, "/");
+		struct sa addr;
+		if (0 == sa_set(&addr, &hu->host, 0))
+			hu->af = sa_af(&addr);
+		else
+			hu->af = AF_UNSPEC;
 
-	struct sa addr;
-	if (0 == sa_set(&addr, &hu->host, 0))
-		hu->af = sa_af(&addr);
-	else
-		hu->af = AF_UNSPEC;
+		hu->port = (uint16_t)pl_u32(&port);
+	}
 
-	return 0;
+	return err;
 }
 
 
@@ -799,10 +799,11 @@ int http_uri_encode(struct re_printf *pf, const struct http_uri *hu)
 	if (err)
 		return err;
 
-	if (pl_isset(&hu->port))
-		err = re_hprintf(pf, ":%r", &hu->port);
+	if (hu->port)
+		err = re_hprintf(pf, ":%u", hu->port);
 
-	err |= re_hprintf(pf, "%r", &hu->path);
+	if (pl_isset(&hu->path))
+		err |= re_hprintf(pf, "%r", &hu->path);
 
 	return err;
 }
@@ -855,8 +856,7 @@ static int http_request_addr_v(struct http_req **reqp, struct http_cli *cli,
 	req->cli    = cli;
 	req->secure = secure;
 	req->port   = (addr && sa_port(addr)) ? sa_port(addr) :
-			(pl_isset(&http_uri.port) ? pl_u32(&http_uri.port) :
-			  defport);
+			(http_uri.port ? http_uri.port : defport);
 	req->resph  = resph;
 	req->datah  = datah;
 	req->bodyh  = bodyh;

--- a/src/http/client.c
+++ b/src/http/client.c
@@ -19,6 +19,7 @@
 #include <re_tls.h>
 #include <re_dns.h>
 #include <re_msg.h>
+#include <re_uri.h>
 #include <re_http.h>
 #include <re_sys.h>
 #include "http.h"
@@ -727,27 +728,81 @@ static void query_handler(int err, const struct dnshdr *hdr, struct list *ansl,
 
 int http_uri_decode(struct http_uri *hu, const struct pl *uri)
 {
-	int err = 0;
-	if (!hu)
+	struct pl hostport = PL_INIT;
+	int err;
+
+	if (!hu || !uri)
 		return EINVAL;
 
 	memset(hu, 0, sizeof(*hu));
 
-	/* Try IPv6 first */
-	err = re_regex(uri->p, uri->l, "[a-z]+://\\[[^\\]]+\\][:]*[0-9]*[^]+",
-		       &hu->scheme, &hu->host, NULL, &hu->port, &hu->path) ||
-	      hu->scheme.p != uri->p;
+	/* Try with auth (user[:password]@hostport) */
+	err = re_regex(uri->p, uri->l,
+		       "[a-z]+://[^:@/]+[:]*[^@/]*@[^/]+[^]*",
+		       &hu->scheme, &hu->user, NULL, NULL,
+		       &hostport, &hu->path);
+	err |= (hu->scheme.p == uri->p ? 0 : EINVAL);
+	err |= uri_decode_hostport(&hostport, &hu->host, &hu->port);
 	if (!err)
 		goto out;
 
-	/* Then non-IPv6 host */
-	err = re_regex(uri->p, uri->l, "[a-z]+://[^:/]+[:]*[0-9]*[^]+",
-		       &hu->scheme, &hu->host, NULL, &hu->port, &hu->path) ||
-	      hu->scheme.p != uri->p;
+	/* Without auth */
+	memset(hu, 0, sizeof(*hu));
+	err = re_regex(uri->p, uri->l, "[a-z]+://[^/]+[^]*",
+		       &hu->scheme, &hostport, &hu->path);
+	err |= (hu->scheme.p == uri->p ? 0 : EINVAL);
+	err |= uri_decode_hostport(&hostport, &hu->host, &hu->port);
 
 out:
-	if (!err && !pl_isset(&hu->path))
+	if (err)
+		return err;
+
+	if (!pl_isset(&hu->path))
 		pl_set_str(&hu->path, "/");
+
+	struct sa addr;
+	if (0 == sa_set(&addr, &hu->host, 0))
+		hu->af = sa_af(&addr);
+	else
+		hu->af = AF_UNSPEC;
+
+	return 0;
+}
+
+
+int http_uri_encode(struct re_printf *pf, const struct http_uri *hu)
+{
+	int err;
+
+	if (!pf || !hu)
+		return EINVAL;
+
+	if (!pl_isset(&hu->scheme) || !pl_isset(&hu->host))
+		return EINVAL;
+
+	err = re_hprintf(pf, "%r://", &hu->scheme);
+	if (err)
+		return err;
+
+	if (pl_isset(&hu->user)) {
+		err = re_hprintf(pf, "%r@", &hu->user);
+		if (err)
+			return err;
+	}
+
+	/* IPv6 address is delimited by '[' and ']' */
+	if (hu->af == AF_INET6)
+		err = re_hprintf(pf, "[%r]", &hu->host);
+	else
+		err = re_hprintf(pf, "%r", &hu->host);
+
+	if (err)
+		return err;
+
+	if (pl_isset(&hu->port))
+		err = re_hprintf(pf, ":%r", &hu->port);
+
+	err |= re_hprintf(pf, "%r", &hu->path);
 
 	return err;
 }

--- a/src/http/request.c
+++ b/src/http/request.c
@@ -636,10 +636,8 @@ int http_reqconn_send(struct http_reqconn *conn, const struct pl *uri)
 		return EINVAL;
 
 	err = http_uri_decode(&hu, uri);
-	if (err) {
-		DEBUG_WARNING("http uri %r decode error (%m)\n", uri, err);
+	if (err)
 		return EINVAL;
-	}
 
 	conn->uri = mem_deref(conn->uri);
 	conn->path = mem_deref(conn->path);

--- a/test/http.c
+++ b/test/http.c
@@ -969,45 +969,45 @@ int test_http_uri_decode(void)
 		const char *scheme;
 		const char *user;
 		const char *host;
-		const char *port;
+		uint16_t port;
 		const char *path;
 		int af;
 	} testv[] = {
 		{
 			"http://host/path",
-			"http", NULL, "host", NULL, "/path", AF_UNSPEC
+			"http", NULL, "host", 0, "/path", AF_UNSPEC
 		},
 		{
 			"https://host:8080/path",
-			"https", NULL, "host", "8080", "/path", AF_UNSPEC
+			"https", NULL, "host", 8080, "/path", AF_UNSPEC
 		},
 		{
 			"http://user@host/path",
-			"http", "user", "host", NULL, "/path", AF_UNSPEC
+			"http", "user", "host", 0, "/path", AF_UNSPEC
 		},
 		{
 			"http://user@host:8080/path",
-			"http", "user", "host", "8080", "/path", AF_UNSPEC
+			"http", "user", "host", 8080, "/path", AF_UNSPEC
 		},
 		{
 			"http://[::1]/path",
-			"http", NULL, "::1", NULL, "/path", AF_INET6
+			"http", NULL, "::1", 0, "/path", AF_INET6
 		},
 		{
 			"http://[::1]:8080/path",
-			"http", NULL, "::1", "8080", "/path", AF_INET6
+			"http", NULL, "::1", 8080, "/path", AF_INET6
 		},
 		{
 			"http://user@[::1]:8080/path",
-			"http", "user", "::1", "8080", "/path", AF_INET6
+			"http", "user", "::1", 8080, "/path", AF_INET6
 		},
 		{
 			"http://host",
-			"http", NULL, "host", NULL, "/", AF_UNSPEC
+			"http", NULL, "host", 0, "/", AF_UNSPEC
 		},
 		{
 			"http://127.0.0.1:38073/index.html",
-			"http", NULL, "127.0.0.1", "38073", "/index.html",
+			"http", NULL, "127.0.0.1", 38073, "/index.html",
 			AF_INET
 		},
 
@@ -1042,13 +1042,7 @@ int test_http_uri_decode(void)
 		TEST_STRCMP(testv[i].host, strlen(testv[i].host),
 			    hu.host.p, hu.host.l);
 
-		if (testv[i].port) {
-			TEST_STRCMP(testv[i].port, strlen(testv[i].port),
-				    hu.port.p, hu.port.l);
-		}
-		else {
-			TEST_ASSERT(!pl_isset(&hu.port));
-		}
+		TEST_EQUALS(testv[i].port, hu.port);
 
 		TEST_STRCMP(testv[i].path, strlen(testv[i].path),
 			    hu.path.p, hu.path.l);
@@ -1070,22 +1064,22 @@ int test_http_uri_encode(void)
 	} testv[] = {
 		{
 			{PL("http"), PL_INIT,
-			 PL("host"), AF_UNSPEC, PL("8080"), PL("/path")},
+			 PL("host"), AF_UNSPEC, 8080, PL("/path")},
 			"http://host:8080/path"
 		},
 		{
 			{PL("https"), PL("user"),
-			 PL("host"), AF_UNSPEC, PL("8080"), PL("/path")},
+			 PL("host"), AF_UNSPEC, 8080, PL("/path")},
 			"https://user@host:8080/path"
 		},
 		{
 			{PL("http"), PL_INIT,
-			 PL("::1"), AF_INET6, PL("8080"), PL("/path")},
+			 PL("::1"), AF_INET6, 8080, PL("/path")},
 			"http://[::1]:8080/path"
 		},
 		{
 			{PL("http"), PL("user"),
-			 PL("::1"), AF_INET6, PL("8080"), PL("/path")},
+			 PL("::1"), AF_INET6, 8080, PL("/path")},
 			"http://user@[::1]:8080/path"
 		},
 	};

--- a/test/http.c
+++ b/test/http.c
@@ -960,3 +960,162 @@ int test_https_request_addr(void)
 	return test_http_request_addr_base(true);
 }
 #endif
+
+
+int test_http_uri_decode(void)
+{
+	static const struct {
+		const char *uri;
+		const char *scheme;
+		const char *user;
+		const char *host;
+		const char *port;
+		const char *path;
+		int af;
+	} testv[] = {
+		{
+			"http://host/path",
+			"http", NULL, "host", NULL, "/path", AF_UNSPEC
+		},
+		{
+			"https://host:8080/path",
+			"https", NULL, "host", "8080", "/path", AF_UNSPEC
+		},
+		{
+			"http://user@host/path",
+			"http", "user", "host", NULL, "/path", AF_UNSPEC
+		},
+		{
+			"http://user@host:8080/path",
+			"http", "user", "host", "8080", "/path", AF_UNSPEC
+		},
+		{
+			"http://[::1]/path",
+			"http", NULL, "::1", NULL, "/path", AF_INET6
+		},
+		{
+			"http://[::1]:8080/path",
+			"http", NULL, "::1", "8080", "/path", AF_INET6
+		},
+		{
+			"http://user@[::1]:8080/path",
+			"http", "user", "::1", "8080", "/path", AF_INET6
+		},
+		{
+			"http://host",
+			"http", NULL, "host", NULL, "/", AF_UNSPEC
+		},
+		{
+			"http://127.0.0.1:38073/index.html",
+			"http", NULL, "127.0.0.1", "38073", "/index.html",
+			AF_INET
+		},
+
+	};
+
+	struct mbuf mb;
+	int err = 0;
+	size_t i;
+
+	mbuf_init(&mb);
+
+	for (i = 0; i < RE_ARRAY_SIZE(testv); i++) {
+		struct http_uri hu;
+		struct pl pl;
+
+		/* Decode */
+		pl_set_str(&pl, testv[i].uri);
+		err = http_uri_decode(&hu, &pl);
+		TEST_ERR(err);
+
+		TEST_STRCMP(testv[i].scheme, strlen(testv[i].scheme),
+			    hu.scheme.p, hu.scheme.l);
+
+		if (testv[i].user) {
+			TEST_STRCMP(testv[i].user, strlen(testv[i].user),
+				    hu.user.p, hu.user.l);
+		}
+		else {
+			TEST_ASSERT(!pl_isset(&hu.user));
+		}
+
+		TEST_STRCMP(testv[i].host, strlen(testv[i].host),
+			    hu.host.p, hu.host.l);
+
+		if (testv[i].port) {
+			TEST_STRCMP(testv[i].port, strlen(testv[i].port),
+				    hu.port.p, hu.port.l);
+		}
+		else {
+			TEST_ASSERT(!pl_isset(&hu.port));
+		}
+
+		TEST_STRCMP(testv[i].path, strlen(testv[i].path),
+			    hu.path.p, hu.path.l);
+
+		TEST_EQUALS(testv[i].af, hu.af);
+	}
+
+out:
+	mbuf_reset(&mb);
+	return err;
+}
+
+
+int test_http_uri_encode(void)
+{
+	static const struct {
+		struct http_uri hu;
+		const char *enc;
+	} testv[] = {
+		{
+			{PL("http"), PL_INIT,
+			 PL("host"), AF_UNSPEC, PL("8080"), PL("/path")},
+			"http://host:8080/path"
+		},
+		{
+			{PL("https"), PL("user"),
+			 PL("host"), AF_UNSPEC, PL("8080"), PL("/path")},
+			"https://user@host:8080/path"
+		},
+		{
+			{PL("http"), PL_INIT,
+			 PL("::1"), AF_INET6, PL("8080"), PL("/path")},
+			"http://[::1]:8080/path"
+		},
+		{
+			{PL("http"), PL("user"),
+			 PL("::1"), AF_INET6, PL("8080"), PL("/path")},
+			"http://user@[::1]:8080/path"
+		},
+	};
+
+	struct mbuf mb;
+	int err = 0;
+	size_t i;
+
+	mbuf_init(&mb);
+
+	for (i = 0; i < RE_ARRAY_SIZE(testv); i++) {
+		struct pl pl;
+
+		mb.pos = 0;
+		mb.end = 0;
+		err = mbuf_printf(&mb, "%H", http_uri_encode, &testv[i].hu);
+		if (err)
+			goto out;
+
+		pl.p = (const char *)mb.buf;
+		pl.l = mb.end;
+		err = pl_strcmp(&pl, testv[i].enc);
+		if (err) {
+			DEBUG_WARNING("http uri encode: ref=(%s),"
+				      " gen=(%r)\n", testv[i].enc, &pl);
+			goto out;
+		}
+	}
+
+out:
+	mbuf_reset(&mb);
+	return err;
+}

--- a/test/test.c
+++ b/test/test.c
@@ -123,6 +123,8 @@ static const struct test tests[] = {
 	TEST(test_http_large_body),
 	TEST(test_http_loop),
 	TEST(test_http_request_addr),
+	TEST(test_http_uri_decode),
+	TEST(test_http_uri_encode),
 #ifdef USE_TLS
 	TEST(test_https_request_addr),
 #endif

--- a/test/test.h
+++ b/test/test.h
@@ -229,6 +229,8 @@ int test_http_conn_large_body(void);
 int test_dns_http_integration(void);
 int test_dns_cache_http_integration(void);
 int test_http_request_addr(void);
+int test_http_uri_decode(void);
+int test_http_uri_encode(void);
 #ifdef USE_TLS
 int test_https_request_addr(void);
 #endif


### PR DESCRIPTION
- **http: http_uri decode/encode and tests**
- **http: do not print http URI**

**Usage**
```c
	struct pl pl;
	struct http_uri hu;
	pl_set_str(&pl, url);

	if (http_uri_decode(&hu, &pl)) {
		/* Hide URI for the warning. It may contain credentials. */
		warning("video URI invalid\n");

		/* Print debugging details (only in verbose mode) */
		debug("URI=%r\n", &pl);
		goto out;
	}

	/* Optionally hide user. Password isn't contained anyway. */
	hu.user = pl_null;
	info("start video %H\n", http_uri_encode, &hu);
```
