### PR TITLE
Timestamp supports year, month, and day, and Windows 32 uses Localetime.

### DIFF
--- a/src/fmt/time.c
+++ b/src/fmt/time.c
@@ -105,16 +105,12 @@ int fmt_human_time(struct re_printf *pf, const uint32_t *seconds)
  */
 int fmt_timestamp(struct re_printf *pf, void *arg)
 {
-	int year, mon, mday, hour, min, sec;
+	int hour, min, sec;
 	uint64_t ms;
-	(void)arg;
 
 #ifdef WIN32
 	SYSTEMTIME st;
 	GetLocalTime(&st);
-	year = st.wYear;
-	mon  = st.wMonth;
-	mday = st.wDay;
 	hour = st.wHour;
 	min  = st.wMinute;
 	sec  = st.wSecond;
@@ -127,17 +123,14 @@ int fmt_timestamp(struct re_printf *pf, void *arg)
 	if (!localtime_r(&tspec.tv_sec, &tm))
 		return EINVAL;
 
-	year = tm.tm_year + 1900;
-	mon  = tm.tm_mon + 1;
-	mday = tm.tm_mday;
 	hour = tm.tm_hour;
 	min  = tm.tm_min;
 	sec  = tm.tm_sec;
 	ms   = tspec.tv_nsec / 1000000;
 #endif
+	(void)arg;
 
-	return re_hprintf(pf, "%04u-%02u-%02u %02u:%02u:%02u.%03llu",
-			  year, mon, mday, hour, min, sec, ms);
+	return re_hprintf(pf, "%02u:%02u:%02u.%03llu", hour, min, sec, ms);
 }
 
 

--- a/src/fmt/time.c
+++ b/src/fmt/time.c
@@ -105,16 +105,16 @@ int fmt_human_time(struct re_printf *pf, const uint32_t *seconds)
  */
 int fmt_timestamp(struct re_printf *pf, void *arg)
 {
-	int hour, min, sec;
+	int h, m, s;
 	uint64_t ms;
 
 #ifdef WIN32
 	SYSTEMTIME st;
 	GetLocalTime(&st);
-	hour = st.wHour;
-	min  = st.wMinute;
-	sec  = st.wSecond;
-	ms   = st.wMilliseconds;
+	h  = st.wHour;
+	m  = st.wMinute;
+	s  = st.wSecond;
+	ms = st.wMilliseconds;
 #else
 	struct timespec tspec;
 	struct tm tm;
@@ -123,14 +123,14 @@ int fmt_timestamp(struct re_printf *pf, void *arg)
 	if (!localtime_r(&tspec.tv_sec, &tm))
 		return EINVAL;
 
-	hour = tm.tm_hour;
-	min  = tm.tm_min;
-	sec  = tm.tm_sec;
-	ms   = tspec.tv_nsec / 1000000;
+	h  = tm.tm_hour;
+	m  = tm.tm_min;
+	s  = tm.tm_sec;
+	ms = tspec.tv_nsec / 1000000;
 #endif
 	(void)arg;
 
-	return re_hprintf(pf, "%02u:%02u:%02u.%03llu", hour, min, sec, ms);
+	return re_hprintf(pf, "%02u:%02u:%02u.%03llu", h, m, s, ms);
 }
 
 

--- a/src/fmt/time.c
+++ b/src/fmt/time.c
@@ -105,17 +105,20 @@ int fmt_human_time(struct re_printf *pf, const uint32_t *seconds)
  */
 int fmt_timestamp(struct re_printf *pf, void *arg)
 {
-	int h, m, s;
+	int year, mon, mday, hour, min, sec;
 	uint64_t ms;
+	(void)arg;
+
 #ifdef WIN32
 	SYSTEMTIME st;
-
-	GetSystemTime(&st);
-
-	h  = st.wHour;
-	m  = st.wMinute;
-	s  = st.wSecond;
-	ms = st.wMilliseconds;
+	GetLocalTime(&st);
+	year = st.wYear;
+	mon  = st.wMonth;
+	mday = st.wDay;
+	hour = st.wHour;
+	min  = st.wMinute;
+	sec  = st.wSecond;
+	ms   = st.wMilliseconds;
 #else
 	struct timespec tspec;
 	struct tm tm;
@@ -124,14 +127,17 @@ int fmt_timestamp(struct re_printf *pf, void *arg)
 	if (!localtime_r(&tspec.tv_sec, &tm))
 		return EINVAL;
 
-	h  = tm.tm_hour;
-	m  = tm.tm_min;
-	s  = tm.tm_sec;
-	ms = tspec.tv_nsec / 1000000;
+	year = tm.tm_year + 1900;
+	mon  = tm.tm_mon + 1;
+	mday = tm.tm_mday;
+	hour = tm.tm_hour;
+	min  = tm.tm_min;
+	sec  = tm.tm_sec;
+	ms   = tspec.tv_nsec / 1000000;
 #endif
-	(void)arg;
 
-	return re_hprintf(pf, "%02u:%02u:%02u.%03llu", h, m, s, ms);
+	return re_hprintf(pf, "%04u-%02u-%02u %02u:%02u:%02u.%03llu",
+			  year, mon, mday, hour, min, sec, ms);
 }
 
 

--- a/src/fmt/time.c
+++ b/src/fmt/time.c
@@ -107,10 +107,11 @@ int fmt_timestamp(struct re_printf *pf, void *arg)
 {
 	int h, m, s;
 	uint64_t ms;
-
 #ifdef WIN32
 	SYSTEMTIME st;
+
 	GetLocalTime(&st);
+
 	h  = st.wHour;
 	m  = st.wMinute;
 	s  = st.wSecond;


### PR DESCRIPTION
In order to locate the problem, timestamp information of year, month, and day is required. At the same time, the time obtained by the Win32 system does not match the local time, so it was changed to localetime.