### PR TITLE
ci: update windows job

### DIFF
--- a/.github/workflows/cmake_win.yml
+++ b/.github/workflows/cmake_win.yml
@@ -39,18 +39,6 @@ jobs:
             c11_threads: "ON"
           }
         - {
-            name: "Windows Debug 32-bit",
-            os: windows-2022,
-            environment_script: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsamd64_x86.bat",
-            generators: "Ninja",
-            build: "Debug",
-            openssl: false,
-            disable_openssl: "ON",
-            choco: "--x86",
-            testing: true,
-            c11_threads: "OFF" # missing vcruntime library
-          }
-        - {
             name: "Windows Debug ARM64",
             os: windows-2022,
             environment_script: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsamd64_arm64.bat",
@@ -68,7 +56,7 @@ jobs:
       - name: Install OpenSSL
         if: ${{ matrix.config.openssl }}
         run: |
-          choco install --no-progress ${{ matrix.config.choco }} openssl --version 3.6.2
+          choco install --no-progress ${{ matrix.config.choco }} openssl
 
       - name: Build
         shell: cmd


### PR DESCRIPTION
- Let choco pick latest version of openssl
- Remove 32-bit build

NOTE: choco should be replaced by native openssl installation