### PR TITLE
websock: Fix integer overflow in websock_decode() masked frame check

### DIFF
--- a/src/websock/websock.c
+++ b/src/websock/websock.c
@@ -204,7 +204,8 @@ static int websock_decode(struct websock_hdr *hdr, struct mbuf *mb)
 
 	if (hdr->mask) {
 
-		if (mbuf_get_left(mb) < (4 + hdr->len))
+		if (hdr->len > SIZE_MAX - 4 ||
+		    mbuf_get_left(mb) < (4 + hdr->len))
 			return ENODATA;
 
 		hdr->mkey[0] = mbuf_read_u8(mb);


### PR DESCRIPTION
## Summary

Integer overflow in the WebSocket frame decoder when validating masked frame payload length.

When a masked WebSocket frame uses the 64-bit extended length encoding (7-bit length field = 127), the bounds check at `websock.c:207`:

```c
if (mbuf_get_left(mb) < (4 + hdr->len))
```

overflows if `hdr->len` is close to `UINT64_MAX`. For example, with `hdr->len = 0xFFFFFFFFFFFFFFFC`, the expression `4 + hdr->len` wraps to `0`, and the check `mbuf_get_left(mb) < 0` is always false -- the guard passes regardless of actual buffer size.

The subsequent XOR unmasking loop at line 215 then iterates `hdr->len` times (~2^64), writing through the entire heap past the buffer.

## Fix

Add an explicit overflow guard before the addition:

```c
if (hdr->len > SIZE_MAX - 4 ||
    mbuf_get_left(mb) < (4 + hdr->len))
```

If `hdr->len` exceeds `SIZE_MAX - 4`, the frame is rejected before the overflowing addition occurs.

## Impact

- Pre-authentication (only requires HTTP WebSocket upgrade handshake)
- Affects any application using `websock_accept()` / `websock_accept_proto()` as a WebSocket server
- A 14-byte crafted WebSocket frame triggers heap corruption via the XOR unmasking loop