### PR TITLE
json,odict: optimize memory and lookup performance

### DIFF
--- a/src/json/decode_odict.c
+++ b/src/json/decode_odict.c
@@ -12,6 +12,8 @@
 #include <re_odict.h>
 #include <re_json.h>
 
+enum { CONTAINER_HASH_SZ = 1u << 2 };
+
 
 static int container_add(const char *name, unsigned idx,
 			 enum odict_type type, struct json_handlers *h)
@@ -27,7 +29,7 @@ static int container_add(const char *name, unsigned idx,
 		name = index;
 	}
 
-	err = odict_alloc(&oc, hash_bsize(o->ht));
+	err = odict_alloc(&oc, CONTAINER_HASH_SZ);
 	if (err)
 		return err;
 

--- a/src/odict/entry.c
+++ b/src/odict/entry.c
@@ -12,6 +12,8 @@
 #include "re_odict.h"
 #include "odict.h"
 
+enum { ENTRY_HASH_MAX = 1u << 16 };
+
 
 static void destructor(void *arg)
 {
@@ -35,6 +37,32 @@ static void destructor(void *arg)
 	hash_unlink(&e->he);
 	list_unlink(&e->le);
 	mem_deref(e->key);
+}
+
+
+static void odict_grow(struct odict *o)
+{
+	uint32_t bsize = hash_bsize(o->ht);
+
+	if (list_count(&o->lst) < bsize || bsize >= ENTRY_HASH_MAX)
+		return;
+
+	struct hash *ht;
+	int err = hash_alloc(&ht, bsize << 1);
+	if (err)
+		return;
+
+	struct le *le;
+	LIST_FOREACH(&o->lst, le)
+	{
+		struct odict_entry *e = le->data;
+
+		hash_unlink(&e->he);
+		hash_append(ht, hash_fast_str(e->key), &e->he, e);
+	}
+
+	mem_deref(o->ht);
+	o->ht = ht;
 }
 
 
@@ -98,6 +126,9 @@ int odict_entry_add(struct odict *o, const char *key,
 
 	list_append(&o->lst, &e->le, e);
 	hash_append(o->ht, hash_fast_str(e->key), &e->he, e);
+
+	/* grow hash table if needed */
+	odict_grow(o);
 
  out:
 	if (err)

--- a/test/odict.c
+++ b/test/odict.c
@@ -110,7 +110,7 @@ int test_odict(void)
 	TEST_ASSERT(odict_type_isreal(ODICT_NULL));
 	TEST_ASSERT(!odict_type_isreal(ODICT_OBJECT));
 
-	err = odict_alloc(&dict, 64);
+	err = odict_alloc(&dict, 8);
 	if (err)
 		goto out;
 


### PR DESCRIPTION
By default current level entry `hash_size` is used from `odict_alloc` or `json_decode_odict` and allocated for all containers.

This PR allows growing `hash_size` dynamic to keep good lookup performance and memory usage low.