### PR TITLE
main: fix race between re_thread_enter/leave and the polling flag

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1294,6 +1294,13 @@ void re_thread_close(void)
 
 /**
  * Enter an 're' thread
+ *
+ * The mutex is acquired unconditionally (not gated by the polling flag)
+ * so that enter/leave stay paired even when the main loop transitions
+ * from not-polling to polling in between. Gating both sides on two
+ * independent reads of re->polling races with re_main() setting the
+ * flag: an enter that skipped the lock could be followed by a leave
+ * that unlocks a mutex the thread never held.
  */
 void re_thread_enter(void)
 {
@@ -1303,9 +1310,6 @@ void re_thread_enter(void)
 		DEBUG_WARNING("re_thread_enter: re not ready\n");
 		return;
 	}
-
-	if (!re_atomic_rlx(&re->polling))
-		return;
 
 	re_lock(re);
 
@@ -1327,9 +1331,6 @@ void re_thread_leave(void)
 		DEBUG_WARNING("re_thread_leave: re not ready\n");
 		return;
 	}
-
-	if (!re_atomic_rlx(&re->polling))
-		return;
 
 	/* Dummy async event, to ensure timers are properly handled */
 	if (re->async)


### PR DESCRIPTION
re_thread_enter() and re_thread_leave() each read re->polling independently and skip the mutex operation when it is not set. re_main() sets the flag when the main loop starts, so a enter/leave pair can straddle that transition:

  1. foreign thread calls re_thread_enter() while polling is still false -- returns without locking
  2. the re thread enters re_main() and sets polling = true
  3. foreign thread calls re_thread_leave(), now sees polling == true and unlocks a mutex it never locked

mtx_unlock() then fails with thrd_error ("re_unlock error"), which was observed on every boot of an embedded target (uclibc, single core, slow startup). On glibc the same unbalanced path exists, it is just not hit by timing.

The flag is also cleared by re_cancel() from an application thread, which has the mirrored effect during shutdown: a thread inside an enter/leave pair when re_cancel() flips polling to false skips the unlock in re_thread_leave() and leaks the mutex. The main loop then blocks forever in re_lock() and never returns from re_main().

Fix: acquire/release the mutex unconditionally so that enter/leave are always paired. Before re_main() runs the recursive mutex is uncontended, so the cost is negligible, and re_main() now simply waits for a pending foreign section to finish before entering the poll loop.