### PR TITLE
srtcp: fix/add AES-GCM no encryption flag auth

### DIFF
--- a/src/srtp/srtcp.c
+++ b/src/srtp/srtcp.c
@@ -215,7 +215,7 @@ int srtcp_decrypt(struct srtp *srtp, struct mbuf *mb)
 		if (err)
 			return err;
 	}
-	else if (rtcp->aes && ep && rtcp->mode == AES_MODE_GCM) {
+	else if (rtcp->aes && rtcp->mode == AES_MODE_GCM) {
 
 		union vect128 iv;
 		size_t tag_start;
@@ -226,9 +226,8 @@ int srtcp_decrypt(struct srtp *srtp, struct mbuf *mb)
 		aes_set_iv(rtcp->aes, iv.u8);
 
 		/* The RTP Header is Associated Data */
-		err  = aes_decr(rtcp->aes, NULL, &mb->buf[start],
+		err = aes_decr(rtcp->aes, NULL, &mb->buf[start],
 				pld_start - start);
-		err |= aes_decr(rtcp->aes, NULL, &mb->buf[eix_start], 4);
 		if (err)
 			return err;
 
@@ -240,9 +239,29 @@ int srtcp_decrypt(struct srtp *srtp, struct mbuf *mb)
 
 		tag_start = mb->end - GCM_TAGLEN;
 
-		err = aes_decr(rtcp->aes, p, p, tag_start - pld_start);
-		if (err)
-			return err;
+		/*
+		 * RFC 7714 section 9: "All SRTCP compound packets MUST be
+		 * authenticated, but unlike SRTP, SRTCP packet encryption
+		 * is optional."
+		 */
+		if (ep) {
+			/* RFC 7714 9.2 (encrypted) */
+			err = aes_decr(rtcp->aes, NULL, &mb->buf[eix_start],
+				       4);
+			err |= aes_decr(rtcp->aes, p, p,
+					tag_start - pld_start);
+			if (err)
+				return err;
+		}
+		else {
+			/* RFC 7714 9.3 (unencrypted) */
+			err = aes_decr(rtcp->aes, NULL, p,
+				       tag_start - pld_start);
+			err |= aes_decr(rtcp->aes, NULL, &mb->buf[eix_start],
+					4);
+			if (err)
+				return err;
+		}
 
 		err = aes_authenticate(rtcp->aes, &mb->buf[tag_start],
 				       GCM_TAGLEN);

--- a/src/srtp/srtcp.c
+++ b/src/srtp/srtcp.c
@@ -71,7 +71,8 @@ int srtcp_encrypt(struct srtp *srtp, struct mbuf *mb)
 		union vect128 iv;
 		uint8_t *p = mbuf_buf(mb);
 		uint8_t tag[GCM_TAGLEN];
-		const uint32_t ix_be = htonl(1L<<31 | strm->rtcp_index);
+		ep = rtcp->encrypted;
+		const uint32_t ix_be = htonl(ep << 31 | strm->rtcp_index);
 
 		srtp_iv_calc_gcm(&iv, &rtcp->k_s, ssrc, strm->rtcp_index);
 
@@ -80,15 +81,25 @@ int srtcp_encrypt(struct srtp *srtp, struct mbuf *mb)
 		/* The RTCP Header and Index is Associated Data */
 		err  = aes_encr(rtcp->aes, NULL, &mb->buf[start],
 				mb->pos - start);
-		err |= aes_encr(rtcp->aes, NULL,
-				(void *)&ix_be, sizeof(ix_be));
 		if (err)
 			return err;
 
-		err = aes_encr(rtcp->aes, p, p, mbuf_get_left(mb));
-		if (err)
-			return err;
-
+		if (rtcp->encrypted) {
+			/* RFC 7714 9.2 (encrypted) */
+			err = aes_encr(rtcp->aes, NULL, (void *)&ix_be,
+					sizeof(ix_be));
+			err |= aes_encr(rtcp->aes, p, p, mbuf_get_left(mb));
+			if (err)
+				return err;
+		}
+		else {
+			/* RFC 7714 9.3 (unencrypted) */
+			err = aes_encr(rtcp->aes, NULL, p, mbuf_get_left(mb));
+			err |= aes_encr(rtcp->aes, NULL, (void *)&ix_be,
+					sizeof(ix_be));
+			if (err)
+				return err;
+		}
 		err = aes_get_authtag(rtcp->aes, tag, sizeof(tag));
 		if (err)
 			return err;
@@ -98,7 +109,6 @@ int srtcp_encrypt(struct srtp *srtp, struct mbuf *mb)
 		if (err)
 			return err;
 
-		ep = 1;
 	}
 
 	/* append E-bit and SRTCP-index */

--- a/src/srtp/srtp.c
+++ b/src/srtp/srtp.c
@@ -47,6 +47,7 @@ static int comp_init(struct comp *c, unsigned offs,
 
 	c->tag_len = tag_len;
 	c->mode = mode;
+	c->encrypted = encrypted;
 
 	err |= srtp_derive(k_e, key_b,       0x00+offs, key, key_b, s, s_b);
 	err |= srtp_derive(k_a, sizeof(k_a), 0x01+offs, key, key_b, s, s_b);
@@ -54,7 +55,8 @@ static int comp_init(struct comp *c, unsigned offs,
 	if (err)
 		return err;
 
-	if (encrypted) {
+	/* AES-GCM always needs aes_alloc for Associated Data authentication */
+	if (encrypted || mode == AES_MODE_GCM) {
 		err = aes_alloc(&c->aes, mode, k_e, key_b*8, NULL);
 		if (err)
 			return err;

--- a/src/srtp/srtp.h
+++ b/src/srtp/srtp.h
@@ -45,6 +45,7 @@ struct srtp {
 		struct hmac *hmac;  /**< HMAC Context                      */
 		union vect128 k_s;  /**< Derived salting key (14 bytes)    */
 		size_t tag_len;     /**< CTR Auth. tag length [bytes]      */
+		bool encrypted;     /**< Enable/Disable Encryption (RTCP)  */
 	} rtp, rtcp;
 
 	struct list streaml;        /**< SRTP-streams (struct srtp_stream) */

--- a/test/srtp.c
+++ b/test/srtp.c
@@ -925,7 +925,7 @@ static int test_srtcp_random(enum srtp_suite suite)
 }
 
 
-static int test_srtp_unauth(enum srtp_suite suite)
+static int test_srtp_unauth(enum srtp_suite suite, enum srtp_flags flags)
 {
 	struct srtp *srtp_tx, *srtp_rx;
 	struct mbuf *mb = NULL;
@@ -946,7 +946,8 @@ static int test_srtp_unauth(enum srtp_suite suite)
 	if (!mb)
 		return ENOMEM;
 
-	err  = srtp_alloc(&srtp_tx, suite, master_key, key_len+salt_len, 0);
+	err = srtp_alloc(&srtp_tx, suite, master_key, key_len + salt_len,
+			 flags);
 	err |= srtp_alloc(&srtp_rx, suite, master_key, key_len+salt_len, 0);
 	if (err)
 		goto out;
@@ -1118,7 +1119,11 @@ int test_srtp(void)
 	err = test_srtp_reordering_and_wrap();
 	TEST_ERR(err);
 
-	err = test_srtp_unauth(SRTP_AES_CM_128_HMAC_SHA1_32);
+	err = test_srtp_unauth(SRTP_AES_CM_128_HMAC_SHA1_32, 0);
+	TEST_ERR(err);
+
+	err = test_srtp_unauth(SRTP_AES_CM_128_HMAC_SHA1_32,
+			       SRTP_UNENCRYPTED_SRTCP);
 	TEST_ERR(err);
 
 	err = test_srtp_random(SRTP_AES_CM_128_HMAC_SHA1_32);
@@ -1191,7 +1196,10 @@ int test_srtp_gcm(void)
 	err = test_srtp_loop(0, SRTP_AES_256_GCM, 65530);
 	TEST_ERR(err);
 
-	err = test_srtp_unauth(SRTP_AES_256_GCM);
+	err = test_srtp_unauth(SRTP_AES_256_GCM, 0);
+	TEST_ERR(err);
+
+	err = test_srtp_unauth(SRTP_AES_256_GCM, SRTP_UNENCRYPTED_SRTCP);
 	TEST_ERR(err);
 
 	err = test_srtp_replay(SRTP_AES_128_GCM);

--- a/test/srtp.c
+++ b/test/srtp.c
@@ -410,7 +410,7 @@ static int test_srtp_loop(size_t offset, enum srtp_suite suite, uint16_t seq)
 
 
 static int test_srtcp_loop(size_t offset, enum srtp_suite suite,
-			   enum rtcp_type type)
+			   enum rtcp_type type, enum srtp_flags flags)
 {
 	struct srtp *ctx_tx = NULL, *ctx_rx = NULL;
 	struct mbuf *mb1 = NULL, *mb2 = NULL;
@@ -436,10 +436,10 @@ static int test_srtcp_loop(size_t offset, enum srtp_suite suite,
 		goto out;
 	}
 
-	err  = srtp_alloc(&ctx_tx, suite, master_key, key_len + salt_len, 0);
+	err = srtp_alloc(&ctx_tx, suite, master_key, key_len + salt_len,
+			 flags);
 	err |= srtp_alloc(&ctx_rx, suite, master_key, key_len + salt_len, 0);
-	if (err)
-		goto out;
+	TEST_ERR(err);
 
 	for (i=0; i<10; i++) {
 
@@ -461,9 +461,7 @@ static int test_srtcp_loop(size_t offset, enum srtp_suite suite,
 			err = EINVAL;
 			break;
 		}
-
-		if (err)
-			break;
+		TEST_ERR(err);
 
 		end = mb1->end;
 
@@ -474,8 +472,7 @@ static int test_srtcp_loop(size_t offset, enum srtp_suite suite,
 		/* tx */
 		mb1->pos = offset;
 		err = srtcp_encrypt(ctx_tx, mb1);
-		if (err)
-			break;
+		TEST_ERR(err);
 
 		TEST_EQUALS(offset, mb1->pos);
 		TEST_ASSERT(mb1->end != end);
@@ -485,8 +482,7 @@ static int test_srtcp_loop(size_t offset, enum srtp_suite suite,
 		/* rx */
 		mb1->pos = offset;
 		err = srtcp_decrypt(ctx_rx, mb1);
-		if (err)
-			break;
+		TEST_ERR(err);
 
 		TEST_EQUALS(offset, mb1->pos);
 		TEST_EQUALS(end, mb1->end);
@@ -1142,25 +1138,25 @@ int test_srtcp(void)
 		return ESKIPPED;
 	}
 
-	err = test_srtcp_loop(0, SRTP_AES_CM_128_HMAC_SHA1_32, RTCP_BYE);
+	err = test_srtcp_loop(0, SRTP_AES_CM_128_HMAC_SHA1_32, RTCP_BYE, 0);
 	TEST_ERR(err);
 
-	err = test_srtcp_loop(0, SRTP_AES_CM_128_HMAC_SHA1_80, RTCP_BYE);
+	err = test_srtcp_loop(0, SRTP_AES_CM_128_HMAC_SHA1_80, RTCP_BYE, 0);
 	TEST_ERR(err);
 
-	err = test_srtcp_loop(0, SRTP_AES_256_CM_HMAC_SHA1_32, RTCP_BYE);
+	err = test_srtcp_loop(0, SRTP_AES_256_CM_HMAC_SHA1_32, RTCP_BYE, 0);
 	TEST_ERR(err);
 
-	err = test_srtcp_loop(0, SRTP_AES_256_CM_HMAC_SHA1_80, RTCP_BYE);
+	err = test_srtcp_loop(0, SRTP_AES_256_CM_HMAC_SHA1_80, RTCP_BYE, 0);
 	TEST_ERR(err);
 
-	err = test_srtcp_loop(4, SRTP_AES_CM_128_HMAC_SHA1_32, RTCP_BYE);
+	err = test_srtcp_loop(4, SRTP_AES_CM_128_HMAC_SHA1_32, RTCP_BYE, 0);
 	TEST_ERR(err);
 
-	err = test_srtcp_loop(4, SRTP_AES_CM_128_HMAC_SHA1_80, RTCP_BYE);
+	err = test_srtcp_loop(4, SRTP_AES_CM_128_HMAC_SHA1_80, RTCP_BYE, 0);
 	TEST_ERR(err);
 
-	err = test_srtcp_loop(0, SRTP_AES_CM_128_HMAC_SHA1_32, RTCP_RR);
+	err = test_srtcp_loop(0, SRTP_AES_CM_128_HMAC_SHA1_32, RTCP_RR, 0);
 	TEST_ERR(err);
 
 	err = test_srtcp_libsrtp();
@@ -1218,16 +1214,20 @@ int test_srtcp_gcm(void)
 		return ESKIPPED;
 	}
 
-	err = test_srtcp_loop(0, SRTP_AES_128_GCM, RTCP_BYE);
+	err = test_srtcp_loop(0, SRTP_AES_128_GCM, RTCP_BYE, 0);
 	TEST_ERR(err);
 
-	err = test_srtcp_loop(0, SRTP_AES_256_GCM, RTCP_BYE);
+	err = test_srtcp_loop(0, SRTP_AES_256_GCM, RTCP_BYE, 0);
 	TEST_ERR(err);
 
-	err = test_srtcp_loop(4, SRTP_AES_128_GCM, RTCP_BYE);
+	err = test_srtcp_loop(4, SRTP_AES_128_GCM, RTCP_BYE, 0);
 	TEST_ERR(err);
 
-	err = test_srtcp_loop(0, SRTP_AES_128_GCM, RTCP_RR);
+	err = test_srtcp_loop(0, SRTP_AES_128_GCM, RTCP_RR, 0);
+	TEST_ERR(err);
+
+	err = test_srtcp_loop(0, SRTP_AES_128_GCM, RTCP_RR,
+			      SRTP_UNENCRYPTED_SRTCP);
 	TEST_ERR(err);
 
 	err = test_srtcp_random(SRTP_AES_128_GCM);


### PR DESCRIPTION
[RFC 7714 section 9:](https://www.rfc-editor.org/info/rfc7714/#section-9).  AES-GCM Processing of SRTCP Compound Packets

> All SRTCP compound packets MUST be authenticated, but unlike SRTP,
   SRTCP packet encryption is optional.  A sender can select which
   packets to encrypt and indicates this choice with a 1-bit
   Encryption flag (located just before the 31-bit SRTCP index).